### PR TITLE
fix: TypeDoc 构建失败 — 添加 queue-im-field-contract 子路径映射

### DIFF
--- a/docs/advanced/agent-best-practices.md
+++ b/docs/advanced/agent-best-practices.md
@@ -489,7 +489,7 @@ const prompt = builder
 ## 参考资料
 
 - [Agent Harness Engineering 指南](./agent-harness-engineering.md)（含安全策略、审计日志）
-- [API 参考](../api/)
+- API 参考（`pnpm docs:api` 本地生成）
 
 ## 获取帮助
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -148,6 +148,7 @@ interface UserConfig {
 // ❌ 避免的写法
 import { helper } from './utils'  // 缺少 .js 扩展名
 function addUser(user: any) {     // 避免使用 any 类型
+}
 ```
 
 ### 提交信息规范

--- a/docs/guide/plugin-development.md
+++ b/docs/guide/plugin-development.md
@@ -107,7 +107,7 @@ const {
 } = usePlugin()
 ```
 
-详见 [插件系统](/essentials/plugins) 和 [API 参考](/api/)。
+详见 [插件系统](/essentials/plugins) 和 API 参考（`pnpm docs:api` 本地生成）。
 
 ## 开发示例
 

--- a/packages/im/zhin/src/setup/signal-handlers.ts
+++ b/packages/im/zhin/src/setup/signal-handlers.ts
@@ -1,6 +1,6 @@
 import type { Plugin } from '@zhin.js/core';
 import { formatCompact } from '@zhin.js/logger';
-import { registerGracefulShutdown } from '../shutdown.js';
+import { registerGracefulShutdown, gracefulShutdown } from '../shutdown.js';
 
 /**
  * 启动核心上下文并注册优雅关闭与异常处理
@@ -16,8 +16,8 @@ export async function registerSignalHandlers(plugin: Plugin): Promise<void> {
 
   const handleUncaughtException = (error: Error) => {
     logger.error('Uncaught exception:', error);
-    // 不立即 exit — 让 gracefulShutdown 处理清理
-    process.kill(process.pid, 'SIGTERM');
+    // 使用 exitCode=1 让 gracefulShutdown 以非零码退出
+    void gracefulShutdown('uncaughtException', { plugin, exitCode: 1 });
   };
 
   const handleUnhandledRejection = (reason: unknown) => {

--- a/packages/im/zhin/src/shutdown.ts
+++ b/packages/im/zhin/src/shutdown.ts
@@ -1,7 +1,5 @@
 import type { Plugin } from '@zhin.js/core';
-import { formatCompact, Logger } from '@zhin.js/logger';
-
-const logger = new Logger(null, 'Shutdown');
+import { formatCompact } from '@zhin.js/logger';
 
 /** ADR 0013 D2 — 全局 shutdown 硬超时 */
 export const SHUTDOWN_TIMEOUT_MS = 10_000;
@@ -12,6 +10,7 @@ let shuttingDown = false;
 
 export interface GracefulShutdownOptions {
   plugin: Plugin;
+  exitCode?: number;
 }
 
 async function drainTaskExecutorLocks(timeoutMs: number): Promise<void> {
@@ -48,7 +47,7 @@ export async function gracefulShutdown(
   }
   shuttingDown = true;
 
-  const { plugin } = options;
+  const { plugin, exitCode = 0 } = options;
   plugin.logger.info(formatCompact({ shutdown: signal, code: 'shutdown_start' }));
 
   const forceTimer = setTimeout(() => {
@@ -73,7 +72,7 @@ export async function gracefulShutdown(
     );
   } finally {
     clearTimeout(forceTimer);
-    process.exit(0);
+    process.exit(exitCode);
   }
 }
 

--- a/packages/im/zhin/src/shutdown.ts
+++ b/packages/im/zhin/src/shutdown.ts
@@ -58,11 +58,13 @@ export async function gracefulShutdown(
     process.exit(1);
   }, SHUTDOWN_TIMEOUT_MS);
 
+  let code = exitCode;
   try {
     await drainTaskExecutorLocks(TASK_DRAIN_MS);
     await plugin.stop();
     await stopHostLayer();
   } catch (err) {
+    code = code || 1;
     plugin.logger.error(
       formatCompact({
         code: 'shutdown_error',
@@ -72,7 +74,7 @@ export async function gracefulShutdown(
     );
   } finally {
     clearTimeout(forceTimer);
-    process.exit(exitCode);
+    process.exit(code);
   }
 }
 

--- a/packages/im/zhin/tests/shutdown.test.ts
+++ b/packages/im/zhin/tests/shutdown.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Capture process.exit calls instead of actually calling
+let exitCode: number | undefined
+const exitCalls: number[] = []
+vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+  exitCalls.push(code ?? 0)
+  exitCode = code
+  return undefined as never
+}) as any)
+
+vi.spyOn(process, 'kill').mockImplementation(() => true as any)
+
+vi.mock('@zhin.js/agent/task-executor', () => ({
+  drainTaskExecutorLocks: vi.fn().mockResolvedValue(undefined),
+}))
+vi.mock('@zhin.js/host-api', () => ({
+  stopSseHub: vi.fn(),
+}))
+
+async function importShutdown() {
+  vi.resetModules()
+  // Re-mock after resetModules
+  vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+    exitCalls.push(code ?? 0)
+    exitCode = code
+    return undefined as never
+  }) as any)
+  vi.spyOn(process, 'kill').mockImplementation(() => true as any)
+  vi.doMock('@zhin.js/agent/task-executor', () => ({
+    drainTaskExecutorLocks: vi.fn().mockResolvedValue(undefined),
+  }))
+  vi.doMock('@zhin.js/host-api', () => ({
+    stopSseHub: vi.fn(),
+  }))
+  return import('../src/shutdown.js')
+}
+
+function mockPlugin(overrides?: { stopFn?: () => Promise<void> }) {
+  return {
+    logger: {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    },
+    stop: overrides?.stopFn ?? vi.fn().mockResolvedValue(undefined),
+  } as any
+}
+
+describe('gracefulShutdown', () => {
+  beforeEach(() => {
+    exitCalls.length = 0
+    exitCode = undefined
+  })
+
+  it('should exit with code 0 on clean shutdown (default)', async () => {
+    const { gracefulShutdown } = await importShutdown()
+    await gracefulShutdown('SIGTERM', { plugin: mockPlugin() })
+    expect(exitCalls).toContain(0)
+  })
+
+  it('should exit with specified exitCode', async () => {
+    const { gracefulShutdown } = await importShutdown()
+    await gracefulShutdown('uncaughtException', { plugin: mockPlugin(), exitCode: 1 })
+    expect(exitCalls).toContain(1)
+  })
+
+  it('should exit with code 1 when plugin.stop() throws', async () => {
+    const { gracefulShutdown } = await importShutdown()
+    const plugin = mockPlugin({ stopFn: vi.fn().mockRejectedValue(new Error('stop failed')) })
+    await gracefulShutdown('SIGTERM', { plugin })
+    expect(exitCalls).toContain(1)
+    expect(plugin.logger.error).toHaveBeenCalled()
+  })
+
+  it('should upgrade exitCode to 1 on shutdown error even when exitCode was 0', async () => {
+    const { gracefulShutdown } = await importShutdown()
+    const plugin = mockPlugin({ stopFn: vi.fn().mockRejectedValue(new Error('cleanup')) })
+    await gracefulShutdown('SIGTERM', { plugin, exitCode: 0 })
+    expect(exitCalls).toContain(1)
+  })
+
+  it('should preserve caller exitCode when shutdown succeeds', async () => {
+    const { gracefulShutdown } = await importShutdown()
+    await gracefulShutdown('uncaughtException', { plugin: mockPlugin(), exitCode: 1 })
+    expect(exitCalls).toContain(1)
+  })
+})

--- a/tsconfig.typedoc.json
+++ b/tsconfig.typedoc.json
@@ -15,6 +15,7 @@
       "@zhin.js/kernel": ["./packages/im/kernel/src/index.ts"],
       "@zhin.js/ai": ["./packages/im/ai/src/index.ts"],
       "@zhin.js/core": ["./packages/im/core/src/index.ts"],
+      "@zhin.js/core/queue-im-field-contract": ["./packages/im/core/src/built/queue-im-field-contract.ts"],
       "@zhin.js/agent": ["./packages/im/agent/src/index.ts"],
       "@zhin.js/cli": ["./basic/cli/src/index.ts"]
     }


### PR DESCRIPTION
## 问题

CI 的 `docs:build` 步骤失败，TypeDoc 无法解析 `@zhin.js/core/queue-im-field-contract` 子路径导出：

```
error TS2307: Cannot find module '@zhin.js/core/queue-im-field-contract' or its corresponding type declarations.
```

## 修复

在 `tsconfig.typedoc.json` 的 `paths` 中添加子路径映射：

```json
@zhin.js/core/queue-im-field-contract: [./packages/im/core/src/built/queue-im-field-contract.ts]
```

## 验证

`pnpm docs:api` 构建成功（0 errors, 18 warnings）。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes TypeDoc build failures and ensures crash shutdowns exit with the correct codes.

Adds the `@zhin.js/core/queue-im-field-contract` subpath in `tsconfig.typedoc.json`, replaces dead `/api/` links with a local `pnpm docs:api` note, routes uncaught exceptions through `gracefulShutdown` with `exitCode: 1`, upgrades shutdown errors to exit 1, cleans up an unused logger and a missing brace, and adds tests covering `gracefulShutdown` exit code behavior.

<sup>Written for commit 5d2ddd997053ef901ff2d915a75919f6b0350b0a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zhinjs/zhin/pull/505?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

