### PR TITLE
[codex] fix create-zhin-app client JSX config

### DIFF
--- a/packages/create-zhin/src/workspace.ts
+++ b/packages/create-zhin/src/workspace.ts
@@ -598,7 +598,6 @@ NODE_ENV=production
       "sourceMap": true,
       "verbatimModuleSyntax": false,
       "jsx": "react-jsx",
-      "jsxImportSource": "zhin.js",
       "types": [
         "@types/node",
         "zhin.js",


### PR DESCRIPTION
## Summary

- remove `jsxImportSource: "zhin.js"` from the generated client `tsconfig.json`

## Why

Following the README / docs flow with `npm create zhin-app@latest` creates a project that initializes successfully, but `pnpm build` fails during the client bundle when JSX is resolved through `zhin.js`.

In the generated project, the client build tries to bundle Node-only modules from Zhin kernel packages and reports errors such as:

```text
Could not resolve "events"
Could not resolve "fs"
Could not resolve "path"
Could not resolve "crypto"
```

The client code is React UI, so it should use the default React JSX runtime rather than Zhin's JSX runtime.

## Reproduction

Environment used during verification:

- Node.js v22.14.0
- npm 10.9.2
- pnpm 10.18.2
- create-zhin-app 1.0.42

Commands:

```bash
npm create zhin-app@latest zhin-cli-init-trial
cd zhin-cli-init-trial
pnpm build
```

Choices: node runtime, yaml config, sqlite/wal, sandbox adapter, AI disabled.

Note: upstream `main` already contains the separate `MessageElement` import fix, so this PR only addresses the remaining client JSX config failure.

## Validation

- reproduced `pnpm build` failure in a freshly generated project
- removed generated client `jsxImportSource` locally and confirmed `pnpm build` passes
- ran `pnpm --filter create-zhin-app build`
- ran `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove `jsxImportSource: "zhin.js"` from the generated client `tsconfig.json` in `create-zhin-app` so the client uses the React JSX runtime. This fixes `pnpm build` failures where the client tried to resolve Node-only modules via `zhin.js` (e.g., `events`, `fs`, `path`, `crypto`).

<sup>Written for commit 229172e91bab66e974942065a46c2edeecdd7b76. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zhinjs/zhin/pull/444?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

