### PR TITLE
fix(router): authenticate WebSocket upgrade requests to prevent unauthenticated access

### DIFF
--- a/packages/host/router/src/index.ts
+++ b/packages/host/router/src/index.ts
@@ -103,6 +103,9 @@ useContext("config", (configService) => {
 
   app.proxy = trustProxy;
 
+  // Share the auth token with the Router so WebSocket upgrades are also protected
+  router.setAuthToken(token);
+
   router.get('/pub/health', async (ctx) => {
     ctx.body = {
       success: true,

--- a/packages/host/router/src/koa-router.ts
+++ b/packages/host/router/src/koa-router.ts
@@ -8,6 +8,7 @@ import { WebSocketServer as WSS } from "ws";
 import type { ListedRoute } from "./openapi.js";
 import { toKoaRouterPath } from "./path-pattern.js";
 import { isRouteMeta, type RouteMeta } from "./route-meta.js";
+import { timingSafeEqualString } from "./timing-safe-equal.js";
 
 /** Koa 上下文；`koa-body` 解析后 `request.body` 可用。 */
 export type RouterContext = Context & {
@@ -67,12 +68,24 @@ export class Router extends KoaRouter {
   whiteList: Path[] = [];
   private listedRoutes: ListedRoute[] = [];
   private _upgradeListenerInstalled = false;
+  private _authToken: string | undefined;
+  /** WebSocket paths that skip the global auth token (they provide their own verifyClient). */
+  private _wsAuthExempt = new Set<string>();
 
   constructor(
     public readonly server: Server,
     prefix = "",
   ) {
     super({ prefix: prefix || undefined });
+  }
+
+  /**
+   * Set the Bearer token used to authenticate WebSocket upgrade requests.
+   * Must be called before the first upgrade arrives (typically right after
+   * the HTTP auth middleware is registered).
+   */
+  setAuthToken(token: string): void {
+    this._authToken = token;
   }
 
   listRoutes(): ListedRoute[] {
@@ -198,6 +211,32 @@ export class Router extends KoaRouter {
     remove(this.wsStack, wsServer);
   }
 
+  /**
+   * Verify the Bearer token on a WebSocket upgrade request.
+   * Returns `true` if the request is authenticated (or no token is configured).
+   */
+  private _verifyUpgradeToken(request: import("node:http").IncomingMessage): boolean {
+    const token = this._authToken;
+    if (!token) return true; // no token configured — allow (same as HTTP middleware)
+
+    // Extract token from Authorization header
+    const authHeader = request.headers["authorization"] ?? "";
+    if (authHeader.startsWith("Bearer ") && timingSafeEqualString(token, authHeader.slice(7))) {
+      return true;
+    }
+
+    // Fall back to query string ?token= or ?access_token=
+    const { query } = parse(request.url ?? "", true);
+    const queryToken =
+      (typeof query.access_token === "string" ? query.access_token : "") ||
+      (typeof query.token === "string" ? query.token : "");
+    if (queryToken && timingSafeEqualString(token, queryToken)) {
+      return true;
+    }
+
+    return false;
+  }
+
   private _ensureUpgradeListener(): void {
     if (this._upgradeListenerInstalled) return;
     this._upgradeListenerInstalled = true;
@@ -206,6 +245,14 @@ export class Router extends KoaRouter {
       const { pathname } = parse(request.url ?? "");
       const target = this.wsStack.find((wss) => wss.options.path === pathname);
       if (!target) return;
+
+      // Authenticate the upgrade unless the path is exempt (has its own verifyClient)
+      if (!this._wsAuthExempt.has(pathname ?? "") && !this._verifyUpgradeToken(request)) {
+        socket.write("HTTP/1.1 401 Unauthorized\r\n\r\n");
+        socket.destroy();
+        return;
+      }
+
       (socket as { _wsRouterHandled?: boolean })._wsRouterHandled = true;
       try {
         target.handleUpgrade(request, socket as import("net").Socket, head, (ws) => {
@@ -222,6 +269,11 @@ export class Router extends KoaRouter {
     if (existing) return existing;
     const wsServer = new WSS({ noServer: true, path, ...options });
     this.wsStack.push(wsServer);
+    // If the caller provides its own verifyClient, exempt this path from
+    // the global auth token check (the caller is responsible for auth).
+    if (options.verifyClient) {
+      this._wsAuthExempt.add(path);
+    }
     this._ensureUpgradeListener();
     return wsServer;
   }

--- a/packages/host/router/tests/ws-auth.test.ts
+++ b/packages/host/router/tests/ws-auth.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createServer } from "node:http";
+
+// Mock @zhin.js/core so the module can be imported without a full Zhin app.
+vi.mock("@zhin.js/core", () => ({
+  usePlugin: () => ({
+    declareConfig: vi.fn(),
+    provide: vi.fn(),
+    root: {
+      inject: vi.fn(() => null),
+      adapters: [],
+      children: [],
+    },
+    useContext: vi.fn(),
+    logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+  }),
+  formatCompact: (v: unknown) => String(v),
+}));
+
+describe("Router WebSocket auth", () => {
+  let Router: typeof import("../src/koa-router.js").Router;
+  const TEST_TOKEN = "test-secret-token-abc123";
+
+  beforeEach(async () => {
+    const mod = await import("../src/koa-router.js");
+    Router = mod.Router;
+  });
+
+  it("should reject WS upgrade without token when authToken is set", async () => {
+    const server = createServer();
+    const router = new Router(server);
+    router.setAuthToken(TEST_TOKEN);
+
+    // Create a WS endpoint (no verifyClient → should require global auth)
+    router.ws("/server");
+
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", () => resolve());
+    });
+    const addr = server.address() as { port: number };
+
+    try {
+      // Attempt connection without a token — should be rejected
+      const ws = new (await import("ws")).default(
+        `ws://127.0.0.1:${addr.port}/server`,
+      );
+      const result = await new Promise<string>((resolve) => {
+        ws.on("open", () => resolve("open"));
+        ws.on("error", () => resolve("error"));
+        ws.on("unexpected-response", () => resolve("rejected"));
+      });
+      expect(result).not.toBe("open");
+    } finally {
+      server.close();
+    }
+  });
+
+  it("should accept WS upgrade with valid token in query", async () => {
+    const server = createServer();
+    const router = new Router(server);
+    router.setAuthToken(TEST_TOKEN);
+    router.ws("/server");
+
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", () => resolve());
+    });
+    const addr = server.address() as { port: number };
+
+    try {
+      const ws = new (await import("ws")).default(
+        `ws://127.0.0.1:${addr.port}/server?token=${TEST_TOKEN}`,
+      );
+      const result = await new Promise<string>((resolve) => {
+        ws.on("open", () => {
+          ws.close();
+          resolve("open");
+        });
+        ws.on("error", () => resolve("error"));
+        ws.on("unexpected-response", () => resolve("rejected"));
+      });
+      expect(result).toBe("open");
+    } finally {
+      server.close();
+    }
+  });
+
+  it("should accept WS upgrade with valid Bearer header", async () => {
+    const server = createServer();
+    const router = new Router(server);
+    router.setAuthToken(TEST_TOKEN);
+    router.ws("/server");
+
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", () => resolve());
+    });
+    const addr = server.address() as { port: number };
+
+    try {
+      const ws = new (await import("ws")).default(
+        `ws://127.0.0.1:${addr.port}/server`,
+        { headers: { Authorization: `Bearer ${TEST_TOKEN}` } },
+      );
+      const result = await new Promise<string>((resolve) => {
+        ws.on("open", () => {
+          ws.close();
+          resolve("open");
+        });
+        ws.on("error", () => resolve("error"));
+        ws.on("unexpected-response", () => resolve("rejected"));
+      });
+      expect(result).toBe("open");
+    } finally {
+      server.close();
+    }
+  });
+
+  it("should exempt paths with their own verifyClient", async () => {
+    const server = createServer();
+    const router = new Router(server);
+    router.setAuthToken(TEST_TOKEN);
+    // Register a WS path with its own verifyClient (like adapter bots do)
+    router.ws("/adapter-bot", {
+      verifyClient: () => true,
+    });
+
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", () => resolve());
+    });
+    const addr = server.address() as { port: number };
+
+    try {
+      // Should connect even without the global auth token
+      const ws = new (await import("ws")).default(
+        `ws://127.0.0.1:${addr.port}/adapter-bot`,
+      );
+      const result = await new Promise<string>((resolve) => {
+        ws.on("open", () => {
+          ws.close();
+          resolve("open");
+        });
+        ws.on("error", () => resolve("error"));
+        ws.on("unexpected-response", () => resolve("rejected"));
+      });
+      expect(result).toBe("open");
+    } finally {
+      server.close();
+    }
+  });
+
+  it("should reject WS upgrade with wrong token", async () => {
+    const server = createServer();
+    const router = new Router(server);
+    router.setAuthToken(TEST_TOKEN);
+    router.ws("/server");
+
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", () => resolve());
+    });
+    const addr = server.address() as { port: number };
+
+    try {
+      const ws = new (await import("ws")).default(
+        `ws://127.0.0.1:${addr.port}/server?token=wrong-token`,
+      );
+      const result = await new Promise<string>((resolve) => {
+        ws.on("open", () => resolve("open"));
+        ws.on("error", () => resolve("error"));
+        ws.on("unexpected-response", () => resolve("rejected"));
+      });
+      expect(result).not.toBe("open");
+    } finally {
+      server.close();
+    }
+  });
+});


### PR DESCRIPTION
## Vulnerability Summary

The WebSocket upgrade handler in `packages/host/router/src/koa-router.ts` operates at the raw HTTP `server.on("upgrade")` level — completely bypassing Koa's middleware chain where `createAuthMiddleware()` enforces Bearer token authentication for HTTP routes.

**CWE-862 (Missing Authorization)** — All WebSocket endpoints that don't provide their own `verifyClient` callback are accessible without any authentication. The primary affected endpoint is `/sandbox` (`plugins/adapters/sandbox/src/index.ts:43`), which registers via `router.ws("/sandbox")` with no `verifyClient`.

**Affected file:** `packages/host/router/src/koa-router.ts` — the `_ensureUpgradeListener()` method at line 243  
**Severity:** High — an unauthenticated attacker with network access to port 8086 can connect to the sandbox WebSocket and gain full bot control (send messages, receive all events, trigger AI commands).

### Data flow

1. HTTP upgrade request arrives on `server.on("upgrade")`
2. The Koa middleware chain (`createAuthMiddleware`) is **never invoked** for upgrade requests — Koa only handles standard HTTP request/response
3. `koa-router.ts` matches the path and calls `target.handleUpgrade()` directly, with no authentication check
4. The attacker receives a fully connected WebSocket session

## Fix Description

This patch adds Bearer token verification at the upgrade handler level:

1. **`setAuthToken(token)`** — called from `index.ts` after the HTTP auth middleware is registered, sharing the same token with the WebSocket layer.
2. **`_verifyUpgradeToken(request)`** — extracts the token from `Authorization: Bearer <token>` header or `?token=`/`?access_token=` query parameter; compares using timing-safe string equality.
3. **Auth exemption for adapter bots** — WebSocket paths registered with their own `verifyClient` (napcat, onebot11, milky, onebot12) are exempted from the global check since they already implement token validation independently.
4. **Rejection** — unauthorized upgrade requests receive `HTTP/1.1 401 Unauthorized` and the socket is destroyed.

The fix is minimal (52 lines in `koa-router.ts`, 3 lines in `index.ts`) and uses the same token that the existing HTTP middleware already validates.

## Test Results

The test suite in `packages/host/router/tests/ws-auth.test.ts` covers:

- **Rejection without token** — connecting to `/server` without credentials returns an error/rejection (not "open")
- **Acceptance with valid query token** — `?token=<correct>` successfully upgrades
- **Acceptance with valid Bearer header** — `Authorization: Bearer <correct>` successfully upgrades
- **Exemption for verifyClient paths** — paths registered with their own `verifyClient` allow connection without the global token
- **Rejection with wrong token** — incorrect token returns an error/rejection

All 5 tests exercise real WebSocket connections against an ephemeral HTTP server (not mocked).

## Proof of Concept

An attacker can exploit the unpatched version with a single command:

```bash
# Connect to the sandbox WebSocket without any authentication.
# Replace <host> with the target IP/hostname running zhin on port 8086.
npx wscat -c ws://<host>:8086/sandbox
```

On a successful connection (pre-fix), the attacker receives the WebSocket session and can:

```javascript
// From a Node.js script:
const WebSocket = require('ws');
const ws = new WebSocket('ws://target:8086/sandbox');
ws.on('open', () => {
  console.log('Connected to sandbox without auth!');
  // Send bot commands, receive all event traffic
  ws.send(JSON.stringify({ type: 'message', content: 'hello from attacker' }));
});
ws.on('message', (data) => {
  console.log('Received:', data.toString());
});
```

The default Docker Compose configuration (`docker-compose.yml:23`) maps `8086:8086`, exposing this port to the host network. The Remote Console architecture (`console.zhin.dev`) also explicitly supports remote access, making network-accessible deployments the standard — not an edge case.

## Security Analysis

The vulnerability exists because Node.js HTTP servers handle WebSocket upgrade requests before any Koa middleware executes. Koa's `app.callback()` only processes standard request/response cycles; the `upgrade` event fires separately on the raw `http.Server`. This is a known architectural gap in Koa-based WebSocket implementations.

Before submitting, we attempted to disprove this finding by checking whether any other mechanism protected the upgrade path. We examined the four adapter bot endpoints (napcat, onebot11, milky, onebot12) and confirmed they each implement their own `verifyClient` with token validation — so those specific paths are safe. However, the `/sandbox` endpoint has no such protection and relies entirely on the now-patched upgrade-level auth. We also verified that no reverse proxy configuration is bundled with the project that might gate WebSocket upgrades externally — the Docker Compose setup exposes the port directly.

---




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Authenticate WebSocket upgrade requests to fix missing authorization (CWE-862). This blocks unauthenticated access to `/sandbox` and other `router.ws()` endpoints.

- **Bug Fixes**
  - Validate Bearer token on upgrades via `Authorization` or `?token=`/`?access_token=`, using timing-safe compare.
  - Add `router.setAuthToken(token)` and call it from `packages/host/router/src/index.ts` to reuse the existing HTTP token.
  - Exempt paths that provide their own `verifyClient` (e.g., napcat/onebot/milky); others return 401 and the socket is closed.
  - Add `packages/host/router/tests/ws-auth.test.ts` covering accept/reject flows and exemptions.

<sup>Written for commit 756924b64dcc11d55b0232ee7e81532520cb867e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zhinjs/zhin/pull/463?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->