### PR TITLE
fix: prevent allowedDomains bypass for network commands

### DIFF
--- a/packages/im/agent/src/security/sandbox.ts
+++ b/packages/im/agent/src/security/sandbox.ts
@@ -210,7 +210,17 @@ function checkNetworkCommand(
   // 网络已启用但有域名白名单时，校验 URL
   if (config.allowedDomains && config.allowedDomains.length > 0) {
     const urls = extractUrlsFromCommand(command);
-    if (urls.length === 0) return { allowed: true }; // 无 URL 的命令放行
+    if (urls.length === 0) {
+      // 网络命令必须包含可校验的 URL
+      const hasNetworkCommand = NETWORK_COMMAND_PATTERNS.some(pattern => pattern.test(command));
+      if (hasNetworkCommand) {
+        return {
+          allowed: false,
+          reason: `启用 allowedDomains 时，网络命令必须包含可校验的 URL（如 http://example.com）`,
+        };
+      }
+      return { allowed: true };
+    }
 
     for (const url of urls) {
       try {


### PR DESCRIPTION
P1 cubic review fix: network commands must contain verifiable URL when allowedDomains is set.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a security gap by enforcing that, when allowedDomains is enabled, network commands must include a verifiable http(s) URL. Commands without URLs (e.g., curl --help, ssh user@host) are now blocked to prevent whitelist bypass.

<sup>Written for commit 8cff2602787f825c585f487ff5c3e057034b1022. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zhinjs/zhin/pull/497?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

