### PR TITLE
docs: ADR 0017 RAG v0 产品边界 + ADR 索引补全

### DIFF
--- a/README.md
+++ b/README.md
@@ -497,7 +497,7 @@ graph TD
 
 ## 多平台适配器
 
-仓库内 [`plugins/adapters/`](./plugins/adapters/) 共 **17** 个适配器包（成熟度因平台而异，对外默认承诺以 Sandbox 为主）：
+仓库内 [`plugins/adapters/`](./plugins/adapters/) 共 **19** 个适配器包（成熟度因平台而异，对外默认承诺以 Sandbox 为主）：
 
 | 平台 | 包名 | 平台 | 包名 |
 |------|------|------|------|
@@ -509,6 +509,7 @@ graph TD
 | Slack | `@zhin.js/adapter-slack` | 钉钉 | `@zhin.js/adapter-dingtalk` |
 | 飞书 | `@zhin.js/adapter-lark` | 微信公众号 | `@zhin.js/adapter-wechat-mp` |
 | Email | `@zhin.js/adapter-email` | GitHub | `@zhin.js/adapter-github` |
+| 企业微信（WeCom） | `@zhin.js/adapter-wecom` | LINE | `@zhin.js/adapter-line` |
 | Satori | `@zhin.js/adapter-satori` | | |
 
 

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -42,6 +42,9 @@ const adapterSidebar = [
       { text: '钉钉', link: '/adapters/dingtalk' },
       { text: '飞书', link: '/adapters/lark' },
       { text: '微信公众号', link: '/adapters/wechat-mp' },
+      { text: '微信 iLink', link: '/adapters/weixin-ilink' },
+      { text: '企业微信', link: '/adapters/wecom' },
+      { text: 'LINE', link: '/adapters/line' },
     ],
   },
   {

--- a/docs/adapters/line.md
+++ b/docs/adapters/line.md
@@ -1,0 +1,88 @@
+---
+title: "@zhin.js/adapter-line"
+package: "@zhin.js/adapter-line"
+tier: Advanced
+---
+
+::: info 文档同步
+本页由 [`plugins/adapters/line/README.md`](https://github.com/zhinjs/zhin/tree/main/plugins/adapters/line/README.md) 自动生成。请修改包内 README 后运行 `pnpm sync:adapter-docs`。
+:::
+
+<!-- sync-adapter-docs:sha256=388a9e969e336bdb -->
+
+# @zhin.js/adapter-line
+
+Zhin.js 适配器 — LINE Messaging API (Webhook 模式)
+
+## 功能
+
+- 接收并解析 LINE Webhook 事件（text、image、video、audio、file、location、sticker）
+- 支持私聊、群组、多人聊天（room）三种场景
+- Reply API / Push API 发送消息
+- HMAC-SHA256 签名验证
+
+## 前置条件
+
+1. 在 [LINE Developers Console](https://developers.line.biz/) 创建 Messaging API Channel
+2. 获取 **Channel Secret** 和 **Channel Access Token**
+3. 设置 Webhook URL 为 `https://your-domain/line/webhook`
+4. 在 Console 中启用 **Use webhooks** 并关闭 **Auto-reply messages**
+
+## 最小配置
+
+```yaml
+# zhin.config.yml
+adapters:
+  - context: line
+    name: my-line-bot
+    channelSecret: ${LINE_CHANNEL_SECRET}
+    channelAccessToken: ${LINE_CHANNEL_ACCESS_TOKEN}
+    webhookPath: /line/webhook       # 可选，默认 /line/webhook
+    apiBaseUrl: https://api.line.me   # 可选，调试时可改为 LINE API 沙盒地址
+```
+
+## 环境变量
+
+| 变量 | 说明 |
+|------|------|
+| `LINE_CHANNEL_SECRET` | Channel Secret（签名验证用） |
+| `LINE_CHANNEL_ACCESS_TOKEN` | Long-lived Channel Access Token（API 调用用） |
+
+## Webhook URL 配置
+
+LINE 要求 Webhook URL 以 HTTPS 开头。常见方案：
+
+- **反向代理**：Nginx/Caddy 将 `https://your-domain/line/webhook` 转发到本地 zhIn 端口
+- **Cloudflare Tunnel**：`cloudflared tunnel --url http://localhost:端口`
+- **ngrok**：调试用 `ngrok http 端口`
+
+设置完成后在 LINE Developers Console 点击 **Verify** 验证连通性。
+
+## 消息类型映射
+
+| LINE 类型 | Zhin.js Segment | 说明 |
+|-----------|----------------|------|
+| text | text | 纯文本 |
+| image | image | 图片（暂不支持二次获取） |
+| video | video | 视频 |
+| audio | audio | 音频 |
+| file | file | 文件 |
+| location | location | 位置信息 |
+| sticker | sticker | 贴纸 |
+
+## 已知限制
+
+- **不支持消息撤回**：LINE Messaging API 不提供撤回已发送消息的接口
+- **图片/视频/音频**：收到的媒体消息仅包含 message_id，需通过 Content API 下载（未实装）
+- **单次最多 5 条消息**：LINE 限制单次 Reply/Push 最多 5 条
+- **文本长度限制**：单条文本消息最多 5000 字符
+
+## 故障排查
+
+| 问题 | 排查方法 |
+|------|---------|
+| Webhook Verify 失败 | 检查 HTTPS 证书、域名解析、端口是否可达 |
+| 签名验证 403 | 确认 Channel Secret 与 Console 一致 |
+| 发送 401 | 确认 Channel Access Token 未过期 |
+| 发送 400 | 检查消息格式是否符合 LINE API 规范 |
+| 事件未到达 | Console 中 Webhook 是否已启用、是否关闭 Auto-reply |

--- a/docs/adapters/wecom.md
+++ b/docs/adapters/wecom.md
@@ -1,0 +1,275 @@
+---
+title: "@zhin.js/adapter-wecom"
+package: "@zhin.js/adapter-wecom"
+tier: Advanced
+---
+
+::: info 文档同步
+本页由 [`plugins/adapters/wecom/README.md`](https://github.com/zhinjs/zhin/tree/main/plugins/adapters/wecom/README.md) 自动生成。请修改包内 README 后运行 `pnpm sync:adapter-docs`。
+:::
+
+<!-- sync-adapter-docs:sha256=605ea0ce73ac6aeb -->
+
+# @zhin.js/adapter-wecom
+
+Zhin.js 企业微信（WeCom）适配器，支持企业内部应用机器人开发。
+
+## 安装
+
+```bash
+pnpm add @zhin.js/adapter-wecom
+```
+
+## 前置条件
+
+### 企业微信管理后台配置
+
+1. **登录企业微信管理后台**
+   - 访问 [企业微信管理后台](https://work.weixin.qq.com/wework_admin/frame)
+   - 使用管理员账号登录
+
+2. **创建应用**
+   - 进入「应用管理」→「自建」
+   - 点击「创建应用」
+   - 填写应用名称、上传 Logo、选择可见范围
+
+3. **获取应用凭证**
+   - 在应用详情页面获取：
+     - **CorpId**（企业 ID）：在「我的企业」→「企业信息」中查看
+     - **AgentId**（应用 AgentId）：在应用详情页面
+     - **Secret**（应用 Secret）：在应用详情页面
+
+4. **配置接收消息**
+   - 在应用详情页面，进入「接收消息」设置
+   - 设置 **URL**：`https://yourdomain.com/wecom/callback`
+   - 设置 **Token**：自定义字符串（用于签名验证）
+   - 设置 **EncodingAESKey**：点击「随机获取」（用于消息加解密）
+   - 点击「保存」，企业微信会发送验证请求
+
+5. **配置权限**
+   - 在「API 权限」中申请所需权限：
+     - `通讯录只读权限` - 读取组织架构和用户信息
+     - `应用消息发送权限` - 向用户发送消息
+     - 其他业务需要的权限
+
+## 配置
+
+### 基础配置（zhin.config.yml）
+
+```yaml
+endpoints:
+  - name: wecom-bot
+    context: wecom
+    corpId: "ww1234567890abcdef"
+    agentSecret: "your-agent-secret"
+    token: "your-verify-token"
+    encodingAESKey: "your-43-char-encoding-aes-key"
+    webhookPath: "/wecom/callback"
+
+plugins:
+  - "@zhin.js/host-router"
+  - "@zhin.js/adapter-wecom"
+```
+
+### 完整配置
+
+```yaml
+endpoints:
+  - name: wecom-bot
+    context: wecom
+    corpId: "ww1234567890abcdef"
+    agentSecret: "your-agent-secret"
+    token: "your-verify-token"
+    encodingAESKey: "your-43-char-encoding-aes-key"
+    webhookPath: "/wecom/callback"
+    apiBaseUrl: "https://qyapi.weixin.qq.com"  # 可选，默认值
+```
+
+### 配置参数说明
+
+| 参数 | 必需 | 说明 |
+|------|------|------|
+| `corpId` | 是 | 企业 ID，在管理后台「我的企业」查看 |
+| `agentSecret` | 是 | 应用 Secret，在应用详情页获取 |
+| `token` | 是 | 用于签名验证，需与管理后台「接收消息」设置中的 Token 一致 |
+| `encodingAESKey` | 是 | 用于消息加解密，需与管理后台一致（43 字符） |
+| `webhookPath` | 否 | Webhook 回调路径，默认 `/wecom/callback` |
+| `apiBaseUrl` | 否 | 企业微信 API 地址，默认 `https://qyapi.weixin.qq.com` |
+
+### 环境变量推荐
+
+```yaml
+endpoints:
+  - name: wecom-bot
+    context: wecom
+    corpId: "${WECOM_CORP_ID}"
+    agentSecret: "${WECOM_AGENT_SECRET}"
+    token: "${WECOM_TOKEN}"
+    encodingAESKey: "${WECOM_AES_KEY}"
+```
+
+## 使用示例
+
+### 接收和发送消息
+
+```typescript
+import { usePlugin, MessageCommand } from 'zhin.js'
+
+const { addCommand, logger } = usePlugin()
+
+// 定义命令
+addCommand(new MessageCommand('hello <name:text>')
+  .action(async (message, result) => {
+    logger.info(`收到问候: ${result.params.name}`)
+    return `你好，${result.params.name}！欢迎使用企业微信机器人。`
+  })
+)
+
+// 监听所有消息
+import { onMessage } from 'zhin.js'
+
+onMessage(async (message) => {
+  logger.info(`收到消息：${JSON.stringify(message.$content)}`)
+  logger.info(`发送者：${message.$sender.name}`)
+  logger.info(`会话类型：${message.$channel.type}`)
+})
+```
+
+### 发送富文本消息
+
+```typescript
+addCommand(new MessageCommand('info')
+  .action(async (message) => {
+    return [
+      {
+        type: 'markdown',
+        data: {
+          content: `# 系统信息\n\n- 服务器: 运行正常\n- 版本: v1.0.0\n- 状态: 在线`
+        }
+      }
+    ]
+  })
+)
+```
+
+## 消息类型支持
+
+### 接收消息类型
+
+| 类型 | 状态 | 说明 |
+|------|------|------|
+| 文本消息 (`text`) | 支持 | 普通文本 |
+| 图片消息 (`image`) | 支持 | 图片文件 |
+| 语音消息 (`voice`) | 支持 | 含语音识别结果 |
+| 视频消息 (`video`) | 支持 | 视频文件 |
+| 位置消息 (`location`) | 支持 | 地理位置 |
+| 链接消息 (`link`) | 支持 | 链接卡片 |
+| 事件消息 (`event`) | 支持 | 关注/取消关注等 |
+
+### 发送消息类型
+
+| 类型 | 状态 | 说明 |
+|------|------|------|
+| 文本消息 | 支持 | 支持 @ 提醒 |
+| 图片消息 | 支持 | 需要 media_id |
+| Markdown 消息 | 支持 | 企业微信原生 Markdown |
+| 图文消息 | 支持 | news 类型 |
+| 撤回消息 | 不支持 | 企业微信机器人不支持撤回 |
+
+## 安全说明
+
+### 消息加解密
+
+企业微信使用 AES-256-CBC 加密算法对回调消息进行加密：
+
+- **签名验证**：SHA1 排序拼接 `[token, timestamp, nonce, encrypt]`
+- **解密流程**：
+  1. Base64 解码加密消息
+  2. AES-256-CBC 解密（Key: `encodingAESKey` + `=` 的 Base64 解码，IV: Key 的前 16 字节）
+  3. PKCS7 去填充
+  4. 提取：16 字节随机数 + 4 字节消息长度 + 消息体 + CorpId
+
+适配器自动处理所有加解密，无需手动处理。
+
+### Token 管理
+
+适配器会自动管理 access_token：
+- 首次连接时获取 token
+- Token 过期前 5 分钟自动刷新
+- 所有 API 请求自动携带有效 token
+
+## API 方法
+
+### 获取用户信息
+
+```typescript
+const endpoint = app.adapters.get('wecom')?.endpoints.get('wecom-bot')
+if (endpoint) {
+  const userInfo = await endpoint.getUserInfo('user-id')
+  console.log(userInfo)
+}
+```
+
+### 获取部门用户列表
+
+```typescript
+const users = await endpoint.getDepartmentUsers(1) // 部门 ID
+console.log(users)
+```
+
+### 获取部门列表
+
+```typescript
+const departments = await endpoint.getDepartmentList(1) // 父部门 ID
+console.log(departments)
+```
+
+### 发送文本消息
+
+```typescript
+const success = await endpoint.sendTextMessage('user-id', '这是一条测试消息')
+```
+
+## 故障排查
+
+### Q: Webhook 验证失败？
+
+A: 检查以下几点：
+1. `token` 是否与企业微信管理后台设置的 Token 一致
+2. `encodingAESKey` 是否与管理后台一致（43 字符）
+3. 服务器是否可从公网访问
+4. 服务器是否返回了正确的验证响应（解密后的 echostr）
+
+### Q: 收不到消息回调？
+
+A: 可能的原因：
+1. 应用未启用「接收消息」功能
+2. Webhook URL 配置错误或不可达
+3. 应用可见范围未包含发送消息的用户
+4. 服务器日志中是否有签名验证失败的警告
+
+### Q: 发送消息失败？
+
+A: 可能的原因：
+1. `agentSecret`（应用 Secret）配置错误
+2. access_token 获取失败（检查 CorpId 和 Secret）
+3. 接收者不在应用可见范围内
+4. 应用未开通消息发送权限
+
+### Q: Token 刷新失败？
+
+A: 检查：
+1. CorpId 是否正确
+2. agentSecret 是否是应用 Secret（不是应用的 AgentId 数字）
+3. 企业微信 API 是否可访问
+
+## 相关链接
+
+- [企业微信开发文档](https://developer.work.weixin.qq.com/document/)
+- [企业微信接收消息](https://developer.work.weixin.qq.com/document/path/90930)
+- [企业微信发送应用消息](https://developer.work.weixin.qq.com/document/path/90236)
+- [Zhin.js 官方文档](https://github.com/zhinjs/zhin)
+
+## 许可证
+
+MIT License

--- a/docs/adapters/weixin-ilink.md
+++ b/docs/adapters/weixin-ilink.md
@@ -2,7 +2,6 @@
 title: "@zhin.js/adapter-weixin-ilink"
 package: "@zhin.js/adapter-weixin-ilink"
 tier: Advanced
-sidebar: false
 ---
 
 ::: info 文档同步

--- a/docs/adr/0017-rag-v0-knowledge-search.md
+++ b/docs/adr/0017-rag-v0-knowledge-search.md
@@ -1,0 +1,93 @@
+---
+sidebar: false
+---
+
+# ADR 0017: RAG v0 — 本地知识库检索
+
+## 状态
+
+已实现（2026-06-13）· PR #506
+
+## 背景
+
+生活助手场景需要检索本地文档（FAQ、说明书、菜谱、规章制度）。用户不想每次都把整个文件粘贴到对话中，需要 Agent 自动按需检索。
+
+**与 semantic memory 的区别**：semantic memory 存储碎片事实（用户偏好、历史事件），knowledge 存储结构化文档（Markdown/PDF 目录）。两者互补，不互相替代。
+
+**产品定位**：RAG 是 Advanced 能力，服务聊天/生活助手场景。明确不做：plan mode、代码库索引、coding-agent 式 repo RAG。
+
+## 决策
+
+### D1 — 工具名：`knowledge_search`
+
+使用 `knowledge_search` 作为工具名（而非 `rag_search` 或 `document_search`），强调「知识检索」语义。
+
+### D2 — 纯本地文件目录，无外部依赖
+
+知识库目录通过 `ai.knowledge.baseDir` 配置（默认 `knowledge`），相对于项目根目录。支持 `.md` 和 `.txt` 文件。
+
+不做向量数据库、不做嵌入模型、不做远程知识源。v0 目标是「够用且零配置」。
+
+### D3 — 段落级分块 + 关键词匹配
+
+分块策略：
+- 按双换行（`\n\n`）拆分段落
+- 超过 `maxChunkSize`（默认 1000 字符）的段落按单换行继续拆分
+- 超长单行按字符强制拆分
+- 每个 chunk 附带源文件路径
+
+搜索策略：
+- 关键词匹配（`String.includes`），不使用 TF-IDF 或 BM25
+- 按匹配数排序，返回 top-K（默认 5）
+- 支持 `file` 参数过滤特定文件
+
+选择关键词匹配而非向量搜索的理由：
+1. 零外部依赖（不需要 embedding 模型）
+2. 对中文短文档足够有效
+3. 启动即用，无需索引构建步骤
+
+### D4 — 启动时懒索引 + TTL 缓存
+
+- 首次 `knowledge_search` 调用时扫描目录并分块索引
+- 索引带 60 秒 TTL 缓存，新增/修改文件下次查询时自动发现
+- 缓存条件：`cacheTime > 0 && (now - cacheTime) < cacheTtl`（空目录也走缓存）
+
+### D5 — 与 semantic memory 并行（非合并）
+
+| 维度 | knowledge_search | semantic memory |
+|------|-----------------|-----------------|
+| 存储 | 文件系统（原始 Markdown） | 数据库 `memory_entries` 表 |
+| 检索 | 关键词匹配 | 向量相似度（未来） |
+| 写入 | 编辑文件 | `memory_upsert` 工具 |
+| 更新 | 文件修改后下次查询自动发现 | 实时 |
+| 适用 | 结构化文档 | 碎片事实 |
+
+v0 不做两者合并。未来可考虑：knowledge 文件变更时自动写入 semantic memory。
+
+### D6 — 配置契约
+
+```yaml
+ai:
+  knowledge:
+    baseDir: knowledge    # 相对于项目根目录，默认 "knowledge"
+```
+
+最小配置，无其他参数。分块大小、缓存 TTL 等内部参数不暴露到配置层。
+
+### D7 — 不做的事项
+
+| 不做 | 原因 |
+|------|------|
+| 向量搜索 / 嵌入模型 | v0 目标是零依赖、零配置 |
+| PDF 解析 | 增加依赖复杂度，v0 仅支持文本 |
+| Console 知识库管理 UI | v0 仅文件系统，v1 考虑 Console 上传 |
+| 代码库索引 | 不在产品边界内（coding-agent 场景） |
+| 远程知识源（URL、API） | v0 仅本地文件 |
+| chunk 大小/重叠可配置 | 内部参数，无需暴露 |
+
+## 参考
+
+- [ADR 0015 D6 产品边界](/adr/0015-capability-tier-model)
+- [capability-tiers RAG 状态](/essentials/capability-tiers#rag--知识库)
+- [配置文档 / 本地知识库](/essentials/configuration#本地知识库-knowledge-search-工具)
+- 实现：`packages/im/agent/src/builtin/knowledge-search-tool.ts`

--- a/docs/essentials/capability-tiers.md
+++ b/docs/essentials/capability-tiers.md
@@ -73,6 +73,8 @@ flowchart LR
 | 飞书 | [lark](/adapters/lark) |
 | 微信公众号 | [wechat-mp](/adapters/wechat-mp) |
 | 微信 iLink（个人微信） | [weixin-ilink](/adapters/weixin-ilink) |
+| 企业微信（WeCom） | [wecom](/adapters/wecom) |
+| LINE | [line](/adapters/line) |
 
 本地调试 IM 仍推荐 **Sandbox**（Stable Core）：[Remote Console 沙盒页](/console-remote#官方管理界面能做什么)。
 
@@ -82,12 +84,7 @@ flowchart LR
 
 ## 待补充平台
 
-下列 IM 尚无 Platform Stable 适配器，Issue 跟踪中：
-
-| 平台 | 跟踪 |
-|------|------|
-| 企业微信（WeCom） | [#484](https://github.com/zhinjs/zhin/issues/484) |
-| LINE | [#485](https://github.com/zhinjs/zhin/issues/485) |
+暂无。企业微信（WeCom）和 LINE 已在上方 Platform Stable 列表中。
 
 ## Stable（Core）还包含什么
 

--- a/plugins/adapters/line/README.md
+++ b/plugins/adapters/line/README.md
@@ -1,0 +1,76 @@
+# @zhin.js/adapter-line
+
+Zhin.js 适配器 — LINE Messaging API (Webhook 模式)
+
+## 功能
+
+- 接收并解析 LINE Webhook 事件（text、image、video、audio、file、location、sticker）
+- 支持私聊、群组、多人聊天（room）三种场景
+- Reply API / Push API 发送消息
+- HMAC-SHA256 签名验证
+
+## 前置条件
+
+1. 在 [LINE Developers Console](https://developers.line.biz/) 创建 Messaging API Channel
+2. 获取 **Channel Secret** 和 **Channel Access Token**
+3. 设置 Webhook URL 为 `https://your-domain/line/webhook`
+4. 在 Console 中启用 **Use webhooks** 并关闭 **Auto-reply messages**
+
+## 最小配置
+
+```yaml
+# zhin.config.yml
+adapters:
+  - context: line
+    name: my-line-bot
+    channelSecret: ${LINE_CHANNEL_SECRET}
+    channelAccessToken: ${LINE_CHANNEL_ACCESS_TOKEN}
+    webhookPath: /line/webhook       # 可选，默认 /line/webhook
+    apiBaseUrl: https://api.line.me   # 可选，调试时可改为 LINE API 沙盒地址
+```
+
+## 环境变量
+
+| 变量 | 说明 |
+|------|------|
+| `LINE_CHANNEL_SECRET` | Channel Secret（签名验证用） |
+| `LINE_CHANNEL_ACCESS_TOKEN` | Long-lived Channel Access Token（API 调用用） |
+
+## Webhook URL 配置
+
+LINE 要求 Webhook URL 以 HTTPS 开头。常见方案：
+
+- **反向代理**：Nginx/Caddy 将 `https://your-domain/line/webhook` 转发到本地 zhIn 端口
+- **Cloudflare Tunnel**：`cloudflared tunnel --url http://localhost:端口`
+- **ngrok**：调试用 `ngrok http 端口`
+
+设置完成后在 LINE Developers Console 点击 **Verify** 验证连通性。
+
+## 消息类型映射
+
+| LINE 类型 | Zhin.js Segment | 说明 |
+|-----------|----------------|------|
+| text | text | 纯文本 |
+| image | image | 图片（暂不支持二次获取） |
+| video | video | 视频 |
+| audio | audio | 音频 |
+| file | file | 文件 |
+| location | location | 位置信息 |
+| sticker | sticker | 贴纸 |
+
+## 已知限制
+
+- **不支持消息撤回**：LINE Messaging API 不提供撤回已发送消息的接口
+- **图片/视频/音频**：收到的媒体消息仅包含 message_id，需通过 Content API 下载（未实装）
+- **单次最多 5 条消息**：LINE 限制单次 Reply/Push 最多 5 条
+- **文本长度限制**：单条文本消息最多 5000 字符
+
+## 故障排查
+
+| 问题 | 排查方法 |
+|------|---------|
+| Webhook Verify 失败 | 检查 HTTPS 证书、域名解析、端口是否可达 |
+| 签名验证 403 | 确认 Channel Secret 与 Console 一致 |
+| 发送 401 | 确认 Channel Access Token 未过期 |
+| 发送 400 | 检查消息格式是否符合 LINE API 规范 |
+| 事件未到达 | Console 中 Webhook 是否已启用、是否关闭 Auto-reply |

--- a/plugins/adapters/line/package.json
+++ b/plugins/adapters/line/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zhin.js/adapter-line",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Zhin.js adapter for LINE Messaging API",
   "type": "module",
   "main": "./lib/index.js",

--- a/plugins/adapters/line/package.json
+++ b/plugins/adapters/line/package.json
@@ -1,0 +1,74 @@
+{
+  "name": "@zhin.js/adapter-line",
+  "version": "0.1.0",
+  "description": "Zhin.js adapter for LINE Messaging API",
+  "type": "module",
+  "main": "./lib/index.js",
+  "types": "./lib/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./lib/index.d.ts",
+      "development": "./src/index.ts",
+      "import": "./lib/index.js"
+    }
+  },
+  "keywords": [
+    "zhin",
+    "zhin.js",
+    "bot",
+    "adapter",
+    "line",
+    "chatbot"
+  ],
+  "author": {
+    "name": "lc-cn",
+    "email": "admin@liucl.cn",
+    "url": "https://github.com/lc-cn"
+  },
+  "license": "MIT",
+  "repository": {
+    "url": "git+https://github.com/zhinjs/zhin.git",
+    "type": "git",
+    "directory": "plugins/adapters/line"
+  },
+  "scripts": {
+    "build": "zhin build",
+    "clean": "rimraf lib dist",
+    "build:node": "tsc"
+  },
+  "devDependencies": {
+    "@types/node": "^25.9.2",
+    "@zhin.js/cli": "workspace:*",
+    "@zhin.js/host-api": "workspace:*",
+    "@zhin.js/host-router": "workspace:*",
+    "@zhin.js/logger": "workspace:*",
+    "typescript": "^6.0.3",
+    "zhin.js": "workspace:*"
+  },
+  "peerDependencies": {
+    "@zhin.js/host-api": "workspace:*",
+    "@zhin.js/host-router": "workspace:*",
+    "@zhin.js/logger": "workspace:*",
+    "zhin.js": "workspace:*"
+  },
+  "peerDependenciesMeta": {
+    "@zhin.js/host-router": {
+      "optional": true
+    },
+    "@zhin.js/host-api": {
+      "optional": true
+    }
+  },
+  "files": [
+    "src",
+    "lib",
+    "skills",
+    "plugin.yml",
+    "README.md",
+    "CHANGELOG.md"
+  ],
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org"
+  }
+}

--- a/plugins/adapters/line/plugin.yml
+++ b/plugins/adapters/line/plugin.yml
@@ -1,0 +1,3 @@
+name: adapter-line
+description: LINE Messaging API 适配器：Webhook 接收、Reply/Push 发送、签名验证
+version: 0.1.0

--- a/plugins/adapters/line/skills/line/PERMITS.md
+++ b/plugins/adapters/line/skills/line/PERMITS.md
@@ -1,0 +1,17 @@
+# LINE 适配器权限说明
+
+LINE Messaging API 适配器本身不涉及平台级权限检查（LINE 没有类似 Telegram 的 ChatMember 权限模型）。
+
+## 平台权限
+
+LINE 的权限模型通过 LINE Official Account Manager 管理，不在 bot 层面控制。
+所有发消息权限由 Channel Access Token 的 scope 决定。
+
+## 已知 scope
+
+| scope | 说明 |
+|-------|------|
+| `message` | 发送消息（Reply + Push） |
+| `profile` | 获取用户资料 |
+
+如需额外权限，请在 LINE Developers Console 的 Messaging API 设置中启用。

--- a/plugins/adapters/line/skills/line/SKILL.md
+++ b/plugins/adapters/line/skills/line/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: line
+platforms:
+  - line
+description: >-
+  LINE Messaging API 适配器技能。当用户在 LINE 私聊或群组中发送消息时，
+  框架通过 Webhook 接收并处理。支持文本、图片、视频、音频、文件、位置、贴纸
+  等消息类型。回复消息使用 Reply API（自动引用上下文），主动发送使用 Push API。
+keywords:
+  - line
+  - adapter:line
+  - messaging-api
+  - webhook
+tags:
+  - im
+  - adapter
+---
+# LINE Messaging API 技能
+
+LINE 的 Messaging API 基于 Webhook 模式：平台将事件 POST 到指定 URL，适配器签名验证后处理。
+
+## 消息接收
+
+- 文本消息：直接转发为 text segment
+- 媒体消息（image/video/audio/file）：包含 message_id，可通过 Content API 获取
+- 位置消息：包含经纬度和地址
+- 贴纸消息：包含 packageId 和 stickerId
+
+## 消息发送
+
+- **Reply API**：有 replyToken 时自动使用，回复会关联原始消息
+- **Push API**：无 replyToken 时使用，主动推送到 userId/groupId/roomId
+- 单次最多 5 条消息，单条文本最多 5000 字符
+
+## 限制
+
+- 不支持消息撤回
+- 不支持已读回执（read receipt）
+- 媒体消息仅提供 message_id，需额外 API 调用获取内容

--- a/plugins/adapters/line/src/adapter.ts
+++ b/plugins/adapters/line/src/adapter.ts
@@ -1,0 +1,29 @@
+/**
+ * LINE 适配器
+ */
+import {
+  Adapter,
+  Plugin,
+} from "zhin.js";
+import { LineEndpoint } from "./endpoint.js";
+import type { LineEndpointConfig } from "./types.js";
+import type { Router } from "@zhin.js/host-router/router";
+
+export class LineAdapter extends Adapter<LineEndpoint> {
+  static override readonly capabilities = ['inbound', 'outbound'] as const;
+
+  #router: Router;
+
+  constructor(plugin: Plugin, router: Router) {
+    super(plugin, "line", []);
+    this.#router = router;
+  }
+
+  createEndpoint(config: LineEndpointConfig): LineEndpoint {
+    return new LineEndpoint(this, this.#router, config);
+  }
+
+  async start(): Promise<void> {
+    await super.start();
+  }
+}

--- a/plugins/adapters/line/src/endpoint.ts
+++ b/plugins/adapters/line/src/endpoint.ts
@@ -1,0 +1,548 @@
+/**
+ * LINE Endpoint 实现
+ *
+ * 使用 Webhook 模式接收消息，通过 LINE Messaging API 发送消息。
+ * HMAC-SHA256 签名验证确保请求来自 LINE 平台。
+ */
+import { createHmac } from "node:crypto";
+import { EventEmitter } from "node:events";
+import {
+  Endpoint,
+  Message,
+  SendOptions,
+  SendContent,
+  MessageSegment,
+  segment,
+  formatCompact,
+  type QuotedMessagePayload,
+} from "zhin.js";
+import { registerFetchRoute, type Router, type RouterContext } from "@zhin.js/host-router/router";
+import type {
+  LineEndpointConfig,
+  LineEvent,
+  LineMessage,
+  LineWebhookBody,
+  LineReplyMessage,
+  LinePushRequest,
+  LineReplyRequest,
+  LineApiResponse,
+} from "./types.js";
+import type { LineAdapter } from "./adapter.js";
+
+export class LineEndpoint extends EventEmitter implements Endpoint<LineEndpointConfig, LineEvent> {
+  $connected: boolean = false;
+
+  get pluginLogger() {
+    return this.adapter.plugin.logger;
+  }
+
+  get $id() {
+    return this.$config.name;
+  }
+
+  constructor(
+    public adapter: LineAdapter,
+    private router: Router,
+    public $config: LineEndpointConfig,
+  ) {
+    super();
+  }
+
+  async $connect(): Promise<void> {
+    try {
+      const path = this.$config.webhookPath || "/line/webhook";
+      const cleanPath = path.startsWith("/") ? path : `/${path}`;
+      registerFetchRoute(this.router, "POST", cleanPath, async (ctx: RouterContext) => {
+        await this.handleWebhook(ctx);
+      });
+      this.$connected = true;
+      this.pluginLogger.info(formatCompact({ op: "webhook", path: cleanPath }));
+    } catch (error) {
+      this.pluginLogger.error("Failed to connect LINE endpoint:", error);
+      this.$connected = false;
+      throw error;
+    }
+  }
+
+  async $disconnect(): Promise<void> {
+    try {
+      this.$connected = false;
+      this.pluginLogger.info(`LINE endpoint ${this.$config.name} disconnected`);
+    } catch (error) {
+      this.pluginLogger.error("Error disconnecting LINE endpoint:", error);
+      throw error;
+    }
+  }
+
+  // ── Webhook 处理 ────────────────────────────────────────────────────
+
+  private async handleWebhook(ctx: RouterContext): Promise<void> {
+    try {
+      // 1. 签名验证
+      const signature = ctx.get("x-line-signature");
+      if (!signature) {
+        ctx.status = 403;
+        ctx.body = { message: "Missing signature" };
+        return;
+      }
+
+      // 获取原始请求体用于签名验证
+      const rawBody = typeof ctx.request.body === "string"
+        ? ctx.request.body
+        : JSON.stringify(ctx.request.body);
+
+      if (!this.verifySignature(rawBody, signature)) {
+        this.pluginLogger.warn(formatCompact({ op: "webhook", ok: false, error: "invalid signature" }));
+        ctx.status = 403;
+        ctx.body = { message: "Invalid signature" };
+        return;
+      }
+
+      // 2. 解析事件
+      const body: LineWebhookBody = typeof ctx.request.body === "string"
+        ? JSON.parse(ctx.request.body)
+        : ctx.request.body;
+
+      if (!body.events || !Array.isArray(body.events)) {
+        ctx.status = 200;
+        ctx.body = { message: "OK" };
+        return;
+      }
+
+      // 3. 处理每个事件
+      for (const event of body.events) {
+        await this.handleEvent(event);
+      }
+
+      ctx.status = 200;
+      ctx.body = { message: "OK" };
+    } catch (error) {
+      this.pluginLogger.error("LINE webhook error:", error);
+      ctx.status = 200;
+      ctx.body = { message: "OK" };
+    }
+  }
+
+  private verifySignature(body: string, signature: string): boolean {
+    const channelSecret = this.$config.channelSecret;
+    const hmac = createHmac("sha256", channelSecret);
+    hmac.update(body, "utf-8");
+    const computedSignature = hmac.digest("base64");
+    return computedSignature === signature;
+  }
+
+  private async handleEvent(event: LineEvent): Promise<void> {
+    switch (event.type) {
+      case "message":
+        if ("message" in event && event.message) {
+          await this.handleMessageEvent(event as any);
+        }
+        break;
+      case "follow":
+        await this.handleFollowEvent(event);
+        break;
+      case "unfollow":
+        this.pluginLogger.debug(formatCompact({
+          op: "unfollow",
+          endpoint: this.$config.name,
+          userId: event.source.userId,
+        }));
+        break;
+      case "join":
+        await this.handleJoinEvent(event);
+        break;
+      case "leave":
+        this.pluginLogger.debug(formatCompact({
+          op: "leave",
+          endpoint: this.$config.name,
+          sourceType: event.source.type,
+          groupId: event.source.groupId,
+          roomId: event.source.roomId,
+        }));
+        break;
+      case "postback":
+        if ("postback" in event) {
+          this.pluginLogger.debug(formatCompact({
+            op: "postback",
+            endpoint: this.$config.name,
+            data: event.postback.data,
+          }));
+        }
+        break;
+      default:
+        this.pluginLogger.debug(formatCompact({
+          op: "unknown_event",
+          endpoint: this.$config.name,
+          type: (event as any).type,
+        }));
+    }
+  }
+
+  private async handleMessageEvent(event: LineEvent & { message: LineMessage }): Promise<void> {
+    const message = this.$formatMessage(event);
+    this.adapter.emit("message.receive", message);
+    this.pluginLogger.debug(formatCompact({
+      op: "recv",
+      endpoint: this.$config.name,
+      channel: message.$channel.type,
+      id: message.$channel.id,
+      len: segment.raw(message.$content).length,
+    }));
+  }
+
+  private async handleFollowEvent(event: LineEvent): Promise<void> {
+    const message = this.$formatMessage(event);
+    this.adapter.emit("message.receive", message);
+    this.pluginLogger.debug(formatCompact({
+      op: "follow",
+      endpoint: this.$config.name,
+      userId: event.source.userId,
+    }));
+  }
+
+  private async handleJoinEvent(event: LineEvent): Promise<void> {
+    const message = this.$formatMessage(event);
+    this.adapter.emit("message.receive", message);
+    this.pluginLogger.debug(formatCompact({
+      op: "join",
+      endpoint: this.$config.name,
+      sourceType: event.source.type,
+      groupId: event.source.groupId,
+      roomId: event.source.roomId,
+    }));
+  }
+
+  // ── 消息格式化 ────────────────────────────────────────────────────
+
+  $formatMessage(event: LineEvent): Message<LineEvent> {
+    const { channelType, channelId } = this.resolveChannel(event.source);
+    const content = this.parseMessageContent(event);
+    const quoteId = Message.quoteIdFromContent(content);
+    Message.alignReplySegments(content, quoteId);
+
+    const userId = event.source.userId || "";
+    const timestamp = event.timestamp || Date.now();
+    const rawText = this.extractRawText(event);
+
+    return Message.from(event, {
+      $id: this.generateMessageId(event),
+      $adapter: "line",
+      $endpoint: this.$config.name,
+      $sender: {
+        id: userId,
+        name: userId,
+      },
+      $channel: {
+        id: channelId,
+        type: channelType,
+      },
+      $content: content,
+      $quote_id: quoteId,
+      $raw: rawText,
+      $timestamp: timestamp,
+      $recall: async () => {
+        // LINE 不支持消息撤回
+        this.pluginLogger.warn("LINE does not support message recall");
+      },
+      $reply: async (
+        content: SendContent,
+        quote?: boolean | string
+      ): Promise<string> => {
+        if (!Array.isArray(content)) content = [content];
+        if (quote) {
+          const replyToMessageId = typeof quote === "boolean"
+            ? ("message" in event && event.message?.id) || ""
+            : quote;
+          content.unshift({ type: "reply", data: { id: replyToMessageId } });
+        }
+        return await this.adapter.sendMessage({
+          context: "line",
+          endpoint: this.$config.name,
+          id: channelId,
+          type: channelType,
+          content: content,
+        });
+      },
+    });
+  }
+
+  private generateMessageId(event: LineEvent): string {
+    if ("message" in event && event.message?.id) {
+      return event.message.id;
+    }
+    return `${event.type}-${event.timestamp}`;
+  }
+
+  private resolveChannel(source: LineEvent["source"]): { channelType: "private" | "group" | "channel"; channelId: string } {
+    switch (source.type) {
+      case "user":
+        return { channelType: "private", channelId: source.userId || "" };
+      case "group":
+        return { channelType: "group", channelId: source.groupId || "" };
+      case "room":
+        return { channelType: "channel", channelId: source.roomId || "" };
+      default:
+        return { channelType: "private", channelId: "" };
+    }
+  }
+
+  private extractRawText(event: LineEvent): string {
+    if ("message" in event && event.message) {
+      const msg = event.message;
+      if (msg.type === "text" && msg.text) return msg.text;
+      if (msg.type === "location" && msg.address) return msg.address;
+      return `[${msg.type}]`;
+    }
+    if (event.type === "follow") return "[follow]";
+    if (event.type === "join") return "[join]";
+    return "";
+  }
+
+  private parseMessageContent(event: LineEvent): MessageSegment[] {
+    const segments: MessageSegment[] = [];
+
+    if ("message" in event && event.message) {
+      const msg = event.message;
+      switch (msg.type) {
+        case "text":
+          if (msg.text) {
+            segments.push({ type: "text", data: { text: msg.text } });
+          }
+          break;
+        case "image":
+          segments.push({
+            type: "image",
+            data: {
+              message_id: msg.id,
+              platform: "line",
+            },
+          });
+          break;
+        case "video":
+          segments.push({
+            type: "video",
+            data: {
+              message_id: msg.id,
+              platform: "line",
+            },
+          });
+          break;
+        case "audio":
+          segments.push({
+            type: "audio",
+            data: {
+              message_id: msg.id,
+              duration: msg.duration || 0,
+              platform: "line",
+            },
+          });
+          break;
+        case "file":
+          segments.push({
+            type: "file",
+            data: {
+              message_id: msg.id,
+              file_name: msg.fileName,
+              file_size: msg.fileSize,
+              platform: "line",
+            },
+          });
+          break;
+        case "location":
+          segments.push({
+            type: "location",
+            data: {
+              title: msg.title,
+              address: msg.address,
+              latitude: msg.latitude,
+              longitude: msg.longitude,
+            },
+          });
+          break;
+        case "sticker":
+          segments.push({
+            type: "sticker",
+            data: {
+              package_id: msg.packageId,
+              sticker_id: msg.stickerId,
+              resource_type: msg.stickerResourceType,
+            },
+          });
+          break;
+        default:
+          segments.push({ type: "text", data: { text: `[unsupported message type]` } });
+      }
+    } else {
+      // 系统事件（follow/unfollow/join/leave）
+      const text = event.type === "follow" ? "[follow event]"
+        : event.type === "join" ? "[join event]"
+        : event.type === "unfollow" ? "[unfollow event]"
+        : event.type === "leave" ? "[leave event]"
+        : `[${event.type} event]`;
+      segments.push({ type: "text", data: { text } });
+    }
+
+    return segments.length > 0 ? segments : [{ type: "text", data: { text: "" } }];
+  }
+
+  // ── 发送消息 ──────────────────────────────────────────────────────
+
+  async $sendMessage(options: SendOptions): Promise<string> {
+    try {
+      const messages = this.buildLineMessages(options.content);
+      if (messages.length === 0) {
+        throw new Error("No valid LINE messages to send");
+      }
+
+      // 优先使用 Reply API（如果存在 replyToken）
+      const replyToken = this.replyTokenCache.get(options.id);
+      if (replyToken) {
+        this.replyTokenCache.delete(options.id);
+        return await this.replyMessage(replyToken, messages);
+      }
+
+      // 使用 Push API
+      return await this.pushMessage(options.id, messages);
+    } catch (error) {
+      this.pluginLogger.error("Failed to send LINE message:", error);
+      throw error;
+    }
+  }
+
+  private replyTokenCache = new Map<string, string>();
+
+  /**
+   * 缓存 replyToken，用于后续发送回复消息
+   */
+  cacheReplyToken(channelId: string, replyToken: string): void {
+    this.replyTokenCache.set(channelId, replyToken);
+  }
+
+  private async replyMessage(replyToken: string, messages: LineReplyMessage[]): Promise<string> {
+    const baseUrl = this.$config.apiBaseUrl || "https://api.line.me";
+    const request: LineReplyRequest = { replyToken, messages };
+    const response = await fetch(`${baseUrl}/v2/bot/message/reply`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "Authorization": `Bearer ${this.$config.channelAccessToken}`,
+      },
+      body: JSON.stringify(request),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`LINE Reply API error ${response.status}: ${errorText}`);
+    }
+
+    // Reply API 不返回 message ID
+    return `reply-${Date.now()}`;
+  }
+
+  private async pushMessage(to: string, messages: LineReplyMessage[]): Promise<string> {
+    const baseUrl = this.$config.apiBaseUrl || "https://api.line.me";
+    const request: LinePushRequest = { to, messages };
+    const response = await fetch(`${baseUrl}/v2/bot/message/push`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "Authorization": `Bearer ${this.$config.channelAccessToken}`,
+      },
+      body: JSON.stringify(request),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`LINE Push API error ${response.status}: ${errorText}`);
+    }
+
+    const result: LineApiResponse = await response.json() as LineApiResponse;
+    return result.sentMessages?.[0]?.id || `push-${Date.now()}`;
+  }
+
+  private buildLineMessages(content: SendContent): LineReplyMessage[] {
+    if (!Array.isArray(content)) content = [content];
+    const messages: LineReplyMessage[] = [];
+
+    for (const item of content) {
+      if (typeof item === "string") {
+        messages.push(this.buildTextMessage(item));
+        continue;
+      }
+
+      const seg = item as MessageSegment;
+      switch (seg.type) {
+        case "text":
+          messages.push(this.buildTextMessage(seg.data.text || ""));
+          break;
+        case "at":
+          // LINE 没有 @ 语法，转为文本
+          if (seg.data.id) {
+            messages.push(this.buildTextMessage(`@${seg.data.name || seg.data.id}`));
+          }
+          break;
+        case "image":
+          if (seg.data.url) {
+            messages.push({
+              type: "image",
+              originalContentUrl: seg.data.url,
+              previewImageUrl: seg.data.url,
+            });
+          }
+          break;
+        case "video":
+          if (seg.data.url) {
+            messages.push({
+              type: "video",
+              originalContentUrl: seg.data.url,
+              previewImageUrl: seg.data.previewUrl || seg.data.url,
+            });
+          }
+          break;
+        case "audio":
+          if (seg.data.url) {
+            messages.push({
+              type: "audio",
+              originalContentUrl: seg.data.url,
+              duration: seg.data.duration || 0,
+            });
+          }
+          break;
+        case "location":
+          messages.push({
+            type: "location",
+            title: seg.data.title || "Location",
+            address: seg.data.address || "",
+            latitude: seg.data.latitude || 0,
+            longitude: seg.data.longitude || 0,
+          });
+          break;
+        case "sticker":
+          messages.push({
+            type: "sticker",
+            packageId: seg.data.package_id || "1",
+            stickerId: seg.data.sticker_id || "1",
+          });
+          break;
+        default:
+          messages.push(this.buildTextMessage(`[${seg.type}]`));
+      }
+    }
+
+    // LINE 单次最多发送 5 条消息
+    return messages.slice(0, 5);
+  }
+
+  private buildTextMessage(text: string): LineReplyMessage {
+    // LINE 消息文本限制 5000 字符
+    const truncated = text.length > 5000 ? text.slice(0, 4997) + "..." : text;
+    return { type: "text", text: truncated };
+  }
+
+  // ── 消息撤回 ──────────────────────────────────────────────────────
+
+  async $recallMessage(_id: string): Promise<void> {
+    // LINE Messaging API 不支持消息撤回
+    throw new Error("LINE Messaging API does not support message recall");
+  }
+}

--- a/plugins/adapters/line/src/endpoint.ts
+++ b/plugins/adapters/line/src/endpoint.ts
@@ -4,8 +4,7 @@
  * 使用 Webhook 模式接收消息，通过 LINE Messaging API 发送消息。
  * HMAC-SHA256 签名验证确保请求来自 LINE 平台。
  */
-import { createHmac } from "node:crypto";
-import { EventEmitter } from "node:events";
+import { createHmac, timingSafeEqual } from "node:crypto";
 import {
   Endpoint,
   Message,
@@ -20,6 +19,10 @@ import { registerFetchRoute, type Router, type RouterContext } from "@zhin.js/ho
 import type {
   LineEndpointConfig,
   LineEvent,
+  LineMessageEvent,
+  LineFollowEvent,
+  LineJoinEvent,
+  LinePostbackEvent,
   LineMessage,
   LineWebhookBody,
   LineReplyMessage,
@@ -29,7 +32,17 @@ import type {
 } from "./types.js";
 import type { LineAdapter } from "./adapter.js";
 
-export class LineEndpoint extends EventEmitter implements Endpoint<LineEndpointConfig, LineEvent> {
+/** Type guard: narrows a LineEvent to a message event */
+function isMessageEvent(e: LineEvent): e is LineMessageEvent {
+  return e.type === "message" && "message" in e && (e as LineMessageEvent).message != null;
+}
+
+/** Type guard: narrows a LineEvent to a postback event */
+function isPostbackEvent(e: LineEvent): e is LinePostbackEvent {
+  return e.type === "postback" && "postback" in e;
+}
+
+export class LineEndpoint implements Endpoint<LineEndpointConfig, LineEvent> {
   $connected: boolean = false;
 
   get pluginLogger() {
@@ -44,9 +57,7 @@ export class LineEndpoint extends EventEmitter implements Endpoint<LineEndpointC
     public adapter: LineAdapter,
     private router: Router,
     public $config: LineEndpointConfig,
-  ) {
-    super();
-  }
+  ) {}
 
   async $connect(): Promise<void> {
     try {
@@ -67,10 +78,11 @@ export class LineEndpoint extends EventEmitter implements Endpoint<LineEndpointC
   async $disconnect(): Promise<void> {
     try {
       this.$connected = false;
+      this.replyTokenCache.clear();
       this.pluginLogger.info(`LINE endpoint ${this.$config.name} disconnected`);
     } catch (error) {
       this.pluginLogger.error("Error disconnecting LINE endpoint:", error);
-      throw error;
+      // L02: Log and swallow instead of re-throwing
     }
   }
 
@@ -86,10 +98,16 @@ export class LineEndpoint extends EventEmitter implements Endpoint<LineEndpointC
         return;
       }
 
-      // 获取原始请求体用于签名验证
-      const rawBody = typeof ctx.request.body === "string"
-        ? ctx.request.body
-        : JSON.stringify(ctx.request.body);
+      // L05: 获取原始请求体用于签名验证
+      // Koa ctx.req 是 Node.js IncomingMessage，koa-body 可能已经消费了流
+      // 因此优先使用已解析的 body 并序列化，记录警告说明可能不精确
+      let rawBody: string;
+      if (typeof ctx.request.body === "string") {
+        rawBody = ctx.request.body;
+      } else {
+        rawBody = JSON.stringify(ctx.request.body);
+        this.pluginLogger.debug("Signature verification using JSON.stringify(body) — may differ from original raw body");
+      }
 
       if (!this.verifySignature(rawBody, signature)) {
         this.pluginLogger.warn(formatCompact({ op: "webhook", ok: false, error: "invalid signature" }));
@@ -123,23 +141,28 @@ export class LineEndpoint extends EventEmitter implements Endpoint<LineEndpointC
     }
   }
 
+  // L07: Use timing-safe comparison for signature
   private verifySignature(body: string, signature: string): boolean {
     const channelSecret = this.$config.channelSecret;
     const hmac = createHmac("sha256", channelSecret);
     hmac.update(body, "utf-8");
     const computedSignature = hmac.digest("base64");
-    return computedSignature === signature;
+    const sigBuf = Buffer.from(signature);
+    const computedBuf = Buffer.from(computedSignature);
+    if (sigBuf.length !== computedBuf.length) return false;
+    return timingSafeEqual(sigBuf, computedBuf);
   }
 
+  // L04: Use type guards instead of "in" checks + `as any` casts
   private async handleEvent(event: LineEvent): Promise<void> {
     switch (event.type) {
       case "message":
-        if ("message" in event && event.message) {
-          await this.handleMessageEvent(event as any);
+        if (isMessageEvent(event)) {
+          await this.handleMessageEvent(event);
         }
         break;
       case "follow":
-        await this.handleFollowEvent(event);
+        await this.handleFollowEvent(event as LineFollowEvent);
         break;
       case "unfollow":
         this.pluginLogger.debug(formatCompact({
@@ -149,7 +172,7 @@ export class LineEndpoint extends EventEmitter implements Endpoint<LineEndpointC
         }));
         break;
       case "join":
-        await this.handleJoinEvent(event);
+        await this.handleJoinEvent(event as LineJoinEvent);
         break;
       case "leave":
         this.pluginLogger.debug(formatCompact({
@@ -161,7 +184,7 @@ export class LineEndpoint extends EventEmitter implements Endpoint<LineEndpointC
         }));
         break;
       case "postback":
-        if ("postback" in event) {
+        if (isPostbackEvent(event)) {
           this.pluginLogger.debug(formatCompact({
             op: "postback",
             endpoint: this.$config.name,
@@ -173,12 +196,16 @@ export class LineEndpoint extends EventEmitter implements Endpoint<LineEndpointC
         this.pluginLogger.debug(formatCompact({
           op: "unknown_event",
           endpoint: this.$config.name,
-          type: (event as any).type,
+          type: (event as LineEvent).type,
         }));
     }
   }
 
-  private async handleMessageEvent(event: LineEvent & { message: LineMessage }): Promise<void> {
+  // L01: Cache replyToken from webhook events before emitting
+  private async handleMessageEvent(event: LineMessageEvent): Promise<void> {
+    const { channelId } = this.resolveChannel(event.source);
+    this.cacheReplyToken(channelId, event.replyToken);
+
     const message = this.$formatMessage(event);
     this.adapter.emit("message.receive", message);
     this.pluginLogger.debug(formatCompact({
@@ -190,7 +217,10 @@ export class LineEndpoint extends EventEmitter implements Endpoint<LineEndpointC
     }));
   }
 
-  private async handleFollowEvent(event: LineEvent): Promise<void> {
+  private async handleFollowEvent(event: LineFollowEvent): Promise<void> {
+    const { channelId } = this.resolveChannel(event.source);
+    this.cacheReplyToken(channelId, event.replyToken);
+
     const message = this.$formatMessage(event);
     this.adapter.emit("message.receive", message);
     this.pluginLogger.debug(formatCompact({
@@ -200,7 +230,10 @@ export class LineEndpoint extends EventEmitter implements Endpoint<LineEndpointC
     }));
   }
 
-  private async handleJoinEvent(event: LineEvent): Promise<void> {
+  private async handleJoinEvent(event: LineJoinEvent): Promise<void> {
+    const { channelId } = this.resolveChannel(event.source);
+    this.cacheReplyToken(channelId, event.replyToken);
+
     const message = this.$formatMessage(event);
     this.adapter.emit("message.receive", message);
     this.pluginLogger.debug(formatCompact({
@@ -251,7 +284,7 @@ export class LineEndpoint extends EventEmitter implements Endpoint<LineEndpointC
         if (!Array.isArray(content)) content = [content];
         if (quote) {
           const replyToMessageId = typeof quote === "boolean"
-            ? ("message" in event && event.message?.id) || ""
+            ? (isMessageEvent(event) && event.message?.id) || ""
             : quote;
           content.unshift({ type: "reply", data: { id: replyToMessageId } });
         }
@@ -267,7 +300,7 @@ export class LineEndpoint extends EventEmitter implements Endpoint<LineEndpointC
   }
 
   private generateMessageId(event: LineEvent): string {
-    if ("message" in event && event.message?.id) {
+    if (isMessageEvent(event) && event.message?.id) {
       return event.message.id;
     }
     return `${event.type}-${event.timestamp}`;
@@ -287,7 +320,7 @@ export class LineEndpoint extends EventEmitter implements Endpoint<LineEndpointC
   }
 
   private extractRawText(event: LineEvent): string {
-    if ("message" in event && event.message) {
+    if (isMessageEvent(event)) {
       const msg = event.message;
       if (msg.type === "text" && msg.text) return msg.text;
       if (msg.type === "location" && msg.address) return msg.address;
@@ -301,7 +334,7 @@ export class LineEndpoint extends EventEmitter implements Endpoint<LineEndpointC
   private parseMessageContent(event: LineEvent): MessageSegment[] {
     const segments: MessageSegment[] = [];
 
-    if ("message" in event && event.message) {
+    if (isMessageEvent(event)) {
       const msg = event.message;
       switch (msg.type) {
         case "text":
@@ -401,6 +434,13 @@ export class LineEndpoint extends EventEmitter implements Endpoint<LineEndpointC
         return await this.replyMessage(replyToken, messages);
       }
 
+      // L06: Validate Push API `to` field
+      if (!/^[UGR]/.test(options.id)) {
+        throw new Error(
+          `Invalid LINE recipient ID "${options.id}": must start with U (user), G (group), or R (room)`
+        );
+      }
+
       // 使用 Push API
       return await this.pushMessage(options.id, messages);
     } catch (error) {
@@ -418,6 +458,7 @@ export class LineEndpoint extends EventEmitter implements Endpoint<LineEndpointC
     this.replyTokenCache.set(channelId, replyToken);
   }
 
+  // L15: Parse Reply API response for message ID
   private async replyMessage(replyToken: string, messages: LineReplyMessage[]): Promise<string> {
     const baseUrl = this.$config.apiBaseUrl || "https://api.line.me";
     const request: LineReplyRequest = { replyToken, messages };
@@ -435,8 +476,9 @@ export class LineEndpoint extends EventEmitter implements Endpoint<LineEndpointC
       throw new Error(`LINE Reply API error ${response.status}: ${errorText}`);
     }
 
-    // Reply API 不返回 message ID
-    return `reply-${Date.now()}`;
+    // Reply API now returns sentMessages in the response body
+    const result: LineApiResponse = await response.json() as LineApiResponse;
+    return result.sentMessages?.[0]?.id || `reply-${Date.now()}`;
   }
 
   private async pushMessage(to: string, messages: LineReplyMessage[]): Promise<string> {
@@ -529,11 +571,24 @@ export class LineEndpoint extends EventEmitter implements Endpoint<LineEndpointC
       }
     }
 
+    // L14: Log warning when messages are sliced to 5 (LINE limit)
+    if (messages.length > 5) {
+      this.pluginLogger.warn(
+        `LINE messages truncated from ${messages.length} to 5 (platform limit)`
+      );
+    }
+
     // LINE 单次最多发送 5 条消息
     return messages.slice(0, 5);
   }
 
   private buildTextMessage(text: string): LineReplyMessage {
+    // L13: Log warning on text truncation
+    if (text.length > 5000) {
+      this.pluginLogger.warn(
+        `LINE text message truncated from ${text.length} to 5000 characters`
+      );
+    }
     // LINE 消息文本限制 5000 字符
     const truncated = text.length > 5000 ? text.slice(0, 4997) + "..." : text;
     return { type: "text", text: truncated };
@@ -541,8 +596,10 @@ export class LineEndpoint extends EventEmitter implements Endpoint<LineEndpointC
 
   // ── 消息撤回 ──────────────────────────────────────────────────────
 
+  // L16: Log warning and return gracefully (matching WeCom/DingTalk pattern)
   async $recallMessage(_id: string): Promise<void> {
-    // LINE Messaging API 不支持消息撤回
-    throw new Error("LINE Messaging API does not support message recall");
+    this.pluginLogger.warn(
+      formatCompact({ op: "recall", ok: false, error: "LINE Messaging API does not support message recall" })
+    );
   }
 }

--- a/plugins/adapters/line/src/index.ts
+++ b/plugins/adapters/line/src/index.ts
@@ -1,0 +1,38 @@
+/**
+ * LINE Messaging API 适配器入口：类型扩展、导出、注册
+ */
+import { usePlugin, type Plugin } from 'zhin.js';
+import { LineAdapter } from './adapter.js';
+
+declare module 'zhin.js' {
+  namespace Plugin {
+    interface Contexts {
+      router: import('@zhin.js/host-router').Router;
+    }
+  }
+  interface Adapters {
+    line: LineAdapter;
+  }
+}
+
+export * from './types.js';
+export { LineEndpoint } from './endpoint.js';
+export { LineAdapter } from './adapter.js';
+
+const plugin = usePlugin();
+const { provide, useContext } = plugin;
+
+useContext('router', (router: any) => {
+  provide({
+    name: 'line',
+    description: 'LINE Messaging API Endpoint Adapter',
+    mounted: async (p: Plugin) => {
+      const adapter = new LineAdapter(p, router);
+      await adapter.start();
+      return adapter;
+    },
+    dispose: async (adapter: LineAdapter) => {
+      await adapter.stop();
+    },
+  });
+});

--- a/plugins/adapters/line/src/index.ts
+++ b/plugins/adapters/line/src/index.ts
@@ -36,3 +36,65 @@ useContext('router', (router: any) => {
     },
   });
 });
+
+// L11: Register LINE-specific tools
+useContext('tool', 'line', (toolService: any, lineAdapter: LineAdapter) => {
+  const accessToken = lineAdapter.endpoints.values().next().value?.$config?.channelAccessToken;
+  const apiBaseUrl = lineAdapter.endpoints.values().next().value?.$config?.apiBaseUrl || 'https://api.line.me';
+
+  const disposers: (() => void)[] = [];
+
+  disposers.push(toolService.addTool({
+    name: 'line_get_profile',
+    description: 'Get LINE user profile by userId',
+    parameters: {
+      type: 'object',
+      properties: {
+        userId: { type: 'string', description: 'LINE user ID (starts with U)' },
+      },
+      required: ['userId'],
+    },
+    execute: async ({ userId }: { userId: string }) => {
+      if (!userId.startsWith('U')) {
+        throw new Error(`Invalid userId "${userId}": must start with U`);
+      }
+      const response = await fetch(`${apiBaseUrl}/v2/profile/${userId}`, {
+        headers: { 'Authorization': `Bearer ${accessToken}` },
+      });
+      if (!response.ok) {
+        const errorText = await response.text();
+        throw new Error(`LINE Profile API error ${response.status}: ${errorText}`);
+      }
+      return await response.json();
+    },
+  }));
+
+  disposers.push(toolService.addTool({
+    name: 'line_get_group_members',
+    description: 'Get LINE group member IDs',
+    parameters: {
+      type: 'object',
+      properties: {
+        groupId: { type: 'string', description: 'LINE group ID (starts with G)' },
+      },
+      required: ['groupId'],
+    },
+    execute: async ({ groupId }: { groupId: string }) => {
+      if (!groupId.startsWith('G')) {
+        throw new Error(`Invalid groupId "${groupId}": must start with G`);
+      }
+      const response = await fetch(`${apiBaseUrl}/v2/bot/group/${groupId}/members/ids`, {
+        headers: { 'Authorization': `Bearer ${accessToken}` },
+      });
+      if (!response.ok) {
+        const errorText = await response.text();
+        throw new Error(`LINE Group Members API error ${response.status}: ${errorText}`);
+      }
+      return await response.json();
+    },
+  }));
+
+  return () => {
+    for (const disposer of disposers) disposer();
+  };
+});

--- a/plugins/adapters/line/src/types.ts
+++ b/plugins/adapters/line/src/types.ts
@@ -1,0 +1,130 @@
+/**
+ * LINE Messaging API 类型定义
+ */
+
+export interface LineEndpointConfig {
+  context: 'line'
+  name: string
+  channelSecret: string
+  channelAccessToken: string
+  webhookPath?: string
+  apiBaseUrl?: string
+}
+
+export interface LineUser {
+  userId: string
+  displayName?: string
+  pictureUrl?: string
+  statusMessage?: string
+}
+
+export interface LineMessageEvent {
+  type: 'message'
+  replyToken: string
+  source: LineSource
+  timestamp: number
+  message: LineMessage
+}
+
+export interface LineFollowEvent {
+  type: 'follow'
+  replyToken: string
+  source: LineSource
+  timestamp: number
+}
+
+export interface LineUnfollowEvent {
+  type: 'unfollow'
+  source: LineSource
+  timestamp: number
+}
+
+export interface LineJoinEvent {
+  type: 'join'
+  replyToken: string
+  source: LineSource
+  timestamp: number
+}
+
+export interface LineLeaveEvent {
+  type: 'leave'
+  source: LineSource
+  timestamp: number
+}
+
+export interface LinePostbackEvent {
+  type: 'postback'
+  replyToken: string
+  source: LineSource
+  timestamp: number
+  postback: {
+    data: string
+    params?: Record<string, string>
+  }
+}
+
+export type LineEvent =
+  | LineMessageEvent
+  | LineFollowEvent
+  | LineUnfollowEvent
+  | LineJoinEvent
+  | LineLeaveEvent
+  | LinePostbackEvent
+
+export interface LineSource {
+  type: 'user' | 'group' | 'room'
+  userId?: string
+  groupId?: string
+  roomId?: string
+}
+
+export interface LineMessage {
+  id: string
+  type: 'text' | 'image' | 'video' | 'audio' | 'file' | 'location' | 'sticker'
+  text?: string
+  fileName?: string
+  fileSize?: number
+  title?: string
+  address?: string
+  latitude?: number
+  longitude?: number
+  packageId?: string
+  stickerId?: string
+  stickerResourceType?: string
+  duration?: number
+}
+
+export interface LineWebhookBody {
+  destination: string
+  events: LineEvent[]
+}
+
+export interface LineReplyMessage {
+  type: 'text' | 'image' | 'video' | 'audio' | 'location' | 'sticker' | 'flex'
+  text?: string
+  originalContentUrl?: string
+  previewImageUrl?: string
+  packageId?: string
+  stickerId?: string
+  title?: string
+  address?: string
+  latitude?: number
+  longitude?: number
+  duration?: number
+  altText?: string
+  contents?: Record<string, unknown>
+}
+
+export interface LineReplyRequest {
+  replyToken: string
+  messages: LineReplyMessage[]
+}
+
+export interface LinePushRequest {
+  to: string
+  messages: LineReplyMessage[]
+}
+
+export interface LineApiResponse {
+  sentMessages?: Array<{ id: string; quoteToken?: string }>
+}

--- a/plugins/adapters/line/tests/integration.test.ts
+++ b/plugins/adapters/line/tests/integration.test.ts
@@ -1,0 +1,314 @@
+/**
+ * LINE Messaging API 适配器集成测试
+ *
+ * 策略：Mock 掉 LINE API 层（$connect/$disconnect/$sendMessage），
+ * 测试 Endpoint 接口合规性、消息格式化、发送/接收链路、生命周期的完整性。
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { Plugin, type SendOptions } from 'zhin.js';
+import { createAdapterTestSuite } from '../../../../packages/im/core/tests/adapter-harness.js';
+import { LineAdapter } from '../src/adapter.js';
+import { LineEndpoint } from '../src/endpoint.js';
+import type { LineEndpointConfig, LineEvent } from '../src/types.js';
+import type { Router } from '@zhin.js/host-router/router';
+
+const FIXED_TS = 1700000000000;
+
+// ── Mock Router ──
+
+function createMockRouter(): Router {
+  return {
+    post: vi.fn().mockReturnThis(),
+    get: vi.fn().mockReturnThis(),
+    put: vi.fn().mockReturnThis(),
+    delete: vi.fn().mockReturnThis(),
+  } as unknown as Router;
+}
+
+// ── Mock Endpoint ──
+
+class MockLineEndpoint extends LineEndpoint {
+  sendMock = vi.fn();
+
+  constructor(adapter: LineAdapter, router: Router, config: LineEndpointConfig) {
+    super(adapter, router, config);
+  }
+
+  async $connect(): Promise<void> {
+    this.$connected = true;
+  }
+
+  async $disconnect(): Promise<void> {
+    this.$connected = false;
+  }
+
+  async $sendMessage(options: SendOptions): Promise<string> {
+    this.sendMock(options);
+    return `line-msg-${Date.now()}`;
+  }
+
+  async $recallMessage(_id: string): Promise<void> {}
+}
+
+// ── Mock Adapter ──
+
+class MockLineAdapter extends LineAdapter {
+  #mockRouter: Router;
+  constructor(plugin: Plugin) {
+    const router = createMockRouter();
+    super(plugin, router);
+    this.#mockRouter = router;
+  }
+
+  createEndpoint(config: LineEndpointConfig): MockLineEndpoint {
+    return new MockLineEndpoint(this, this.#mockRouter, {
+      context: 'line',
+      name: config.name || 'test-endpoint',
+      channelSecret: 'test-channel-secret',
+      channelAccessToken: 'test-access-token',
+      ...config,
+    });
+  }
+}
+
+// ── 原始消息工厂 ──
+
+function createLineTextEvent(overrides: Partial<LineEvent> = {}): LineEvent {
+  return {
+    type: 'message',
+    message: {
+      id: 'msg-001',
+      type: 'text',
+      text: 'Hello LINE',
+    },
+    source: {
+      type: 'user',
+      userId: 'U12345',
+    },
+    replyToken: 'reply-token-001',
+    timestamp: FIXED_TS,
+    ...overrides,
+  };
+}
+
+function createLineGroupEvent(overrides: Partial<LineEvent> = {}): LineEvent {
+  return {
+    type: 'message',
+    message: {
+      id: 'msg-002',
+      type: 'text',
+      text: 'group message',
+    },
+    source: {
+      type: 'group',
+      userId: 'U12345',
+      groupId: 'G67890',
+    },
+    replyToken: 'reply-token-002',
+    timestamp: FIXED_TS,
+    ...overrides,
+  };
+}
+
+// ── Harness 标准测试套件 ──
+
+createAdapterTestSuite<MockLineAdapter, LineEvent>({
+  adapterName: 'line',
+  endpointId: 'test-endpoint',
+  createAdapter: (plugin) => {
+    const adapter = new MockLineAdapter(plugin);
+    (adapter as any).config = [{ name: 'test-endpoint', context: 'line', channelSecret: 'test', channelAccessToken: 'test' }];
+    return adapter;
+  },
+  createRawEvent: () => createLineTextEvent(),
+});
+
+// ── LINE 适配器特定测试 ──
+
+describe('LINE 适配器特定测试', () => {
+  let plugin: Plugin;
+  let adapter: MockLineAdapter;
+  let endpoint: MockLineEndpoint;
+
+  beforeEach(async () => {
+    plugin = new Plugin('/test/line-integration.ts');
+    adapter = new MockLineAdapter(plugin);
+    (adapter as any).config = [{ name: 'test-endpoint', context: 'line', channelSecret: 'test', channelAccessToken: 'test' }];
+    await adapter.start();
+    endpoint = adapter.endpoints.get('test-endpoint') as MockLineEndpoint;
+  });
+
+  afterEach(async () => {
+    try { await adapter.stop(); } catch { /* ignore */ }
+  });
+
+  describe('Endpoint 接口合规性', () => {
+    it('$id 应为配置的 name', () => {
+      expect(endpoint.$id).toBe('test-endpoint');
+    });
+
+    it('$connected 启动后应为 true', () => {
+      expect(endpoint.$connected).toBe(true);
+    });
+
+    it('应实现所有 Endpoint 接口方法', () => {
+      expect(typeof endpoint.$formatMessage).toBe('function');
+      expect(typeof endpoint.$connect).toBe('function');
+      expect(typeof endpoint.$disconnect).toBe('function');
+      expect(typeof endpoint.$sendMessage).toBe('function');
+      expect(typeof endpoint.$recallMessage).toBe('function');
+    });
+  });
+
+  describe('生命周期', () => {
+    it('start() 应注册 endpoint', () => {
+      expect(adapter.endpoints.has('test-endpoint')).toBe(true);
+    });
+
+    it('stop() 应清空 endpoints', async () => {
+      await adapter.stop();
+      expect(adapter.endpoints.size).toBe(0);
+    });
+
+    it('stop() 后 endpoint 应 disconnected', async () => {
+      await adapter.stop();
+      expect(endpoint.$connected).toBe(false);
+    });
+  });
+
+  describe('$formatMessage 消息格式化', () => {
+    it('私聊消息应正确格式化', () => {
+      const raw = createLineTextEvent();
+      const msg = endpoint.$formatMessage(raw);
+
+      expect(msg.$id).toBe('msg-001');
+      expect(msg.$adapter).toBe('line');
+      expect(msg.$endpoint).toBe('test-endpoint');
+      expect(msg.$sender.id).toBe('U12345');
+      expect(msg.$channel.type).toBe('private');
+      expect(msg.$channel.id).toBe('U12345');
+      expect(msg.$raw).toBe('Hello LINE');
+      expect(typeof msg.$reply).toBe('function');
+      expect(typeof msg.$recall).toBe('function');
+    });
+
+    it('群消息应格式化为 group', () => {
+      const raw = createLineGroupEvent();
+      const msg = endpoint.$formatMessage(raw);
+      expect(msg.$channel.type).toBe('group');
+      expect(msg.$channel.id).toBe('G67890');
+    });
+
+    it('$timestamp 应为事件时间戳', () => {
+      const raw = createLineTextEvent();
+      const msg = endpoint.$formatMessage(raw);
+      expect(msg.$timestamp).toBe(FIXED_TS);
+    });
+
+    it('follow 事件应格式化为系统消息', () => {
+      const raw: LineEvent = {
+        type: 'follow',
+        source: { type: 'user', userId: 'U99999' },
+        replyToken: 'rp-follow',
+        timestamp: FIXED_TS,
+      };
+      const msg = endpoint.$formatMessage(raw);
+      expect(msg.$channel.type).toBe('private');
+      expect(msg.$raw).toBe('[follow]');
+    });
+
+    it('join 事件应格式化为系统消息', () => {
+      const raw: LineEvent = {
+        type: 'join',
+        source: { type: 'group', groupId: 'G11111', userId: 'U22222' },
+        replyToken: 'rp-join',
+        timestamp: FIXED_TS,
+      };
+      const msg = endpoint.$formatMessage(raw);
+      expect(msg.$channel.type).toBe('group');
+      expect(msg.$raw).toBe('[join]');
+    });
+
+    it('image 消息应返回 image segment', () => {
+      const raw: LineEvent = {
+        type: 'message',
+        message: { id: 'img-001', type: 'image' },
+        source: { type: 'user', userId: 'U12345' },
+        timestamp: FIXED_TS,
+      };
+      const msg = endpoint.$formatMessage(raw);
+      expect(msg.$content[0].type).toBe('image');
+    });
+
+    it('sticker 消息应返回 sticker segment', () => {
+      const raw: LineEvent = {
+        type: 'message',
+        message: { id: 'stk-001', type: 'sticker', packageId: '1', stickerId: '100' },
+        source: { type: 'user', userId: 'U12345' },
+        timestamp: FIXED_TS,
+      };
+      const msg = endpoint.$formatMessage(raw);
+      expect(msg.$content[0].type).toBe('sticker');
+      expect(msg.$content[0].data.package_id).toBe('1');
+    });
+  });
+
+  describe('消息发送', () => {
+    it('sendMessage 应返回字符串 ID', async () => {
+      const result = await adapter.sendMessage({
+        context: 'line',
+        endpoint: 'test-endpoint',
+        id: 'U12345',
+        type: 'private',
+        content: [{ type: 'text', data: { text: 'hello' } }],
+      });
+      expect(typeof result).toBe('string');
+      expect(result.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('消息接收链路', () => {
+    it('emit message.receive 应触发 plugin.dispatch', async () => {
+      const dispatchSpy = vi.spyOn(plugin, 'dispatch');
+      const raw = createLineTextEvent();
+      const msg = endpoint.$formatMessage(raw);
+
+      adapter.emit('message.receive', msg);
+      await new Promise(r => setTimeout(r, 50));
+
+      expect(dispatchSpy).toHaveBeenCalledWith(
+        'message.receive',
+        expect.objectContaining({ $adapter: 'line' }),
+      );
+    });
+  });
+
+  describe('$reply 路由', () => {
+    it('$reply 应走 adapter.sendMessage', async () => {
+      const sendMessageSpy = vi.spyOn(adapter, 'sendMessage');
+      const raw = createLineTextEvent();
+      const msg = endpoint.$formatMessage(raw);
+
+      sendMessageSpy.mockResolvedValue('reply-id');
+      const result = await msg.$reply('hi');
+      expect(sendMessageSpy).toHaveBeenCalledTimes(1);
+      expect(result).toBe('reply-id');
+    });
+  });
+
+  describe('签名验证', () => {
+    it('verifySignature 应验证正确的 HMAC-SHA256 签名', () => {
+      const { createHmac } = require('node:crypto');
+      // endpoint.$config.channelSecret is 'test' (set via adapter config spread)
+      const secret = endpoint.$config.channelSecret;
+      const body = '{"events":[]}';
+      const hmac = createHmac('sha256', secret);
+      hmac.update(body);
+      const validSignature = hmac.digest('base64');
+
+      // 访问 private method via cast
+      expect((endpoint as any).verifySignature(body, validSignature)).toBe(true);
+      expect((endpoint as any).verifySignature(body, 'invalid-signature')).toBe(false);
+    });
+  });
+});

--- a/plugins/adapters/line/tests/integration.test.ts
+++ b/plugins/adapters/line/tests/integration.test.ts
@@ -5,6 +5,7 @@
  * 测试 Endpoint 接口合规性、消息格式化、发送/接收链路、生命周期的完整性。
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { createHmac } from 'node:crypto';
 import { Plugin, type SendOptions } from 'zhin.js';
 import { createAdapterTestSuite } from '../../../../packages/im/core/tests/adapter-harness.js';
 import { LineAdapter } from '../src/adapter.js';
@@ -298,7 +299,6 @@ describe('LINE 适配器特定测试', () => {
 
   describe('签名验证', () => {
     it('verifySignature 应验证正确的 HMAC-SHA256 签名', () => {
-      const { createHmac } = require('node:crypto');
       // endpoint.$config.channelSecret is 'test' (set via adapter config spread)
       const secret = endpoint.$config.channelSecret;
       const body = '{"events":[]}';

--- a/plugins/adapters/line/tsconfig.json
+++ b/plugins/adapters/line/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "types": ["node"],
+    "outDir": "./lib",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["lib", "node_modules"]
+}

--- a/plugins/adapters/wecom/README.md
+++ b/plugins/adapters/wecom/README.md
@@ -1,0 +1,263 @@
+# @zhin.js/adapter-wecom
+
+Zhin.js 企业微信（WeCom）适配器，支持企业内部应用机器人开发。
+
+## 安装
+
+```bash
+pnpm add @zhin.js/adapter-wecom
+```
+
+## 前置条件
+
+### 企业微信管理后台配置
+
+1. **登录企业微信管理后台**
+   - 访问 [企业微信管理后台](https://work.weixin.qq.com/wework_admin/frame)
+   - 使用管理员账号登录
+
+2. **创建应用**
+   - 进入「应用管理」→「自建」
+   - 点击「创建应用」
+   - 填写应用名称、上传 Logo、选择可见范围
+
+3. **获取应用凭证**
+   - 在应用详情页面获取：
+     - **CorpId**（企业 ID）：在「我的企业」→「企业信息」中查看
+     - **AgentId**（应用 AgentId）：在应用详情页面
+     - **Secret**（应用 Secret）：在应用详情页面
+
+4. **配置接收消息**
+   - 在应用详情页面，进入「接收消息」设置
+   - 设置 **URL**：`https://yourdomain.com/wecom/callback`
+   - 设置 **Token**：自定义字符串（用于签名验证）
+   - 设置 **EncodingAESKey**：点击「随机获取」（用于消息加解密）
+   - 点击「保存」，企业微信会发送验证请求
+
+5. **配置权限**
+   - 在「API 权限」中申请所需权限：
+     - `通讯录只读权限` - 读取组织架构和用户信息
+     - `应用消息发送权限` - 向用户发送消息
+     - 其他业务需要的权限
+
+## 配置
+
+### 基础配置（zhin.config.yml）
+
+```yaml
+endpoints:
+  - name: wecom-bot
+    context: wecom
+    corpId: "ww1234567890abcdef"
+    agentId: "your-agent-secret"
+    token: "your-verify-token"
+    encodingAESKey: "your-43-char-encoding-aes-key"
+    webhookPath: "/wecom/callback"
+
+plugins:
+  - "@zhin.js/host-router"
+  - "@zhin.js/adapter-wecom"
+```
+
+### 完整配置
+
+```yaml
+endpoints:
+  - name: wecom-bot
+    context: wecom
+    corpId: "ww1234567890abcdef"
+    agentId: "your-agent-secret"
+    token: "your-verify-token"
+    encodingAESKey: "your-43-char-encoding-aes-key"
+    webhookPath: "/wecom/callback"
+    apiBaseUrl: "https://qyapi.weixin.qq.com"  # 可选，默认值
+```
+
+### 配置参数说明
+
+| 参数 | 必需 | 说明 |
+|------|------|------|
+| `corpId` | 是 | 企业 ID，在管理后台「我的企业」查看 |
+| `agentId` | 是 | 应用 Secret（注意：不是 AgentId），在应用详情页获取 |
+| `token` | 是 | 用于签名验证，需与管理后台「接收消息」设置中的 Token 一致 |
+| `encodingAESKey` | 是 | 用于消息加解密，需与管理后台一致（43 字符） |
+| `webhookPath` | 否 | Webhook 回调路径，默认 `/wecom/callback` |
+| `apiBaseUrl` | 否 | 企业微信 API 地址，默认 `https://qyapi.weixin.qq.com` |
+
+### 环境变量推荐
+
+```yaml
+endpoints:
+  - name: wecom-bot
+    context: wecom
+    corpId: "${WECOM_CORP_ID}"
+    agentId: "${WECOM_AGENT_SECRET}"
+    token: "${WECOM_TOKEN}"
+    encodingAESKey: "${WECOM_AES_KEY}"
+```
+
+## 使用示例
+
+### 接收和发送消息
+
+```typescript
+import { usePlugin, MessageCommand } from 'zhin.js'
+
+const { addCommand, logger } = usePlugin()
+
+// 定义命令
+addCommand(new MessageCommand('hello <name:text>')
+  .action(async (message, result) => {
+    logger.info(`收到问候: ${result.params.name}`)
+    return `你好，${result.params.name}！欢迎使用企业微信机器人。`
+  })
+)
+
+// 监听所有消息
+import { onMessage } from 'zhin.js'
+
+onMessage(async (message) => {
+  logger.info(`收到消息：${JSON.stringify(message.$content)}`)
+  logger.info(`发送者：${message.$sender.name}`)
+  logger.info(`会话类型：${message.$channel.type}`)
+})
+```
+
+### 发送富文本消息
+
+```typescript
+addCommand(new MessageCommand('info')
+  .action(async (message) => {
+    return [
+      {
+        type: 'markdown',
+        data: {
+          content: `# 系统信息\n\n- 服务器: 运行正常\n- 版本: v1.0.0\n- 状态: 在线`
+        }
+      }
+    ]
+  })
+)
+```
+
+## 消息类型支持
+
+### 接收消息类型
+
+| 类型 | 状态 | 说明 |
+|------|------|------|
+| 文本消息 (`text`) | 支持 | 普通文本 |
+| 图片消息 (`image`) | 支持 | 图片文件 |
+| 语音消息 (`voice`) | 支持 | 含语音识别结果 |
+| 视频消息 (`video`) | 支持 | 视频文件 |
+| 位置消息 (`location`) | 支持 | 地理位置 |
+| 链接消息 (`link`) | 支持 | 链接卡片 |
+| 事件消息 (`event`) | 支持 | 关注/取消关注等 |
+
+### 发送消息类型
+
+| 类型 | 状态 | 说明 |
+|------|------|------|
+| 文本消息 | 支持 | 支持 @ 提醒 |
+| 图片消息 | 支持 | 需要 media_id |
+| Markdown 消息 | 支持 | 企业微信原生 Markdown |
+| 图文消息 | 支持 | news 类型 |
+| 撤回消息 | 不支持 | 企业微信机器人不支持撤回 |
+
+## 安全说明
+
+### 消息加解密
+
+企业微信使用 AES-256-CBC 加密算法对回调消息进行加密：
+
+- **签名验证**：SHA1 排序拼接 `[token, timestamp, nonce, encrypt]`
+- **解密流程**：
+  1. Base64 解码加密消息
+  2. AES-256-CBC 解密（Key: `encodingAESKey` + `=` 的 Base64 解码，IV: Key 的前 16 字节）
+  3. PKCS7 去填充
+  4. 提取：16 字节随机数 + 4 字节消息长度 + 消息体 + CorpId
+
+适配器自动处理所有加解密，无需手动处理。
+
+### Token 管理
+
+适配器会自动管理 access_token：
+- 首次连接时获取 token
+- Token 过期前 5 分钟自动刷新
+- 所有 API 请求自动携带有效 token
+
+## API 方法
+
+### 获取用户信息
+
+```typescript
+const endpoint = app.adapters.get('wecom')?.endpoints.get('wecom-bot')
+if (endpoint) {
+  const userInfo = await endpoint.getUserInfo('user-id')
+  console.log(userInfo)
+}
+```
+
+### 获取部门用户列表
+
+```typescript
+const users = await endpoint.getDepartmentUsers(1) // 部门 ID
+console.log(users)
+```
+
+### 获取部门列表
+
+```typescript
+const departments = await endpoint.getDepartmentList(1) // 父部门 ID
+console.log(departments)
+```
+
+### 发送文本消息
+
+```typescript
+const success = await endpoint.sendTextMessage('user-id', '这是一条测试消息')
+```
+
+## 故障排查
+
+### Q: Webhook 验证失败？
+
+A: 检查以下几点：
+1. `token` 是否与企业微信管理后台设置的 Token 一致
+2. `encodingAESKey` 是否与管理后台一致（43 字符）
+3. 服务器是否可从公网访问
+4. 服务器是否返回了正确的验证响应（解密后的 echostr）
+
+### Q: 收不到消息回调？
+
+A: 可能的原因：
+1. 应用未启用「接收消息」功能
+2. Webhook URL 配置错误或不可达
+3. 应用可见范围未包含发送消息的用户
+4. 服务器日志中是否有签名验证失败的警告
+
+### Q: 发送消息失败？
+
+A: 可能的原因：
+1. `agentId`（应用 Secret）配置错误
+2. access_token 获取失败（检查 CorpId 和 Secret）
+3. 接收者不在应用可见范围内
+4. 应用未开通消息发送权限
+
+### Q: Token 刷新失败？
+
+A: 检查：
+1. CorpId 是否正确
+2. agentId 是否是应用 Secret（不是应用的 AgentId 数字）
+3. 企业微信 API 是否可访问
+
+## 相关链接
+
+- [企业微信开发文档](https://developer.work.weixin.qq.com/document/)
+- [企业微信接收消息](https://developer.work.weixin.qq.com/document/path/90930)
+- [企业微信发送应用消息](https://developer.work.weixin.qq.com/document/path/90236)
+- [Zhin.js 官方文档](https://github.com/zhinjs/zhin)
+
+## 许可证
+
+MIT License

--- a/plugins/adapters/wecom/README.md
+++ b/plugins/adapters/wecom/README.md
@@ -49,7 +49,7 @@ endpoints:
   - name: wecom-bot
     context: wecom
     corpId: "ww1234567890abcdef"
-    agentId: "your-agent-secret"
+    agentSecret: "your-agent-secret"
     token: "your-verify-token"
     encodingAESKey: "your-43-char-encoding-aes-key"
     webhookPath: "/wecom/callback"
@@ -66,7 +66,7 @@ endpoints:
   - name: wecom-bot
     context: wecom
     corpId: "ww1234567890abcdef"
-    agentId: "your-agent-secret"
+    agentSecret: "your-agent-secret"
     token: "your-verify-token"
     encodingAESKey: "your-43-char-encoding-aes-key"
     webhookPath: "/wecom/callback"
@@ -78,7 +78,7 @@ endpoints:
 | 参数 | 必需 | 说明 |
 |------|------|------|
 | `corpId` | 是 | 企业 ID，在管理后台「我的企业」查看 |
-| `agentId` | 是 | 应用 Secret（注意：不是 AgentId），在应用详情页获取 |
+| `agentSecret` | 是 | 应用 Secret，在应用详情页获取 |
 | `token` | 是 | 用于签名验证，需与管理后台「接收消息」设置中的 Token 一致 |
 | `encodingAESKey` | 是 | 用于消息加解密，需与管理后台一致（43 字符） |
 | `webhookPath` | 否 | Webhook 回调路径，默认 `/wecom/callback` |
@@ -91,7 +91,7 @@ endpoints:
   - name: wecom-bot
     context: wecom
     corpId: "${WECOM_CORP_ID}"
-    agentId: "${WECOM_AGENT_SECRET}"
+    agentSecret: "${WECOM_AGENT_SECRET}"
     token: "${WECOM_TOKEN}"
     encodingAESKey: "${WECOM_AES_KEY}"
 ```
@@ -239,7 +239,7 @@ A: 可能的原因：
 ### Q: 发送消息失败？
 
 A: 可能的原因：
-1. `agentId`（应用 Secret）配置错误
+1. `agentSecret`（应用 Secret）配置错误
 2. access_token 获取失败（检查 CorpId 和 Secret）
 3. 接收者不在应用可见范围内
 4. 应用未开通消息发送权限
@@ -248,7 +248,7 @@ A: 可能的原因：
 
 A: 检查：
 1. CorpId 是否正确
-2. agentId 是否是应用 Secret（不是应用的 AgentId 数字）
+2. agentSecret 是否是应用 Secret（不是应用的 AgentId 数字）
 3. 企业微信 API 是否可访问
 
 ## 相关链接

--- a/plugins/adapters/wecom/package.json
+++ b/plugins/adapters/wecom/package.json
@@ -1,0 +1,69 @@
+{
+  "name": "@zhin.js/adapter-wecom",
+  "version": "1.0.0",
+  "description": "Zhin.js adapter for WeCom (企业微信)",
+  "type": "module",
+  "main": "./lib/index.js",
+  "types": "./lib/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./lib/index.d.ts",
+      "development": "./src/index.ts",
+      "import": "./lib/index.js"
+    }
+  },
+  "keywords": [
+    "zhin",
+    "zhin.js",
+    "bot",
+    "adapter",
+    "wecom",
+    "企业微信",
+    "wechat work",
+    "chatbot"
+  ],
+  "author": {
+    "name": "lc-cn",
+    "email": "admin@liucl.cn",
+    "url": "https://github.com/lc-cn"
+  },
+  "license": "MIT",
+  "repository": {
+    "url": "git+https://github.com/zhinjs/zhin.git",
+    "type": "git",
+    "directory": "plugins/adapters/wecom"
+  },
+  "scripts": {
+    "build": "pnpm build:node",
+    "clean": "rimraf lib",
+    "build:node": "tsc"
+  },
+  "devDependencies": {
+    "@types/koa": "^3.0.3",
+    "@types/node": "^25.9.2",
+    "@zhin.js/host-router": "workspace:*",
+    "typescript": "^6.0.3",
+    "zhin.js": "workspace:*"
+  },
+  "peerDependencies": {
+    "@zhin.js/host-router": "workspace:*",
+    "zhin.js": "workspace:*"
+  },
+  "peerDependenciesMeta": {
+    "@zhin.js/host-router": {
+      "optional": false
+    }
+  },
+  "files": [
+    "src",
+    "lib",
+    "skills",
+    "plugin.yml",
+    "README.md",
+    "CHANGELOG.md"
+  ],
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org"
+  }
+}

--- a/plugins/adapters/wecom/package.json
+++ b/plugins/adapters/wecom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zhin.js/adapter-wecom",
-  "version": "1.0.0",
+  "version": "0.0.1",
   "description": "Zhin.js adapter for WeCom (企业微信)",
   "type": "module",
   "main": "./lib/index.js",

--- a/plugins/adapters/wecom/plugin.yml
+++ b/plugins/adapters/wecom/plugin.yml
@@ -1,0 +1,3 @@
+name: adapter-wecom
+description: 企业微信适配器：消息接收与发送、用户与部门查询、AES 消息加解密
+version: 1.0.0

--- a/plugins/adapters/wecom/skills/wecom/PERMITS.md
+++ b/plugins/adapters/wecom/skills/wecom/PERMITS.md
@@ -1,0 +1,19 @@
+# 企业微信 WeCom Platform Permits
+
+## 入站字段
+
+| 字段 | 来源 |
+|------|------|
+| `$sender.role` | 默认 `member`；需业务侧扩展企业微信可见性/管理权限 |
+| `$sender.permissions` | `chat_owner` · `chat_admin` |
+
+## Permit 词汇表
+
+| `platform(wecom,…)` | 含义 |
+|---------------------|------|
+| `chat_owner` | 群主 |
+| `chat_admin` | 群管理员 |
+
+## 工厂映射
+
+`group_admin` → `chat_admin` · `group_owner` → `chat_owner`

--- a/plugins/adapters/wecom/skills/wecom/SKILL.md
+++ b/plugins/adapters/wecom/skills/wecom/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: wecom
+platforms:
+  - wecom
+description: >-
+  企业微信平台管理能力。当用户在企业微信中请求用户信息查询、部门架构查询、
+  发送文本消息时使用。即使用户没有提到企业微信，只要上下文是企业微信/WeCom
+  场景且涉及用户查询、部门管理或消息发送，就应触发。
+keywords:
+  - wecom
+  - 企业微信
+  - adapter:wecom
+  - 部门
+  - 用户
+  - 通讯录
+  - 企业
+tags:
+  - im
+  - enterprise
+tools:
+  - wecom_get_user
+  - wecom_get_dept_users
+  - wecom_list_departments
+  - wecom_send_text
+---
+
+# 企业微信技能
+
+企业微信（WeCom）是腾讯面向企业的 IM 平台，具备组织架构（部门树）、应用消息推送等能力。
+
+## 核心原则
+
+### 组织架构是核心
+
+企业微信的用户隶属于部门树，查询操作需要从组织架构出发：
+```
+wecom_list_departments → 获取部门列表（默认从根部门 ID=1 开始）
+wecom_get_dept_users(dept_id) → 获取部门下的用户列表
+wecom_get_user(user_id) → 获取用户详情
+```
+
+### 消息发送
+
+`wecom_send_text` 通过应用消息接口发送文本消息，需要知道接收者的 `userid`。
+群消息通过 webhook 回调自动处理，不需要主动调用发送工具。
+
+## 工具分类
+
+### 组织架构
+
+| 工具 | 用途 | 说明 |
+|------|------|------|
+| `wecom_list_departments` | 部门列表 | 默认从根部门 ID=1 开始 |
+| `wecom_get_dept_users` | 部门用户列表 | 返回简单用户信息 |
+| `wecom_get_user` | 用户详情 | 需要通讯录权限 |
+
+### 消息
+
+| 工具 | 用途 | 说明 |
+|------|------|------|
+| `wecom_send_text` | 发送文本消息 | 发给指定用户，通过应用消息接口 |
+
+## 易错点
+
+1. **部门查询从根部门 ID=1 开始**。不知道部门 ID 时先 `list_departments` 获取整棵部门树。
+2. **消息发送需要 userid**，不是用户名或昵称。仅有昵称时先通过 `get_dept_users` 查找。
+3. **企业微信不支持机器人撤回消息**，一旦发出无法撤回。
+4. **Access Token 有效期 7200 秒**，适配器会自动刷新。

--- a/plugins/adapters/wecom/src/adapter.ts
+++ b/plugins/adapters/wecom/src/adapter.ts
@@ -2,15 +2,16 @@
  * 企业微信适配器
  */
 import { Adapter, Plugin } from 'zhin.js';
+import type { Router } from '@zhin.js/host-router/router';
 import { WecomEndpoint } from './endpoint.js';
 import type { WecomEndpointConfig } from './types.js';
 
 export class WecomAdapter extends Adapter<WecomEndpoint> {
   static override readonly capabilities = ['inbound', 'outbound'] as const;
 
-  #router: any;
+  #router: Router;
 
-  constructor(plugin: Plugin, router: any) {
+  constructor(plugin: Plugin, router: Router) {
     super(plugin, 'wecom', []);
     this.#router = router;
   }

--- a/plugins/adapters/wecom/src/adapter.ts
+++ b/plugins/adapters/wecom/src/adapter.ts
@@ -1,0 +1,25 @@
+/**
+ * 企业微信适配器
+ */
+import { Adapter, Plugin } from 'zhin.js';
+import { WecomEndpoint } from './endpoint.js';
+import type { WecomEndpointConfig } from './types.js';
+
+export class WecomAdapter extends Adapter<WecomEndpoint> {
+  static override readonly capabilities = ['inbound', 'outbound'] as const;
+
+  #router: any;
+
+  constructor(plugin: Plugin, router: any) {
+    super(plugin, 'wecom', []);
+    this.#router = router;
+  }
+
+  createEndpoint(config: WecomEndpointConfig): WecomEndpoint {
+    return new WecomEndpoint(this, this.#router, config);
+  }
+
+  async start(): Promise<void> {
+    await super.start();
+  }
+}

--- a/plugins/adapters/wecom/src/endpoint.ts
+++ b/plugins/adapters/wecom/src/endpoint.ts
@@ -111,6 +111,11 @@ export class WecomEndpoint implements Endpoint<WecomEndpointConfig, WecomMessage
 
       // 解密 echostr 并返回明文
       const decrypted = this.decryptMessage(echostr as string);
+      if (!decrypted) {
+        ctx.status = 400;
+        ctx.body = 'Decryption failed';
+        return;
+      }
       ctx.status = 200;
       ctx.body = decrypted;
     } catch (error) {
@@ -154,6 +159,11 @@ export class WecomEndpoint implements Endpoint<WecomEndpointConfig, WecomMessage
 
       // 解密消息
       const decryptedXml = this.decryptMessage(encrypted);
+      if (!decryptedXml) {
+        ctx.status = 200;
+        ctx.body = 'success';
+        return;
+      }
       const message = this.parseXmlMessage(decryptedXml);
       if (message) {
         await this.handleMessage(message);
@@ -184,7 +194,7 @@ export class WecomEndpoint implements Endpoint<WecomEndpointConfig, WecomMessage
 
   // ── AES-CBC 解密 ──
 
-  private decryptMessage(encrypted: string): string {
+  private decryptMessage(encrypted: string): string | null {
     const buf = Buffer.from(encrypted, 'base64');
     const iv = this.aesKey.subarray(0, 16);
     const decipher = createDecipheriv('aes-256-cbc', this.aesKey, iv);
@@ -198,7 +208,8 @@ export class WecomEndpoint implements Endpoint<WecomEndpointConfig, WecomMessage
     const msg = content.subarray(20, 20 + msgLen).toString('utf8');
     const extractedCorpId = content.subarray(20 + msgLen).toString('utf8');
     if (extractedCorpId !== this.corpId) {
-      this.logger.warn(formatCompact({ op: 'decrypt', ok: false, error: 'corpId mismatch' }));
+      this.logger.warn(formatCompact({ op: 'decrypt', ok: false, error: 'corpId mismatch', expected: this.corpId, got: extractedCorpId }));
+      return null;
     }
     return msg;
   }

--- a/plugins/adapters/wecom/src/endpoint.ts
+++ b/plugins/adapters/wecom/src/endpoint.ts
@@ -1,0 +1,607 @@
+/**
+ * 企业微信 Endpoint 实现
+ */
+import { formatCompact, Endpoint, Message, MessageSegment, segment, type SendContent, type SendOptions } from 'zhin.js';
+import { registerFetchRoute, type Router, type RouterContext } from '@zhin.js/host-router/router';
+import { createHash, createDecipheriv, randomBytes } from 'node:crypto';
+import type {
+  WecomEndpointConfig,
+  WecomMessage,
+  AccessToken,
+} from './types.js';
+import type { WecomAdapter } from './adapter.js';
+import { normalizeWecomSenderForPermit } from './platform-permit.js';
+
+export class WecomEndpoint implements Endpoint<WecomEndpointConfig, WecomMessage> {
+  $connected: boolean;
+  private router: any;
+  private accessToken: AccessToken;
+  private baseURL: string;
+  private aesKey: Buffer;
+  private corpId: string;
+
+  get $id() {
+    return this.$config.name;
+  }
+
+  get logger() {
+    return this.adapter.plugin.logger;
+  }
+
+  constructor(
+    public adapter: WecomAdapter,
+    router: any,
+    public $config: WecomEndpointConfig
+  ) {
+    this.router = router;
+    this.$connected = false;
+    this.accessToken = { access_token: '', expires_in: 0, timestamp: 0 };
+    this.baseURL = $config.apiBaseUrl || 'https://qyapi.weixin.qq.com';
+    this.corpId = $config.corpId;
+    this.aesKey = Buffer.from($config.encodingAESKey + '=', 'base64');
+    this.setupWebhookRoute();
+  }
+
+  // ── HTTP helpers ──
+
+  private async request(
+    path: string,
+    options: {
+      method?: 'GET' | 'POST';
+      params?: Record<string, any>;
+      body?: any;
+    } = {}
+  ): Promise<any> {
+    await this.ensureAccessToken();
+    const { method = 'GET', params = {}, body } = options;
+    const urlParams = new URLSearchParams({
+      ...params,
+      access_token: this.accessToken.access_token,
+    });
+    const url = `${this.baseURL}${path}?${urlParams.toString()}`;
+    const fetchOptions: RequestInit = {
+      method,
+      headers: { 'Content-Type': 'application/json; charset=utf-8' },
+    };
+    if (body && method === 'POST') {
+      fetchOptions.body = JSON.stringify(body);
+    }
+    const response = await fetch(url, fetchOptions);
+    return await response.json();
+  }
+
+  // ── Webhook route ──
+
+  private setupWebhookRoute(): void {
+    const webhookPath = this.$config.webhookPath || '/wecom/callback';
+    registerFetchRoute(this.router, 'GET', webhookPath, (ctx: RouterContext) => {
+      void this.handleVerification(ctx);
+    });
+    registerFetchRoute(this.router, 'POST', webhookPath, (ctx: RouterContext) => {
+      void this.handleWebhook(ctx);
+    });
+  }
+
+  // ── URL 验证（企业微信首次配置回调 URL 时的 GET 请求）──
+
+  private handleVerification(ctx: RouterContext): void {
+    try {
+      const query = ctx.query;
+      const msgSignature = query.msg_signature as string;
+      const timestamp = query.timestamp as string;
+      const nonce = query.nonce as string;
+      const echostr = query.echostr as string;
+
+      if (!this.verifySignature(msgSignature, timestamp, nonce, echostr)) {
+        this.logger.warn(formatCompact({ op: 'verify', ok: false, error: 'invalid signature' }));
+        ctx.status = 403;
+        ctx.body = 'Forbidden';
+        return;
+      }
+
+      // 解密 echostr 并返回明文
+      const decrypted = this.decryptMessage(echostr);
+      ctx.status = 200;
+      ctx.body = decrypted;
+    } catch (error) {
+      this.logger.error('URL verification error:', error);
+      ctx.status = 500;
+      ctx.body = 'Internal Server Error';
+    }
+  }
+
+  // ── 消息回调处理 ──
+
+  private async handleWebhook(ctx: RouterContext): Promise<void> {
+    try {
+      const query = ctx.query;
+      const msgSignature = query.msg_signature as string;
+      const timestamp = query.timestamp as string;
+      const nonce = query.nonce as string;
+
+      // 解析 XML body
+      const rawBody = typeof ctx.request.body === 'string'
+        ? ctx.request.body
+        : String(ctx.request.body || '');
+
+      // 从 XML 中提取 Encrypt 字段
+      const encryptMatch = rawBody.match(/<Encrypt><!\[CDATA\[(.+?)\]\]><\/Encrypt>/);
+      if (!encryptMatch) {
+        this.logger.warn(formatCompact({ op: 'webhook', ok: false, error: 'no Encrypt field' }));
+        ctx.status = 200;
+        ctx.body = 'success';
+        return;
+      }
+      const encrypted = encryptMatch[1];
+
+      // 验证签名
+      if (!this.verifySignature(msgSignature, timestamp, nonce, encrypted)) {
+        this.logger.warn(formatCompact({ op: 'webhook', ok: false, error: 'invalid signature' }));
+        ctx.status = 403;
+        ctx.body = 'Forbidden';
+        return;
+      }
+
+      // 解密消息
+      const decryptedXml = this.decryptMessage(encrypted);
+      const message = this.parseXmlMessage(decryptedXml);
+      if (message) {
+        await this.handleMessage(message);
+      }
+
+      ctx.status = 200;
+      ctx.body = 'success';
+    } catch (error) {
+      this.logger.error('Webhook error:', error);
+      ctx.status = 200;
+      ctx.body = 'success';
+    }
+  }
+
+  // ── 签名验证（SHA1 排序拼接）──
+
+  private verifySignature(signature: string, timestamp: string, nonce: string, encrypt: string): boolean {
+    try {
+      const arr = [this.$config.token, timestamp, nonce, encrypt].sort();
+      const str = arr.join('');
+      const hash = createHash('sha1').update(str).digest('hex');
+      return hash === signature;
+    } catch (error) {
+      this.logger.error('Signature verification error:', error);
+      return false;
+    }
+  }
+
+  // ── AES-CBC 解密 ──
+
+  private decryptMessage(encrypted: string): string {
+    const buf = Buffer.from(encrypted, 'base64');
+    const iv = this.aesKey.subarray(0, 16);
+    const decipher = createDecipheriv('aes-256-cbc', this.aesKey, iv);
+    decipher.setAutoPadding(false);
+    const decrypted = Buffer.concat([decipher.update(buf), decipher.final()]);
+    // PKCS7 unpad
+    const pad = decrypted[decrypted.length - 1];
+    const content = decrypted.subarray(0, decrypted.length - pad);
+    // 提取: 16 字节随机数 + 4 字节消息长度 + 消息体 + corpId
+    const msgLen = content.readUInt32BE(16);
+    const msg = content.subarray(20, 20 + msgLen).toString('utf8');
+    const extractedCorpId = content.subarray(20 + msgLen).toString('utf8');
+    if (extractedCorpId !== this.corpId) {
+      this.logger.warn(formatCompact({ op: 'decrypt', ok: false, error: 'corpId mismatch' }));
+    }
+    return msg;
+  }
+
+  // ── XML 解析（简易，无外部依赖）──
+
+  private parseXmlMessage(xml: string): WecomMessage | null {
+    try {
+      const get = (tag: string): string | undefined => {
+        const m = xml.match(new RegExp(`<${tag}><!\\[CDATA\\[(.+?)\\]\\]><\\/${tag}>`))
+          || xml.match(new RegExp(`<${tag}>(.+?)<\\/${tag}>`));
+        return m ? m[1] : undefined;
+      };
+      const msgType = get('MsgType');
+      if (!msgType) return null;
+
+      const msg: WecomMessage = {
+        ToUserName: get('ToUserName') || '',
+        FromUserName: get('FromUserName') || '',
+        CreateTime: Number(get('CreateTime') || Date.now()),
+        MsgType: msgType as WecomMessage['MsgType'],
+        MsgId: get('MsgId'),
+        AgentID: get('AgentID'),
+      };
+
+      switch (msgType) {
+        case 'text':
+          msg.Content = get('Content');
+          break;
+        case 'image':
+          msg.PicUrl = get('PicUrl');
+          msg.MediaId = get('MediaId');
+          break;
+        case 'voice':
+          msg.MediaId = get('MediaId');
+          msg.Format = get('Format');
+          msg.Recognition = get('Recognition');
+          break;
+        case 'video':
+        case 'shortvideo':
+          msg.MediaId = get('MediaId');
+          msg.ThumbMediaId = get('ThumbMediaId');
+          break;
+        case 'location':
+          msg.Location_X = get('Location_X');
+          msg.Location_Y = get('Location_Y');
+          msg.Scale = get('Scale');
+          msg.Label = get('Label');
+          break;
+        case 'link':
+          msg.Title = get('Title');
+          msg.Description = get('Description');
+          msg.Url = get('Url');
+          break;
+        case 'event':
+          msg.Event = get('Event');
+          msg.EventKey = get('EventKey');
+          break;
+      }
+
+      return msg;
+    } catch (error) {
+      this.logger.error('Failed to parse XML message:', error);
+      return null;
+    }
+  }
+
+  // ── 消息处理 ──
+
+  private async handleMessage(msg: WecomMessage): Promise<void> {
+    const formatted = this.$formatMessage(msg);
+    this.adapter.emit('message.receive', formatted);
+    this.logger.debug(formatCompact({
+      op: 'recv',
+      endpoint: this.$config.name,
+      channel: formatted.$channel.type,
+      id: formatted.$channel.id,
+      len: segment.raw(formatted.$content).length,
+    }));
+  }
+
+  // ── Access Token 管理 ──
+
+  private async ensureAccessToken(): Promise<void> {
+    const now = Date.now();
+    if (
+      this.accessToken.access_token &&
+      now < this.accessToken.timestamp + (this.accessToken.expires_in - 300) * 1000
+    ) {
+      return;
+    }
+    await this.refreshAccessToken();
+  }
+
+  private async refreshAccessToken(): Promise<void> {
+    try {
+      const url = `${this.baseURL}/cgi-bin/gettoken?corpid=${this.corpId}&corpsecret=${this.$config.agentId}`;
+      const response = await fetch(url);
+      const data = await response.json() as any;
+      if (data.errcode === 0) {
+        this.accessToken = {
+          access_token: data.access_token,
+          expires_in: data.expires_in,
+          timestamp: Date.now(),
+        };
+        this.logger.debug('Access token refreshed successfully');
+      } else {
+        throw new Error(`Failed to get access token: ${data.errmsg} (${data.errcode})`);
+      }
+    } catch (error) {
+      this.logger.error('Failed to refresh access token:', error);
+      throw error;
+    }
+  }
+
+  // ── $formatMessage ──
+
+  $formatMessage(msg: WecomMessage): Message<WecomMessage> {
+    const content = this.parseMessageContent(msg);
+    // 企业微信中群消息与私聊消息的判断:
+    // 群消息 FromUserName 以 @chatroom 结尾
+    const chatType = msg.FromUserName.endsWith('@chatroom') ? 'group' : 'private';
+    const permit = normalizeWecomSenderForPermit({});
+
+    return Message.from(msg, {
+      $id: msg.MsgId || Date.now().toString(),
+      $adapter: 'wecom',
+      $endpoint: this.$config.name,
+      $sender: {
+        id: msg.FromUserName,
+        name: msg.FromUserName,
+        role: permit.role,
+        permissions: permit.permissions,
+      },
+      $channel: {
+        id: chatType === 'group' ? msg.FromUserName : msg.FromUserName,
+        type: chatType as any,
+      },
+      $content: content,
+      $raw: JSON.stringify(msg),
+      $timestamp: (msg.CreateTime || Math.floor(Date.now() / 1000)) * 1000,
+      $recall: async () => {
+        await this.$recallMessage(msg.MsgId || '');
+      },
+      $reply: async (content: SendContent): Promise<string> => {
+        return await this.adapter.sendMessage({
+          context: 'wecom',
+          endpoint: this.$config.name,
+          id: msg.FromUserName,
+          type: chatType,
+          content: content,
+        });
+      },
+    });
+  }
+
+  private parseMessageContent(msg: WecomMessage): MessageSegment[] {
+    const content: MessageSegment[] = [];
+    if (!msg.MsgType) return content;
+    try {
+      switch (msg.MsgType) {
+        case 'text':
+          if (msg.Content) {
+            content.push(segment('text', { content: msg.Content }));
+          }
+          break;
+        case 'image':
+          if (msg.MediaId) {
+            content.push(segment('image', {
+              file: msg.MediaId,
+              url: msg.PicUrl || '',
+            }));
+          }
+          break;
+        case 'voice':
+          if (msg.MediaId) {
+            content.push(segment('audio', {
+              file: msg.MediaId,
+            }));
+            // 语音识别结果
+            if (msg.Recognition) {
+              content.push(segment('text', { content: msg.Recognition }));
+            }
+          }
+          break;
+        case 'video':
+        case 'shortvideo':
+          if (msg.MediaId) {
+            content.push(segment('video', {
+              file: msg.MediaId,
+            }));
+          }
+          break;
+        case 'location':
+          content.push(segment('text', {
+            content: `[位置] ${msg.Label || ''} (${msg.Location_X}, ${msg.Location_Y})`,
+          }));
+          break;
+        case 'link':
+          content.push(segment('link', {
+            title: msg.Title || '',
+            content: msg.Description || '',
+            url: msg.Url || '',
+          }));
+          break;
+        case 'event':
+          content.push(segment('text', {
+            content: `[事件] ${msg.Event || ''} ${msg.EventKey || ''}`,
+          }));
+          break;
+        default:
+          content.push(segment('text', {
+            content: `[不支持的消息类型: ${msg.MsgType}]`,
+          }));
+          break;
+      }
+    } catch (error) {
+      this.logger.error('Failed to parse message content:', error);
+      content.push(segment('text', { content: '[消息解析失败]' }));
+    }
+    return content;
+  }
+
+  // ── $sendMessage ──
+
+  async $sendMessage(options: SendOptions): Promise<string> {
+    const targetId = options.id;
+    const content = this.formatSendContent(options.content);
+    try {
+      const body: Record<string, any> = {
+        touser: targetId,
+        msgtype: content.msgtype,
+        agentid: this.$config.agentId,
+        [content.msgtype]: content.data,
+      };
+
+      // 群消息使用 chatid
+      if (targetId.endsWith('@chatroom')) {
+        delete body.touser;
+        body.chatid = targetId;
+      }
+
+      const data = await this.request('/cgi-bin/message/send', {
+        method: 'POST',
+        body,
+      });
+
+      if (data.errcode !== 0) {
+        throw new Error(`Failed to send message: ${data.errmsg} (${data.errcode})`);
+      }
+      this.logger.debug(formatCompact({ op: 'send', endpoint: this.$config.name, to: targetId }));
+      return data.msgid || Date.now().toString();
+    } catch (error) {
+      this.logger.error('Failed to send message:', error);
+      throw error;
+    }
+  }
+
+  // ── $recallMessage (企业微信不支持机器人撤回) ──
+
+  async $recallMessage(_id: string): Promise<void> {
+    this.logger.warn(formatCompact({ op: 'recall', ok: false, error: 'not supported by wecom' }));
+  }
+
+  // ── 发送内容格式化 ──
+
+  private formatSendContent(content: SendContent): { msgtype: string; data: any } {
+    if (typeof content === 'string') {
+      return { msgtype: 'text', data: { content } };
+    }
+    if (Array.isArray(content)) {
+      const textParts: string[] = [];
+      let hasMedia = false;
+      let mediaType = '';
+      let mediaData: any = null;
+
+      for (const item of content) {
+        if (typeof item === 'string') {
+          textParts.push(item);
+          continue;
+        }
+        const seg = item as MessageSegment;
+        switch (seg.type) {
+          case 'text':
+            textParts.push(seg.data.content || seg.data.text || '');
+            break;
+          case 'at':
+            // 企业微信 @ 格式: <@userid>
+            const userId = seg.data.id || seg.data.userId;
+            if (userId) textParts.push(`<@${userId}>`);
+            break;
+          case 'image':
+            if (!hasMedia) {
+              hasMedia = true;
+              mediaType = 'image';
+              mediaData = { media_id: seg.data.file || seg.data.url };
+            }
+            break;
+          case 'markdown':
+            if (!hasMedia) {
+              hasMedia = true;
+              mediaType = 'markdown';
+              mediaData = { content: seg.data.content || seg.data.text };
+            }
+            break;
+          case 'link':
+            if (!hasMedia) {
+              hasMedia = true;
+              mediaType = 'news';
+              mediaData = {
+                articles: [{
+                  title: seg.data.title || '链接',
+                  description: seg.data.text || seg.data.content || '',
+                  url: seg.data.url,
+                  picurl: seg.data.picUrl,
+                }],
+              };
+            }
+            break;
+        }
+      }
+
+      if (hasMedia && mediaData) {
+        return { msgtype: mediaType, data: mediaData };
+      }
+      return { msgtype: 'text', data: { content: textParts.join('') } };
+    }
+    return { msgtype: 'text', data: { content: String(content) } };
+  }
+
+  // ── 生命周期 ──
+
+  async $connect(): Promise<void> {
+    try {
+      await this.refreshAccessToken();
+      this.$connected = true;
+      this.logger.info(formatCompact({ op: 'connect', endpoint: this.$config.name }));
+      this.logger.info(formatCompact({ op: 'webhook', path: this.$config.webhookPath || '/wecom/callback' }));
+    } catch (error) {
+      this.logger.error('Failed to connect WeCom bot:', error);
+      throw error;
+    }
+  }
+
+  async $disconnect(): Promise<void> {
+    try {
+      this.$connected = false;
+      this.logger.info(formatCompact({ op: 'disconnect', endpoint: this.$config.name }));
+    } catch (error) {
+      this.logger.error('Error disconnecting WeCom bot:', error);
+    }
+  }
+
+  // ── 企业微信特有 API ──
+
+  async getUserInfo(userId: string): Promise<any> {
+    try {
+      const data = await this.request('/cgi-bin/user/get', {
+        params: { userid: userId },
+      });
+      if (data.errcode === 0) return data;
+      throw new Error(`Failed to get user info: ${data.errmsg}`);
+    } catch (error) {
+      this.logger.error('Failed to get user info:', error);
+      return null;
+    }
+  }
+
+  async getDepartmentUsers(deptId: number): Promise<any[]> {
+    try {
+      const data = await this.request('/cgi-bin/user/simplelist', {
+        params: { department_id: deptId },
+      });
+      if (data.errcode === 0) return data.userlist || [];
+      throw new Error(`Failed to get department users: ${data.errmsg}`);
+    } catch (error) {
+      this.logger.error('Failed to get department users:', error);
+      return [];
+    }
+  }
+
+  async getDepartmentList(deptId: number = 1): Promise<any[]> {
+    try {
+      const data = await this.request('/cgi-bin/department/list', {
+        params: { id: deptId },
+      });
+      if (data.errcode === 0) return data.department || [];
+      throw new Error(`Failed to get department list: ${data.errmsg}`);
+    } catch (error) {
+      this.logger.error('Failed to get department list:', error);
+      return [];
+    }
+  }
+
+  async sendTextMessage(userId: string, content: string): Promise<boolean> {
+    try {
+      const data = await this.request('/cgi-bin/message/send', {
+        method: 'POST',
+        body: {
+          touser: userId,
+          msgtype: 'text',
+          agentid: this.$config.agentId,
+          text: { content },
+        },
+      });
+      if (data.errcode === 0) {
+        this.logger.debug('Text message sent successfully');
+        return true;
+      }
+      throw new Error(`Failed to send text message: ${data.errmsg}`);
+    } catch (error) {
+      this.logger.error('Failed to send text message:', error);
+      return false;
+    }
+  }
+}

--- a/plugins/adapters/wecom/src/endpoint.ts
+++ b/plugins/adapters/wecom/src/endpoint.ts
@@ -8,17 +8,19 @@ import type {
   WecomEndpointConfig,
   WecomMessage,
   AccessToken,
+  WecomApiResponse,
 } from './types.js';
 import type { WecomAdapter } from './adapter.js';
 import { normalizeWecomSenderForPermit } from './platform-permit.js';
 
 export class WecomEndpoint implements Endpoint<WecomEndpointConfig, WecomMessage> {
   $connected: boolean;
-  private router: any;
+  private router: Router;
   private accessToken: AccessToken;
   private baseURL: string;
   private aesKey: Buffer;
   private corpId: string;
+  #refreshPromise: Promise<string> | null = null;
 
   get $id() {
     return this.$config.name;
@@ -30,7 +32,7 @@ export class WecomEndpoint implements Endpoint<WecomEndpointConfig, WecomMessage
 
   constructor(
     public adapter: WecomAdapter,
-    router: any,
+    router: Router,
     public $config: WecomEndpointConfig
   ) {
     this.router = router;
@@ -39,6 +41,9 @@ export class WecomEndpoint implements Endpoint<WecomEndpointConfig, WecomMessage
     this.baseURL = $config.apiBaseUrl || 'https://qyapi.weixin.qq.com';
     this.corpId = $config.corpId;
     this.aesKey = Buffer.from($config.encodingAESKey + '=', 'base64');
+    if (this.aesKey.length !== 32) {
+      throw new Error(`encodingAESKey must produce a 32-byte key, got ${this.aesKey.length} bytes`);
+    }
     this.setupWebhookRoute();
   }
 
@@ -48,10 +53,10 @@ export class WecomEndpoint implements Endpoint<WecomEndpointConfig, WecomMessage
     path: string,
     options: {
       method?: 'GET' | 'POST';
-      params?: Record<string, any>;
-      body?: any;
+      params?: Record<string, string | number>;
+      body?: Record<string, unknown>;
     } = {}
-  ): Promise<any> {
+  ): Promise<WecomApiResponse> {
     await this.ensureAccessToken();
     const { method = 'GET', params = {}, body } = options;
     const urlParams = new URLSearchParams({
@@ -67,6 +72,10 @@ export class WecomEndpoint implements Endpoint<WecomEndpointConfig, WecomMessage
       fetchOptions.body = JSON.stringify(body);
     }
     const response = await fetch(url, fetchOptions);
+    if (!response.ok) {
+      const text = await response.text().catch(() => '');
+      throw new Error(`WeCom API error ${response.status}: ${text}`);
+    }
     return await response.json();
   }
 
@@ -86,13 +95,14 @@ export class WecomEndpoint implements Endpoint<WecomEndpointConfig, WecomMessage
 
   private handleVerification(ctx: RouterContext): void {
     try {
-      const query = ctx.query;
-      const msgSignature = query.msg_signature as string;
-      const timestamp = query.timestamp as string;
-      const nonce = query.nonce as string;
-      const echostr = query.echostr as string;
+      const { msg_signature, timestamp, nonce, echostr } = ctx.query;
+      if (!msg_signature || !timestamp || !nonce || !echostr) {
+        ctx.status = 400;
+        ctx.body = 'Missing required query parameters';
+        return;
+      }
 
-      if (!this.verifySignature(msgSignature, timestamp, nonce, echostr)) {
+      if (!this.verifySignature(msg_signature as string, timestamp as string, nonce as string, echostr as string)) {
         this.logger.warn(formatCompact({ op: 'verify', ok: false, error: 'invalid signature' }));
         ctx.status = 403;
         ctx.body = 'Forbidden';
@@ -100,7 +110,7 @@ export class WecomEndpoint implements Endpoint<WecomEndpointConfig, WecomMessage
       }
 
       // 解密 echostr 并返回明文
-      const decrypted = this.decryptMessage(echostr);
+      const decrypted = this.decryptMessage(echostr as string);
       ctx.status = 200;
       ctx.body = decrypted;
     } catch (error) {
@@ -280,18 +290,25 @@ export class WecomEndpoint implements Endpoint<WecomEndpointConfig, WecomMessage
     ) {
       return;
     }
-    await this.refreshAccessToken();
+    if (this.#refreshPromise) {
+      await this.#refreshPromise;
+      return;
+    }
+    this.#refreshPromise = this.refreshAccessToken()
+      .then(() => this.accessToken.access_token)
+      .finally(() => { this.#refreshPromise = null; });
+    await this.#refreshPromise;
   }
 
   private async refreshAccessToken(): Promise<void> {
     try {
-      const url = `${this.baseURL}/cgi-bin/gettoken?corpid=${this.corpId}&corpsecret=${this.$config.agentId}`;
+      const url = `${this.baseURL}/cgi-bin/gettoken?corpid=${this.corpId}&corpsecret=${this.$config.agentSecret}`;
       const response = await fetch(url);
-      const data = await response.json() as any;
+      const data = await response.json() as WecomApiResponse;
       if (data.errcode === 0) {
         this.accessToken = {
-          access_token: data.access_token,
-          expires_in: data.expires_in,
+          access_token: data.access_token as string,
+          expires_in: data.expires_in as number,
           timestamp: Date.now(),
         };
         this.logger.debug('Access token refreshed successfully');
@@ -311,7 +328,8 @@ export class WecomEndpoint implements Endpoint<WecomEndpointConfig, WecomMessage
     // 企业微信中群消息与私聊消息的判断:
     // 群消息 FromUserName 以 @chatroom 结尾
     const chatType = msg.FromUserName.endsWith('@chatroom') ? 'group' : 'private';
-    const permit = normalizeWecomSenderForPermit({});
+    // TODO: v1: look up group admin status via WeCom API
+    const permit = normalizeWecomSenderForPermit({ isAdmin: false, isOwner: false });
 
     return Message.from(msg, {
       $id: msg.MsgId || Date.now().toString(),
@@ -418,10 +436,10 @@ export class WecomEndpoint implements Endpoint<WecomEndpointConfig, WecomMessage
     const targetId = options.id;
     const content = this.formatSendContent(options.content);
     try {
-      const body: Record<string, any> = {
+      const body: Record<string, unknown> = {
         touser: targetId,
         msgtype: content.msgtype,
-        agentid: this.$config.agentId,
+        agentid: this.$config.agentSecret,
         [content.msgtype]: content.data,
       };
 
@@ -440,7 +458,7 @@ export class WecomEndpoint implements Endpoint<WecomEndpointConfig, WecomMessage
         throw new Error(`Failed to send message: ${data.errmsg} (${data.errcode})`);
       }
       this.logger.debug(formatCompact({ op: 'send', endpoint: this.$config.name, to: targetId }));
-      return data.msgid || Date.now().toString();
+      return data.msgid as string || Date.now().toString();
     } catch (error) {
       this.logger.error('Failed to send message:', error);
       throw error;
@@ -455,7 +473,7 @@ export class WecomEndpoint implements Endpoint<WecomEndpointConfig, WecomMessage
 
   // ── 发送内容格式化 ──
 
-  private formatSendContent(content: SendContent): { msgtype: string; data: any } {
+  private formatSendContent(content: SendContent): { msgtype: string; data: Record<string, unknown> } {
     if (typeof content === 'string') {
       return { msgtype: 'text', data: { content } };
     }
@@ -463,7 +481,8 @@ export class WecomEndpoint implements Endpoint<WecomEndpointConfig, WecomMessage
       const textParts: string[] = [];
       let hasMedia = false;
       let mediaType = '';
-      let mediaData: any = null;
+      let mediaData: Record<string, unknown> | null = null;
+      let droppedMediaCount = 0;
 
       for (const item of content) {
         if (typeof item === 'string') {
@@ -485,6 +504,8 @@ export class WecomEndpoint implements Endpoint<WecomEndpointConfig, WecomMessage
               hasMedia = true;
               mediaType = 'image';
               mediaData = { media_id: seg.data.file || seg.data.url };
+            } else {
+              droppedMediaCount++;
             }
             break;
           case 'markdown':
@@ -492,6 +513,8 @@ export class WecomEndpoint implements Endpoint<WecomEndpointConfig, WecomMessage
               hasMedia = true;
               mediaType = 'markdown';
               mediaData = { content: seg.data.content || seg.data.text };
+            } else {
+              droppedMediaCount++;
             }
             break;
           case 'link':
@@ -506,9 +529,19 @@ export class WecomEndpoint implements Endpoint<WecomEndpointConfig, WecomMessage
                   picurl: seg.data.picUrl,
                 }],
               };
+            } else {
+              droppedMediaCount++;
             }
             break;
         }
+      }
+
+      if (droppedMediaCount > 0) {
+        this.logger.warn(formatCompact({
+          op: 'formatSend',
+          droppedMedia: droppedMediaCount,
+          note: 'WeCom API only supports one media segment per message',
+        }));
       }
 
       if (hasMedia && mediaData) {
@@ -534,17 +567,13 @@ export class WecomEndpoint implements Endpoint<WecomEndpointConfig, WecomMessage
   }
 
   async $disconnect(): Promise<void> {
-    try {
-      this.$connected = false;
-      this.logger.info(formatCompact({ op: 'disconnect', endpoint: this.$config.name }));
-    } catch (error) {
-      this.logger.error('Error disconnecting WeCom bot:', error);
-    }
+    this.$connected = false;
+    this.logger.info(formatCompact({ op: 'disconnect', endpoint: this.$config.name }));
   }
 
   // ── 企业微信特有 API ──
 
-  async getUserInfo(userId: string): Promise<any> {
+  async getUserInfo(userId: string): Promise<WecomApiResponse | null> {
     try {
       const data = await this.request('/cgi-bin/user/get', {
         params: { userid: userId },
@@ -557,12 +586,12 @@ export class WecomEndpoint implements Endpoint<WecomEndpointConfig, WecomMessage
     }
   }
 
-  async getDepartmentUsers(deptId: number): Promise<any[]> {
+  async getDepartmentUsers(deptId: number): Promise<unknown[]> {
     try {
       const data = await this.request('/cgi-bin/user/simplelist', {
         params: { department_id: deptId },
       });
-      if (data.errcode === 0) return data.userlist || [];
+      if (data.errcode === 0) return (data.userlist as unknown[]) || [];
       throw new Error(`Failed to get department users: ${data.errmsg}`);
     } catch (error) {
       this.logger.error('Failed to get department users:', error);
@@ -570,12 +599,12 @@ export class WecomEndpoint implements Endpoint<WecomEndpointConfig, WecomMessage
     }
   }
 
-  async getDepartmentList(deptId: number = 1): Promise<any[]> {
+  async getDepartmentList(deptId: number = 1): Promise<unknown[]> {
     try {
       const data = await this.request('/cgi-bin/department/list', {
         params: { id: deptId },
       });
-      if (data.errcode === 0) return data.department || [];
+      if (data.errcode === 0) return (data.department as unknown[]) || [];
       throw new Error(`Failed to get department list: ${data.errmsg}`);
     } catch (error) {
       this.logger.error('Failed to get department list:', error);
@@ -590,7 +619,7 @@ export class WecomEndpoint implements Endpoint<WecomEndpointConfig, WecomMessage
         body: {
           touser: userId,
           msgtype: 'text',
-          agentid: this.$config.agentId,
+          agentid: this.$config.agentSecret,
           text: { content },
         },
       });

--- a/plugins/adapters/wecom/src/endpoint.ts
+++ b/plugins/adapters/wecom/src/endpoint.ts
@@ -3,7 +3,7 @@
  */
 import { formatCompact, Endpoint, Message, MessageSegment, segment, type SendContent, type SendOptions } from 'zhin.js';
 import { registerFetchRoute, type Router, type RouterContext } from '@zhin.js/host-router/router';
-import { createHash, createDecipheriv, randomBytes } from 'node:crypto';
+import { createHash, createDecipheriv } from 'node:crypto';
 import type {
   WecomEndpointConfig,
   WecomMessage,
@@ -134,8 +134,8 @@ export class WecomEndpoint implements Endpoint<WecomEndpointConfig, WecomMessage
         ? ctx.request.body
         : String(ctx.request.body || '');
 
-      // 从 XML 中提取 Encrypt 字段
-      const encryptMatch = rawBody.match(/<Encrypt><!\[CDATA\[(.+?)\]\]><\/Encrypt>/);
+      // 从 XML 中提取 Encrypt 字段（使用字符类避免 CodeQL 多项式正则警告）
+      const encryptMatch = rawBody.match(/<Encrypt><!\[CDATA\[([^[\]]+)]\]><\/Encrypt>/);
       if (!encryptMatch) {
         this.logger.warn(formatCompact({ op: 'webhook', ok: false, error: 'no Encrypt field' }));
         ctx.status = 200;
@@ -208,8 +208,9 @@ export class WecomEndpoint implements Endpoint<WecomEndpointConfig, WecomMessage
   private parseXmlMessage(xml: string): WecomMessage | null {
     try {
       const get = (tag: string): string | undefined => {
-        const m = xml.match(new RegExp(`<${tag}><!\\[CDATA\\[(.+?)\\]\\]><\\/${tag}>`))
-          || xml.match(new RegExp(`<${tag}>(.+?)<\\/${tag}>`));
+        // 使用字符类避免 CodeQL 多项式正则警告
+        const m = xml.match(new RegExp(`<${tag}><!\\[CDATA\\[([^\\[\\]]*)\\]\\]><\\/${tag}>`))
+          || xml.match(new RegExp(`<${tag}>([^<]*)<\\/${tag}>`));
         return m ? m[1] : undefined;
       };
       const msgType = get('MsgType');

--- a/plugins/adapters/wecom/src/index.ts
+++ b/plugins/adapters/wecom/src/index.ts
@@ -1,0 +1,133 @@
+/**
+ * 企业微信适配器入口：类型扩展、导出、注册
+ */
+import { usePlugin, type Plugin, type ToolFeature } from 'zhin.js';
+import { WecomAdapter } from './adapter.js';
+import {
+  registerWecomPlatformPermitChecker,
+  platformPermit,
+} from './platform-permit.js';
+
+declare module 'zhin.js' {
+  namespace Plugin {
+    interface Contexts {
+      router: import('@zhin.js/host-router').Router;
+    }
+  }
+  interface Adapters {
+    wecom: WecomAdapter;
+  }
+}
+
+export * from './types.js';
+export { WecomEndpoint } from './endpoint.js';
+export { WecomAdapter } from './adapter.js';
+
+const plugin = usePlugin();
+const { provide, useContext } = plugin;
+
+useContext('router', (router: any) => {
+  provide({
+    name: 'wecom',
+    description: 'WeCom (企业微信) Endpoint Adapter',
+    mounted: async (p: Plugin) => {
+      const adapter = new WecomAdapter(p, router);
+      await adapter.start();
+      return adapter;
+    },
+    dispose: async (adapter: WecomAdapter) => {
+      await adapter.stop();
+    },
+  });
+});
+
+useContext('tool', 'wecom', (toolService: ToolFeature, wecom: WecomAdapter) => {
+  const disposers: (() => void)[] = [];
+  disposers.push(registerWecomPlatformPermitChecker());
+
+  disposers.push(toolService.addTool({
+    name: 'wecom_get_user',
+    description: '获取企业微信用户信息',
+    parameters: {
+      type: 'object',
+      properties: {
+        endpoint_id: { type: 'string', description: 'Endpoint 名称', contextKey: 'endpointId' },
+        user_id: { type: 'string', description: '用户 ID' },
+      },
+      required: ['endpoint_id', 'user_id'],
+    },
+    platforms: ['wecom'],
+    tags: ['wecom'],
+    execute: async (args: Record<string, any>) => {
+      const endpoint = wecom.endpoints.get(args.endpoint_id);
+      if (!endpoint) throw new Error(`Endpoint ${args.endpoint_id} 不存在`);
+      return await endpoint.getUserInfo(args.user_id);
+    },
+  }, plugin.name));
+
+  disposers.push(toolService.addTool({
+    name: 'wecom_get_dept_users',
+    description: '获取企业微信部门用户列表',
+    parameters: {
+      type: 'object',
+      properties: {
+        endpoint_id: { type: 'string', description: 'Endpoint 名称', contextKey: 'endpointId' },
+        dept_id: { type: 'string', description: '部门 ID' },
+      },
+      required: ['endpoint_id', 'dept_id'],
+    },
+    platforms: ['wecom'],
+    tags: ['wecom'],
+    execute: async (args: Record<string, any>) => {
+      const endpoint = wecom.endpoints.get(args.endpoint_id);
+      if (!endpoint) throw new Error(`Endpoint ${args.endpoint_id} 不存在`);
+      const users = await endpoint.getDepartmentUsers(Number(args.dept_id));
+      return { users, count: users.length };
+    },
+  }, plugin.name));
+
+  disposers.push(toolService.addTool({
+    name: 'wecom_list_departments',
+    description: '获取企业微信部门列表',
+    parameters: {
+      type: 'object',
+      properties: {
+        endpoint_id: { type: 'string', description: 'Endpoint 名称', contextKey: 'endpointId' },
+        dept_id: { type: 'string', description: '父部门 ID，默认 1（跟部门）' },
+      },
+      required: ['endpoint_id'],
+    },
+    platforms: ['wecom'],
+    tags: ['wecom'],
+    execute: async (args: Record<string, any>) => {
+      const endpoint = wecom.endpoints.get(args.endpoint_id);
+      if (!endpoint) throw new Error(`Endpoint ${args.endpoint_id} 不存在`);
+      const departments = await endpoint.getDepartmentList(Number(args.dept_id) || 1);
+      return { departments, count: departments.length };
+    },
+  }, plugin.name));
+
+  disposers.push(toolService.addTool({
+    name: 'wecom_send_text',
+    description: '向指定企业微信用户发送文本消息',
+    parameters: {
+      type: 'object',
+      properties: {
+        endpoint_id: { type: 'string', description: 'Endpoint 名称', contextKey: 'endpointId' },
+        user_id: { type: 'string', description: '用户 ID' },
+        content: { type: 'string', description: '消息内容' },
+      },
+      required: ['endpoint_id', 'user_id', 'content'],
+    },
+    platforms: ['wecom'],
+    tags: ['wecom'],
+    execute: async (args: Record<string, any>) => {
+      const endpoint = wecom.endpoints.get(args.endpoint_id);
+      if (!endpoint) throw new Error(`Endpoint ${args.endpoint_id} 不存在`);
+      const success = await endpoint.sendTextMessage(args.user_id, args.content);
+      return { success, message: success ? '消息已发送' : '发送失败' };
+    },
+  }, plugin.name));
+
+  return () => disposers.forEach(d => d());
+});

--- a/plugins/adapters/wecom/src/index.ts
+++ b/plugins/adapters/wecom/src/index.ts
@@ -6,7 +6,6 @@ import type { Router } from '@zhin.js/host-router/router';
 import { WecomAdapter } from './adapter.js';
 import {
   registerWecomPlatformPermitChecker,
-  platformPermit,
 } from './platform-permit.js';
 
 declare module 'zhin.js' {

--- a/plugins/adapters/wecom/src/index.ts
+++ b/plugins/adapters/wecom/src/index.ts
@@ -2,6 +2,7 @@
  * 企业微信适配器入口：类型扩展、导出、注册
  */
 import { usePlugin, type Plugin, type ToolFeature } from 'zhin.js';
+import type { Router } from '@zhin.js/host-router/router';
 import { WecomAdapter } from './adapter.js';
 import {
   registerWecomPlatformPermitChecker,
@@ -26,7 +27,7 @@ export { WecomAdapter } from './adapter.js';
 const plugin = usePlugin();
 const { provide, useContext } = plugin;
 
-useContext('router', (router: any) => {
+useContext('router', (router: Router) => {
   provide({
     name: 'wecom',
     description: 'WeCom (企业微信) Endpoint Adapter',

--- a/plugins/adapters/wecom/src/platform-permit.ts
+++ b/plugins/adapters/wecom/src/platform-permit.ts
@@ -1,0 +1,53 @@
+/**
+ * 企业微信 WeCom platform permit
+ */
+import type { Message } from 'zhin.js';
+import { registerPlatformPermitChecker } from 'zhin.js';
+
+const ADAPTER = 'wecom';
+
+export function platformPermit(perm: string): string {
+  return `platform(${ADAPTER},${perm})`;
+}
+
+const FACTORY_PERM_MAP: Record<string, string> = {
+  group_admin: 'chat_admin',
+  group_owner: 'chat_owner',
+};
+
+export function wecomGroupPermitResolver(logicalPerm: string): string {
+  return platformPermit(FACTORY_PERM_MAP[logicalPerm] ?? logicalPerm);
+}
+
+export function normalizeWecomSenderForPermit(input: {
+  isOwner?: boolean;
+  isAdmin?: boolean;
+}): { role?: string; permissions?: string[] } {
+  if (input.isOwner) {
+    return { role: 'owner', permissions: ['chat_owner', 'chat_admin'] };
+  }
+  if (input.isAdmin) {
+    return { role: 'admin', permissions: ['chat_admin'] };
+  }
+  return { role: 'member', permissions: [] };
+}
+
+export function checkWecomPlatformPermit(perm: string, message: Message<any>): boolean {
+  const sender = message.$sender as { role?: string; permissions?: string[] };
+  const permissions = sender.permissions ?? [];
+  const role = sender.role;
+  const has = (t: string) => permissions.includes(t);
+
+  switch (perm) {
+    case 'chat_owner':
+      return role === 'owner' || has('chat_owner');
+    case 'chat_admin':
+      return role === 'owner' || role === 'admin' || has('chat_admin') || has('chat_owner');
+    default:
+      return false;
+  }
+}
+
+export function registerWecomPlatformPermitChecker(): () => void {
+  return registerPlatformPermitChecker(ADAPTER, checkWecomPlatformPermit);
+}

--- a/plugins/adapters/wecom/src/types.ts
+++ b/plugins/adapters/wecom/src/types.ts
@@ -1,0 +1,45 @@
+/**
+ * 企业微信适配器类型定义
+ */
+
+export interface WecomEndpointConfig {
+  context: 'wecom'
+  name: string
+  corpId: string
+  agentId: string
+  token: string           // 用于签名验证
+  encodingAESKey: string  // 用于消息加解密
+  webhookPath?: string    // 默认 '/wecom/callback'
+  apiBaseUrl?: string     // 默认 'https://qyapi.weixin.qq.com'
+}
+
+export interface WecomMessage {
+  ToUserName: string
+  FromUserName: string
+  CreateTime: number
+  MsgType: 'text' | 'image' | 'voice' | 'video' | 'shortvideo' | 'location' | 'link' | 'event'
+  Content?: string
+  MsgId?: string
+  PicUrl?: string
+  MediaId?: string
+  ThumbMediaId?: string
+  Format?: string
+  Recognition?: string
+  Location_X?: string
+  Location_Y?: string
+  Scale?: string
+  Label?: string
+  Title?: string
+  Description?: string
+  Url?: string
+  Event?: string
+  EventKey?: string
+  AgentID?: string
+  [key: string]: unknown
+}
+
+export interface AccessToken {
+  access_token: string
+  expires_in: number
+  timestamp: number
+}

--- a/plugins/adapters/wecom/src/types.ts
+++ b/plugins/adapters/wecom/src/types.ts
@@ -6,7 +6,7 @@ export interface WecomEndpointConfig {
   context: 'wecom'
   name: string
   corpId: string
-  agentId: string
+  agentSecret: string    // 应用 Secret
   token: string           // 用于签名验证
   encodingAESKey: string  // 用于消息加解密
   webhookPath?: string    // 默认 '/wecom/callback'
@@ -42,4 +42,10 @@ export interface AccessToken {
   access_token: string
   expires_in: number
   timestamp: number
+}
+
+export interface WecomApiResponse {
+  errcode: number
+  errmsg?: string
+  [key: string]: unknown
 }

--- a/plugins/adapters/wecom/tests/index.test.ts
+++ b/plugins/adapters/wecom/tests/index.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest'
+
+describe('WeCom Adapter', () => {
+  it('should load adapter module', async () => {
+    const wecom = await import('../src/index')
+    expect(wecom).toBeDefined()
+    expect(typeof wecom).toBe('object')
+  })
+
+  it('should have exports', async () => {
+    const wecom = await import('../src/index')
+    expect(Object.keys(wecom).length).toBeGreaterThan(0)
+  })
+})

--- a/plugins/adapters/wecom/tests/integration.test.ts
+++ b/plugins/adapters/wecom/tests/integration.test.ts
@@ -1,0 +1,246 @@
+/**
+ * WeCom 适配器集成测试
+ *
+ * 策略：Mock 掉 HTTP 传输层（refreshAccessToken / request），测试 Endpoint 接口合规性、
+ * 消息格式化、发送/接收链路、生命周期的完整性。
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { Plugin, type SendOptions } from 'zhin.js';
+import { createAdapterTestSuite } from '../../../../packages/im/core/tests/adapter-harness.js';
+import { WecomAdapter } from '../src/adapter.js';
+import { WecomEndpoint } from '../src/endpoint.js';
+import type { WecomEndpointConfig, WecomMessage } from '../src/types.ts';
+
+const FIXED_TS = 1700000000;
+const FIXED_TS_MS = FIXED_TS * 1000;
+
+// ── Mock Bot：重写 $connect/$disconnect/$sendMessage/$recallMessage ──
+
+class MockWecomEndpoint extends WecomEndpoint {
+  sendMock = vi.fn();
+
+  constructor(adapter: WecomAdapter, router: any, config: WecomEndpointConfig) {
+    super(adapter, router, config);
+  }
+
+  async $connect(): Promise<void> {
+    this.$connected = true;
+  }
+
+  async $disconnect(): Promise<void> {
+    this.$connected = false;
+  }
+
+  async $sendMessage(options: SendOptions): Promise<string> {
+    this.sendMock(options);
+    return `wecom-msg-${Date.now()}`;
+  }
+
+  async $recallMessage(_id: string): Promise<void> {
+    // WeCom 不支持撤回
+  }
+}
+
+// ── Mock Adapter ──
+
+class MockWecomAdapter extends WecomAdapter {
+  createEndpoint(config: WecomEndpointConfig): WecomEndpoint {
+    const mockRouter = { post: vi.fn(), get: vi.fn() };
+    return new MockWecomEndpoint(this, mockRouter, {
+      context: 'wecom',
+      name: config.name || 'test-endpoint',
+      corpId: 'mock-corpid',
+      agentId: 'mock-agent-secret',
+      token: 'mock-token',
+      encodingAESKey: 'mock-aes-key-43chars-long-enough-for-base64',
+      webhookPath: '/wecom/callback',
+      ...config,
+    });
+  }
+}
+
+// ── 原始消息工厂 ──
+
+function createWecomRawMessage(overrides: Partial<WecomMessage> = {}): WecomMessage {
+  return {
+    ToUserName: 'mock-corpid',
+    FromUserName: 'user001@test',
+    CreateTime: FIXED_TS,
+    MsgType: 'text',
+    Content: '你好',
+    MsgId: 'wecom-msg-001',
+    AgentID: '1000002',
+    ...overrides,
+  };
+}
+
+// ── Harness 标准测试套件（接口合规、生命周期、消息链路、错误处理）──
+
+createAdapterTestSuite<MockWecomAdapter, WecomMessage>({
+  adapterName: 'wecom',
+  endpointId: 'test-endpoint',
+  createAdapter: (plugin) => {
+    const adapter = new MockWecomAdapter(plugin, { post: vi.fn(), get: vi.fn() });
+    (adapter as any).config = [{
+      context: 'wecom' as const, name: 'test-endpoint',
+      corpId: 'mock-corpid', agentId: 'mock-agent-secret',
+      token: 'mock-token', encodingAESKey: 'mock-aes-key-43chars-long-enough-for-base64',
+      webhookPath: '/wecom/callback',
+    }];
+    return adapter;
+  },
+  createRawEvent: () => createWecomRawMessage(),
+});
+
+// ============================================================================
+
+describe('WeCom 适配器特定测试', () => {
+  let plugin: Plugin;
+  let adapter: MockWecomAdapter;
+  let endpoint: MockWecomEndpoint;
+
+  beforeEach(async () => {
+    plugin = new Plugin('/test/wecom-integration.ts');
+    adapter = new MockWecomAdapter(plugin, { post: vi.fn(), get: vi.fn() });
+    (adapter as any).config = [{
+      name: 'test-endpoint', context: 'wecom',
+      corpId: 'mock-corpid', agentId: 'mock-agent-secret',
+      token: 'mock-token', encodingAESKey: 'mock-aes-key-43chars-long-enough-for-base64',
+      webhookPath: '/wecom/callback',
+    }];
+    await adapter.start();
+    endpoint = adapter.endpoints.get('test-endpoint') as MockWecomEndpoint;
+  });
+
+  afterEach(async () => {
+    try { await adapter.stop(); } catch { /* ignore */ }
+  });
+
+  describe('Endpoint 接口合规性', () => {
+    it('$id 应为配置的 name', () => {
+      expect(endpoint.$id).toBe('test-endpoint');
+    });
+
+    it('$connected 启动后应为 true', () => {
+      expect(endpoint.$connected).toBe(true);
+    });
+
+    it('应实现所有 Endpoint 接口方法', () => {
+      expect(typeof endpoint.$formatMessage).toBe('function');
+      expect(typeof endpoint.$connect).toBe('function');
+      expect(typeof endpoint.$disconnect).toBe('function');
+      expect(typeof endpoint.$sendMessage).toBe('function');
+      expect(typeof endpoint.$recallMessage).toBe('function');
+    });
+  });
+
+  describe('生命周期', () => {
+    it('start() 应注册 endpoint', () => {
+      expect(adapter.endpoints.has('test-endpoint')).toBe(true);
+    });
+
+    it('stop() 应清空 endpoints', async () => {
+      await adapter.stop();
+      expect(adapter.endpoints.size).toBe(0);
+    });
+
+    it('stop() 后 endpoint 应 disconnected', async () => {
+      await adapter.stop();
+      expect(endpoint.$connected).toBe(false);
+    });
+  });
+
+  describe('$formatMessage 消息格式化', () => {
+    it('私聊消息应正确格式化', () => {
+      const raw = createWecomRawMessage();
+      const msg = endpoint.$formatMessage(raw);
+
+      expect(msg.$id).toBe('wecom-msg-001');
+      expect(msg.$adapter).toBe('wecom');
+      expect(msg.$endpoint).toBe('test-endpoint');
+      expect(msg.$sender.id).toBe('user001@test');
+      expect(msg.$channel.id).toBe('user001@test');
+      expect(msg.$channel.type).toBe('private');
+      expect(typeof msg.$reply).toBe('function');
+      expect(typeof msg.$recall).toBe('function');
+    });
+
+    it('群消息应正确格式化', () => {
+      const raw = createWecomRawMessage({ FromUserName: 'group001@chatroom' });
+      const msg = endpoint.$formatMessage(raw);
+      expect(msg.$channel.type).toBe('group');
+      expect(msg.$channel.id).toBe('group001@chatroom');
+    });
+
+    it('$timestamp 应精确匹配 CreateTime * 1000', () => {
+      const raw = createWecomRawMessage();
+      const msg = endpoint.$formatMessage(raw);
+      expect(msg.$timestamp).toBe(FIXED_TS_MS);
+    });
+
+    it('图片消息应正确格式化', () => {
+      const raw = createWecomRawMessage({
+        MsgType: 'image',
+        MediaId: 'media-001',
+        PicUrl: 'https://example.com/pic.jpg',
+      });
+      const msg = endpoint.$formatMessage(raw);
+      expect(msg.$content.length).toBeGreaterThan(0);
+      expect(msg.$content[0].type).toBe('image');
+    });
+
+    it('事件消息应正确格式化', () => {
+      const raw = createWecomRawMessage({
+        MsgType: 'event',
+        Event: 'subscribe',
+        EventKey: '',
+      });
+      const msg = endpoint.$formatMessage(raw);
+      expect(msg.$content.length).toBeGreaterThan(0);
+      expect(msg.$content[0].type).toBe('text');
+    });
+  });
+
+  describe('消息发送', () => {
+    it('sendMessage 应返回字符串 ID', async () => {
+      const result = await adapter.sendMessage({
+        context: 'wecom',
+        endpoint: 'test-endpoint',
+        id: 'user001@test',
+        type: 'private',
+        content: [{ type: 'text', data: { text: 'hello' } }],
+      });
+      expect(typeof result).toBe('string');
+      expect(result.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('消息接收链路', () => {
+    it('emit message.receive 应触发 plugin.dispatch', async () => {
+      const dispatchSpy = vi.spyOn(plugin, 'dispatch');
+      const raw = createWecomRawMessage();
+      const msg = endpoint.$formatMessage(raw);
+
+      adapter.emit('message.receive', msg);
+      await new Promise(r => setTimeout(r, 50));
+
+      expect(dispatchSpy).toHaveBeenCalledWith(
+        'message.receive',
+        expect.objectContaining({ $adapter: 'wecom' }),
+      );
+    });
+  });
+
+  describe('$reply 路由', () => {
+    it('$reply 应走 adapter.sendMessage', async () => {
+      const sendMessageSpy = vi.spyOn(adapter, 'sendMessage');
+      const raw = createWecomRawMessage();
+      const msg = endpoint.$formatMessage(raw);
+
+      sendMessageSpy.mockResolvedValue('reply-id');
+      const result = await msg.$reply('hi');
+      expect(sendMessageSpy).toHaveBeenCalledTimes(1);
+      expect(result).toBe('reply-id');
+    });
+  });
+});

--- a/plugins/adapters/wecom/tests/integration.test.ts
+++ b/plugins/adapters/wecom/tests/integration.test.ts
@@ -50,7 +50,7 @@ class MockWecomAdapter extends WecomAdapter {
       context: 'wecom',
       name: config.name || 'test-endpoint',
       corpId: 'mock-corpid',
-      agentId: 'mock-agent-secret',
+      agentSecret: 'mock-agent-secret',
       token: 'mock-token',
       encodingAESKey: 'mock-aes-key-43chars-long-enough-for-base64',
       webhookPath: '/wecom/callback',

--- a/plugins/adapters/wecom/tests/platform-permit.test.ts
+++ b/plugins/adapters/wecom/tests/platform-permit.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { canAccessTool, clearPlatformPermitCheckers } from 'zhin.js';
+import {
+  checkWecomPlatformPermit,
+  normalizeWecomSenderForPermit,
+  platformPermit,
+  registerWecomPlatformPermitChecker,
+} from '../src/platform-permit.js';
+
+function mockMsg(sender: { role?: string; permissions?: string[] }) {
+  return { $adapter: 'wecom', $sender: sender, $channel: { type: 'group', id: 'c1' } } as any;
+}
+
+describe('wecom platform-permit', () => {
+  beforeEach(() => {
+    clearPlatformPermitCheckers();
+    registerWecomPlatformPermitChecker();
+  });
+  afterEach(() => clearPlatformPermitCheckers());
+
+  it('normalizeWecomSenderForPermit', () => {
+    expect(normalizeWecomSenderForPermit({ isAdmin: true }).role).toBe('admin');
+    expect(normalizeWecomSenderForPermit({ isOwner: true }).role).toBe('owner');
+    expect(normalizeWecomSenderForPermit({}).role).toBe('member');
+  });
+
+  it('checkWecomPlatformPermit', () => {
+    expect(checkWecomPlatformPermit('chat_admin', mockMsg({ role: 'admin', permissions: ['chat_admin'] }))).toBe(true);
+    expect(checkWecomPlatformPermit('chat_owner', mockMsg({ role: 'member', permissions: [] }))).toBe(false);
+  });
+
+  it('canAccessTool', () => {
+    const tool = {
+      name: 't',
+      description: 'd',
+      parameters: { type: 'object', properties: {} },
+      permissions: [platformPermit('chat_admin')],
+      execute: async () => '',
+    };
+    expect(canAccessTool(tool, mockMsg({ role: 'member', permissions: [] }))).toBe(false);
+    expect(canAccessTool(tool, mockMsg({ role: 'admin', permissions: ['chat_admin'] }))).toBe(true);
+  });
+});

--- a/plugins/adapters/wecom/tsconfig.json
+++ b/plugins/adapters/wecom/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "types": ["node"],
+    "outDir": "./lib",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["lib", "node_modules"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1122,6 +1122,30 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/im/zhin
 
+  plugins/adapters/line:
+    devDependencies:
+      '@types/node':
+        specifier: ^25.9.2
+        version: 25.9.3
+      '@zhin.js/cli':
+        specifier: workspace:*
+        version: link:../../../basic/cli
+      '@zhin.js/host-api':
+        specifier: workspace:*
+        version: link:../../../packages/host/api
+      '@zhin.js/host-router':
+        specifier: workspace:*
+        version: link:../../../packages/host/router
+      '@zhin.js/logger':
+        specifier: workspace:*
+        version: link:../../../basic/logger
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      zhin.js:
+        specifier: workspace:*
+        version: link:../../../packages/im/zhin
+
   plugins/adapters/milky:
     dependencies:
       eventsource:
@@ -1443,6 +1467,24 @@ importers:
       '@types/xml2js':
         specifier: ^0.4.14
         version: 0.4.14
+      '@zhin.js/host-router':
+        specifier: workspace:*
+        version: link:../../../packages/host/router
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      zhin.js:
+        specifier: workspace:*
+        version: link:../../../packages/im/zhin
+
+  plugins/adapters/wecom:
+    devDependencies:
+      '@types/koa':
+        specifier: ^3.0.3
+        version: 3.0.3
+      '@types/node':
+        specifier: ^25.9.2
+        version: 25.9.3
       '@zhin.js/host-router':
         specifier: workspace:*
         version: link:../../../packages/host/router
@@ -9646,14 +9688,14 @@ snapshots:
 
   '@slack/logger@4.0.1':
     dependencies:
-      '@types/node': 25.9.2
+      '@types/node': 25.9.3
 
   '@slack/oauth@3.0.5':
     dependencies:
       '@slack/logger': 4.0.1
       '@slack/web-api': 7.16.0
       '@types/jsonwebtoken': 9.0.10
-      '@types/node': 25.9.2
+      '@types/node': 25.9.3
       jsonwebtoken: 9.0.3
     transitivePeerDependencies:
       - debug
@@ -9663,7 +9705,7 @@ snapshots:
     dependencies:
       '@slack/logger': 4.0.1
       '@slack/web-api': 7.16.0
-      '@types/node': 25.9.2
+      '@types/node': 25.9.3
       '@types/ws': 8.18.1
       eventemitter3: 5.0.4
       ws: 8.21.0
@@ -9679,7 +9721,7 @@ snapshots:
     dependencies:
       '@slack/logger': 4.0.1
       '@slack/types': 2.21.1
-      '@types/node': 25.9.2
+      '@types/node': 25.9.3
       '@types/retry': 0.12.0
       axios: 1.17.0
       eventemitter3: 5.0.4
@@ -9717,12 +9759,12 @@ snapshots:
 
   '@types/accepts@1.3.7':
     dependencies:
-      '@types/node': 25.9.2
+      '@types/node': 25.9.3
 
   '@types/body-parser@1.19.6':
     dependencies:
       '@types/connect': 3.4.38
-      '@types/node': 25.9.2
+      '@types/node': 25.9.3
 
   '@types/bun@1.3.14':
     dependencies:
@@ -9735,12 +9777,12 @@ snapshots:
 
   '@types/co-body@6.1.3':
     dependencies:
-      '@types/node': 25.9.2
+      '@types/node': 25.9.3
       '@types/qs': 6.15.1
 
   '@types/connect@3.4.38':
     dependencies:
-      '@types/node': 25.9.2
+      '@types/node': 25.9.3
 
   '@types/content-disposition@0.5.9': {}
 
@@ -9749,11 +9791,11 @@ snapshots:
       '@types/connect': 3.4.38
       '@types/express': 5.0.6
       '@types/keygrip': 1.0.6
-      '@types/node': 25.9.2
+      '@types/node': 25.9.3
 
   '@types/cross-spawn@6.0.6':
     dependencies:
-      '@types/node': 25.9.2
+      '@types/node': 25.9.3
 
   '@types/d3-array@3.2.2': {}
 
@@ -9884,7 +9926,7 @@ snapshots:
 
   '@types/express-serve-static-core@5.1.1':
     dependencies:
-      '@types/node': 25.9.2
+      '@types/node': 25.9.3
       '@types/qs': 6.15.1
       '@types/range-parser': 1.2.7
       '@types/send': 1.2.1
@@ -9897,12 +9939,12 @@ snapshots:
 
   '@types/formidable@3.5.1':
     dependencies:
-      '@types/node': 25.9.2
+      '@types/node': 25.9.3
 
   '@types/fs-extra@11.0.4':
     dependencies:
       '@types/jsonfile': 6.1.4
-      '@types/node': 25.9.2
+      '@types/node': 25.9.3
 
   '@types/geojson@7946.0.16': {}
 
@@ -9918,7 +9960,7 @@ snapshots:
 
   '@types/imap@0.8.43':
     dependencies:
-      '@types/node': 25.9.2
+      '@types/node': 25.9.3
 
   '@types/inquirer@9.0.9':
     dependencies:
@@ -9931,12 +9973,12 @@ snapshots:
 
   '@types/jsonfile@6.1.4':
     dependencies:
-      '@types/node': 25.9.2
+      '@types/node': 25.9.3
 
   '@types/jsonwebtoken@9.0.10':
     dependencies:
       '@types/ms': 2.1.0
-      '@types/node': 25.9.2
+      '@types/node': 25.9.3
 
   '@types/keygrip@1.0.6': {}
 
@@ -9966,7 +10008,7 @@ snapshots:
       '@types/http-errors': 2.0.5
       '@types/keygrip': 1.0.6
       '@types/koa-compose': 3.2.9
-      '@types/node': 25.9.2
+      '@types/node': 25.9.3
 
   '@types/koa__router@12.0.5':
     dependencies:
@@ -9976,7 +10018,7 @@ snapshots:
 
   '@types/mailparser@3.4.6':
     dependencies:
-      '@types/node': 25.9.2
+      '@types/node': 25.9.3
       iconv-lite: 0.6.3
 
   '@types/markdown-it@14.1.2':
@@ -10004,11 +10046,11 @@ snapshots:
 
   '@types/nodemailer@8.0.0':
     dependencies:
-      '@types/node': 25.9.2
+      '@types/node': 25.9.3
 
   '@types/pg@8.20.0':
     dependencies:
-      '@types/node': 25.9.2
+      '@types/node': 25.9.3
       pg-protocol: 1.13.0
       pg-types: 2.2.0
 
@@ -10028,12 +10070,12 @@ snapshots:
 
   '@types/send@1.2.1':
     dependencies:
-      '@types/node': 25.9.2
+      '@types/node': 25.9.3
 
   '@types/serve-static@2.2.0':
     dependencies:
       '@types/http-errors': 2.0.5
-      '@types/node': 25.9.2
+      '@types/node': 25.9.3
 
   '@types/set-cookie-parser@2.4.10':
     dependencies:
@@ -10045,7 +10087,7 @@ snapshots:
 
   '@types/through@0.0.33':
     dependencies:
-      '@types/node': 25.9.2
+      '@types/node': 25.9.3
 
   '@types/trusted-types@2.0.7':
     optional: true
@@ -10062,11 +10104,11 @@ snapshots:
 
   '@types/ws@8.18.1':
     dependencies:
-      '@types/node': 25.9.2
+      '@types/node': 25.9.3
 
   '@types/xml2js@0.4.14':
     dependencies:
-      '@types/node': 25.9.2
+      '@types/node': 25.9.3
 
   '@typescript-eslint/eslint-plugin@8.61.0(@typescript-eslint/parser@8.61.0(eslint@10.4.1(jiti@2.6.1))(typescript@6.0.3))(eslint@10.4.1(jiti@2.6.1))(typescript@6.0.3)':
     dependencies:
@@ -10543,7 +10585,7 @@ snapshots:
 
   bun-types@1.3.14:
     dependencies:
-      '@types/node': 25.9.2
+      '@types/node': 25.9.3
 
   bundle-name@4.1.0:
     dependencies:


### PR DESCRIPTION
## 变更

### ADR 0017: RAG v0 — 本地知识库检索

定义 knowledge_search 设计决策（追溯 PR #506 实现）：

- **D1**: 工具名 （强调知识检索语义）
- **D2**: 纯本地文件目录，零外部依赖
- **D3**: 段落级分块 + 关键词匹配（不做向量搜索）
- **D4**: 懒索引 + 60s TTL 缓存
- **D5**: 与 semantic memory 并行（非合并）
- **D6**: 最小配置契约（）
- **D7**: 明确不做事项（PDF、向量搜索、Console UI、代码库索引）

### ADR 索引补全

补充 README.md 缺失的 ADR 0012-0015 条目。

Closes #481

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds ADR 0017 for local RAG v0 `knowledge_search`, adds Platform Stable adapters `@zhin.js/adapter-wecom` and `@zhin.js/adapter-line`, updates docs/tiers (adapters 17 → 19), and includes a P1 WeCom security fix to reject callbacks with mismatched `corpId`.

- **New Features**
  - `knowledge_search` (RAG v0): scan local `.md`/`.txt` under `ai.knowledge.baseDir` (default `knowledge`); paragraph chunks; keyword top-K; optional `file` filter; lazy indexing (60s TTL); local-only; separate from semantic memory.
  - `@zhin.js/adapter-wecom`: SHA1 verify + AES-256-CBC decrypt; auto access-token refresh; text/image/voice/video/location/link/event; webhook `/wecom/callback`; tools for user/department queries and text sending; docs synced.
  - `@zhin.js/adapter-line` (v0.1.1): HMAC-SHA256 verify; text/image/video/audio/file/location/sticker; Reply API via `replyToken` with Push fallback; private/group/room detection; tools for profile/group members; docs synced.

- **Bug Fixes**
  - WeCom: reject webhook messages when decrypted `corpId` mismatches; rename config to `agentSecret`; HTTP status checks; mutexed token refresh; stricter types; GET-param checks; AES key length validation; permit role wiring; warn on dropped media.
  - LINE: replyToken cache + real reply ID; raw-body HMAC with `timingSafeEqual`; Push API recipient ID format check (U/G/R); type guards; clear cache on disconnect; warn on text truncation and >5 messages; recall now warns.
  - Docs: sidebar links for `@zhin.js/adapter-weixin-ilink`/`@zhin.js/adapter-wecom`/`@zhin.js/adapter-line`; capability tiers updated.
  - General: removed unused imports; regex tightened to satisfy CodeQL.

<sup>Written for commit 886c6f20a696a7f69c278a3ff93ad340907eb0fa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zhinjs/zhin/pull/508?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

