### PR TITLE
1、优化win兼容性，2、统一初始化方式。

### DIFF
--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -26,57 +26,7 @@ npm install -g pnpm
 
 ## 创建项目
 
-### 方式一：一键安装（推荐）
-
-使用一键安装脚本，自动检测环境并启动配置向导。
-
-::: code-group
-
-```bash [macOS / Linux / WSL]
-curl -fsSL https://zhin.js.org/install.sh | bash
-```
-
-```powershell [Windows PowerShell]
-irm https://zhin.js.org/install.ps1 | iex
-```
-
-:::
-
-你也可以直接指定项目名称：
-
-::: code-group
-
-```bash [macOS / Linux / WSL]
-curl -fsSL https://zhin.js.org/install.sh | bash -s -- my-bot
-```
-
-```powershell [Windows PowerShell]
-irm https://zhin.js.org/install.ps1 | iex
-```
-
-:::
-
-快速模式（跳过所有交互，使用默认配置）：
-
-::: code-group
-
-```bash [macOS / Linux / WSL]
-curl -fsSL https://zhin.js.org/install.sh | bash -s -- my-bot -y
-```
-
-```powershell [Windows PowerShell]
-irm https://zhin.js.org/install.ps1 | iex
-```
-:::
-脚本会自动完成以下检查：
-
-- 检测 Node.js 版本（>= 20.19.0 或 >= 22.12.0）
-- 检测并安装 pnpm（Bash 版）/ 检测并安装 pnpm（PowerShell 版）
-- 启动 Zhin.js 交互式配置向导
-
-### 方式二：手动创建
-
-使用脚手架工具创建新项目：
+使用 `npm create` 创建新项目：
 
 ```bash
 npm create zhin-app my-bot

--- a/packages/agent/src/file-policy.ts
+++ b/packages/agent/src/file-policy.ts
@@ -131,25 +131,40 @@ export interface FileAccessCheckResult {
   reason?: string;
 }
 
+function expandHome(filePath: string): string {
+  return filePath.replace(/^~(?=$|[\\/])/, os.homedir());
+}
+
+function normalizePathSeparators(filePath: string): string {
+  return filePath.replace(/\\/g, '/');
+}
+
+function getPolicyPathCandidates(filePath: string): string[] {
+  const expanded = expandHome(filePath);
+  const raw = normalizePathSeparators(expanded);
+  const resolved = normalizePathSeparators(path.resolve(expanded));
+  return [...new Set([raw, resolved])];
+}
+
 /**
  * 检查文件路径是否允许被 AI Agent 访问。
  * 该函数只做「阻止明确敏感文件」的检查，不做正向白名单。
  */
 export function checkFileAccess(filePath: string): FileAccessCheckResult {
   // 解析为绝对路径
-  const resolved = path.resolve(filePath.replace(/^~/, os.homedir()));
+  const resolved = path.resolve(expandHome(filePath));
   const basename = path.basename(resolved);
-  const normalized = resolved.replace(/\\/g, '/');
+  const normalizedCandidates = getPolicyPathCandidates(filePath);
 
   // 1. 检查敏感路径前缀
   for (const prefix of SENSITIVE_PATH_PREFIXES) {
-    if (normalized.startsWith(prefix)) {
+    if (normalizedCandidates.some(candidate => candidate.startsWith(prefix))) {
       return { allowed: false, reason: `拒绝访问系统敏感文件: ${prefix}` };
     }
   }
 
   // 2. 检查敏感目录
-  const parts = normalized.split('/');
+  const parts = normalizePathSeparators(resolved).split('/');
   for (let i = 0; i < parts.length; i++) {
     if (SENSITIVE_DIR_NAMES.has(parts[i])) {
       return { allowed: false, reason: `拒绝访问敏感目录: ${parts[i]}` };

--- a/packages/core/src/plugin.ts
+++ b/packages/core/src/plugin.ts
@@ -11,7 +11,7 @@ import { Schema } from "@zhin.js/schema";
 import type { Models, RegisteredAdapters, PluginManifest } from "./types.js";
 import * as fs from "fs";
 import * as path from "path";
-import { fileURLToPath } from "url";
+import { fileURLToPath, pathToFileURL } from "url";
 import logger, { Logger } from "@zhin.js/logger";
 import { compose, remove, resolveEntry } from "./utils.js";
 import { MessageMiddleware, RegisteredAdapter, MaybePromise, ArrayItem, SendOptions } from "./types.js";
@@ -747,7 +747,7 @@ export class Plugin extends EventEmitter<Plugin.Lifecycle> {
     loadedModules.set(realPath, plugin);
 
     await storage.run(plugin, async () => {
-      await import(`${import.meta.resolve(entryFile)}?t=${Date.now()}`);
+      await import(`${pathToFileURL(entryFile).href}?t=${Date.now()}`);
     });
 
     return plugin;

--- a/plugins/adapters/discord/package.json
+++ b/plugins/adapters/discord/package.json
@@ -32,7 +32,7 @@
     "directory": "plugins/adapters/discord"
   },
   "scripts": {
-    "build": "tsc && (test -f ../../services/console/lib/bin.js && node ../../services/console/lib/bin.js build || echo 'Skipping client build: console not built yet')",
+    "build": "tsc && node ../../../scripts/build-console-client-if-present.mjs",
     "clean": "rimraf lib dist",
     "build:node": "tsc"
   },

--- a/plugins/adapters/icqq/package.json
+++ b/plugins/adapters/icqq/package.json
@@ -44,7 +44,7 @@
     "CHANGELOG.md"
   ],
   "scripts": {
-    "build": "tsc && (test -f ../../services/console/lib/bin.js && node ../../services/console/lib/bin.js build || echo 'Skipping client build: console not built yet')",
+    "build": "tsc && node ../../../scripts/build-console-client-if-present.mjs",
     "clean": "rimraf lib"
   },
   "dependencies": {},

--- a/plugins/adapters/kook/package.json
+++ b/plugins/adapters/kook/package.json
@@ -33,7 +33,7 @@
     "directory": "plugins/adapters/kook"
   },
   "scripts": {
-    "build": "tsc && (test -f ../../services/console/lib/bin.js && node ../../services/console/lib/bin.js build || echo 'Skipping client build: console not built yet')",
+    "build": "tsc && node ../../../scripts/build-console-client-if-present.mjs",
     "clean": "rimraf lib dist",
     "build:node": "tsc"
   },

--- a/plugins/adapters/milky/package.json
+++ b/plugins/adapters/milky/package.json
@@ -13,7 +13,7 @@
     }
   },
   "scripts": {
-    "build": "tsc && (test -f ../../services/console/lib/bin.js && node ../../services/console/lib/bin.js build || echo 'Skipping client build: console not built yet')",
+    "build": "tsc && node ../../../scripts/build-console-client-if-present.mjs",
     "clean": "rimraf lib"
   },
   "files": [

--- a/plugins/adapters/onebot11/package.json
+++ b/plugins/adapters/onebot11/package.json
@@ -13,7 +13,7 @@
     }
   },
   "scripts": {
-    "build": "tsc && (test -f ../../services/console/lib/bin.js && node ../../services/console/lib/bin.js build || echo 'Skipping client build: console not built yet')",
+    "build": "tsc && node ../../../scripts/build-console-client-if-present.mjs",
     "clean": "rimraf lib"
   },
   "files": [

--- a/plugins/adapters/onebot12/package.json
+++ b/plugins/adapters/onebot12/package.json
@@ -13,7 +13,7 @@
     }
   },
   "scripts": {
-    "build": "tsc && (test -f ../../services/console/lib/bin.js && node ../../services/console/lib/bin.js build || echo 'Skipping client build: console not built yet')",
+    "build": "tsc && node ../../../scripts/build-console-client-if-present.mjs",
     "clean": "rimraf lib"
   },
   "files": [

--- a/plugins/adapters/qq/package.json
+++ b/plugins/adapters/qq/package.json
@@ -34,7 +34,7 @@
     "directory": "plugins/adapters/qq"
   },
   "scripts": {
-    "build": "tsc && (test -f ../../services/console/lib/bin.js && node ../../services/console/lib/bin.js build || echo 'Skipping client build: console not built yet')",
+    "build": "tsc && node ../../../scripts/build-console-client-if-present.mjs",
     "clean": "rimraf lib dist",
     "build:node": "tsc"
   },

--- a/plugins/adapters/sandbox/package.json
+++ b/plugins/adapters/sandbox/package.json
@@ -43,7 +43,7 @@
     "directory": "plugins/adapters/sandbox"
   },
   "scripts": {
-    "build": "tsc && (test -f ../../services/console/lib/bin.js && node ../../services/console/lib/bin.js build || echo 'Skipping client build: console not built yet')",
+    "build": "tsc && node ../../../scripts/build-console-client-if-present.mjs",
     "clean": "rimraf lib"
   },
   "devDependencies": {

--- a/plugins/adapters/satori/package.json
+++ b/plugins/adapters/satori/package.json
@@ -13,7 +13,7 @@
     }
   },
   "scripts": {
-    "build": "tsc && (test -f ../../services/console/lib/bin.js && node ../../services/console/lib/bin.js build || echo 'Skipping client build: console not built yet')",
+    "build": "tsc && node ../../../scripts/build-console-client-if-present.mjs",
     "clean": "rimraf lib"
   },
   "files": [

--- a/plugins/adapters/telegram/package.json
+++ b/plugins/adapters/telegram/package.json
@@ -32,7 +32,7 @@
     "directory": "plugins/adapters/telegram"
   },
   "scripts": {
-    "build": "tsc && (test -f ../../services/console/lib/bin.js && node ../../services/console/lib/bin.js build || echo 'Skipping client build: console not built yet')",
+    "build": "tsc && node ../../../scripts/build-console-client-if-present.mjs",
     "clean": "rimraf lib dist",
     "build:node": "tsc"
   },

--- a/scripts/build-console-client-if-present.mjs
+++ b/scripts/build-console-client-if-present.mjs
@@ -1,0 +1,13 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const consoleBin = path.resolve(process.cwd(), '../../services/console/lib/bin.js');
+
+if (!fs.existsSync(consoleBin)) {
+  console.log('Skipping client build: console not built yet');
+  process.exit(0);
+}
+
+process.argv = [process.argv[0], consoleBin, 'build'];
+await import(pathToFileURL(consoleBin).href);


### PR DESCRIPTION
fix:windows系统兼容性。
doc：删除终端脚本，统一使用npm create。

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves Windows compatibility for path resolution, plugin imports, and build scripts, and unifies project initialization to use `npm create`.

- **Bug Fixes**
  - Normalized path handling in `packages/agent` file policy: expand `~`, unify separators, and check both raw/resolved candidates to block sensitive paths reliably on Windows.
  - Switched plugin loader in `packages/core` to `pathToFileURL(...)` for dynamic imports to avoid Windows file URL issues.
  - Replaced POSIX `test -f` checks in adapter `package.json` builds with `scripts/build-console-client-if-present.mjs` (Node-based), making builds cross-platform.

- **Migration**
  - Initialize new projects with `npm create zhin-app`. The one-click curl/PowerShell installer scripts were removed from docs.

<sup>Written for commit 781e7a471d04809d51e22be716117b193a9e166f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

