### PR TITLE
fix: regex may fail to match MessageElem

### DIFF
--- a/core/src/message.ts
+++ b/core/src/message.ts
@@ -42,10 +42,10 @@ export class Message<AD extends Adapter> {
 export function parseFromTemplate(template: string | MessageElem): MessageElem[] {
   if (typeof template !== 'string') return [template];
   const result: MessageElem[] = [];
-  const closingReg = /<(\S+)(\s[^\/]+)?\/>/;
-  const twinningReg = /<(\S+)(\s[^>]+)?>([^<]*)<\/\1>/;
+  const closingReg = /^<(\S+)(\s[^>]+)?\/>/;
+  const twinningReg = /^<(\S+)(\s[^>]+)?>([\s\S]*?)<\/\1>/;
   while (template.length) {
-    const [_, type, attrStr = '', child = ''] = template.match(closingReg) || template.match(twinningReg) || [];
+    const [_, type, attrStr = '', child = ''] = template.match(twinningReg) || template.match(closingReg) || [];
     if (!type) break;
     const isClosing = closingReg.test(template);
     const matched = isClosing ? `<${type}${attrStr}/>` : `<${type}${attrStr}>${child}</${type}>`;
@@ -70,6 +70,10 @@ export function parseFromTemplate(template: string | MessageElem): MessageElem[]
         }
       }),
     );
+    if (child) {
+      // TODO temporarily use 'message' as the key of the child MessageElem
+      data.message = parseFromTemplate(child).map(({ type, data }) => ({ type, ...data }))
+    }
     result.push({
       type: type,
       data,


### PR DESCRIPTION
`closingReg` : 原表达式无法匹配： `<image src="https://xxx.com/aaa.jpg" />`
`twinningReg` : 原表达式无法匹配：`<node user_id="xxx"><image src="xxx" /></node>`

另外非 `自闭合标签` 中的元素貌似被忽略了，我暂时将其加到了data中。

> 另外，我发现 `parseFromTemplate` 方法调用的结果都会跟上 `.map(({ type, data }) => ({ type, ...data }))` 操作。
如果没有别的考虑，我建议 77 行代码直接解构 data：`result.push({ type, ...data })`

