### PR TITLE
docs: Segment content model SSOT (#549)

### DIFF
--- a/docs/adr/0025-adapter-ai-outbound-json.md
+++ b/docs/adr/0025-adapter-ai-outbound-json.md
@@ -19,6 +19,8 @@ Accepted
 | Core `ZhinAiOutboundPayload` | `text` / `mentions` / `segments` / `extensions` — 平台无关 |
 | Adapter `extensions` | 对齐各 SDK 文档子集（如 `onebot.keyboard`、`qq.markdown`） |
 
+`segments` 数组元素与 IM **`Segment[]` 同形**（`{ type, data, platform? }`），见 [Segment 内容模型 SSOT](../architecture/segment-content-model.md)。**废弃** `{ kind, mode, data }` DSL。
+
 **禁止**让 AI 直接输出平台原生 segment 数组；Adapter 负责 `extensions` → `MessageElement[]`。
 
 ### D2. structured_only 生效范围

--- a/docs/advanced/ai.md
+++ b/docs/advanced/ai.md
@@ -1090,18 +1090,11 @@ agent.processMultimodal(
 
 未安装 `@zhin.js/speech` 且 strategy 为 `transcribe` 时降级为占位文本（warn once）。配置见 [configuration — 语音](/essentials/configuration#语音-stt-tts-zhinjsspeech-optional-peer) 与 [ADR 0020](/adr/0020-speech-pipeline-stt-tts)。
 
-### 输入：MessageElement 约定
+### 输入：Segment 约定（SSOT）
 
-多模态输入依赖 `message.$content`（`MessageElement[]`）中 **MessageSegment** 的 `type` 与 `data` 约定。适配器在构造 `$content` 时需使用下表约定的段类型与字段，AI 触发器才能正确提取并转为 `ContentPart`：
+多模态输入依赖 `message.$content`（`MessageElement[]`）中的 canonical **`Segment[]`**。段类型、`MediaRef`、legacy 映射与 IM 可见性见 **[Segment 内容模型](../architecture/segment-content-model.md)**（唯一权威表）。
 
-| 消息段 type | 说明 | data 常用字段 |
-|---|---|---|
-| `image` | 图片 | `url`、`file` 或 `src`（任一带有效值即可） |
-| `video` | 视频 | `url`、`file` 或 `src` |
-| `audio`、`record`、`voice` | 音频/语音 | base64 内容：`data` 或 `base64`；格式：`format`（`wav`/`mp3`）。若仅有 `url`，会退化为文本描述传给模型 |
-| `face`、`sticker`、`emoji` | 表情/贴纸 | `id` 或 `face_id`；可选 `text`、`name`、`describe` |
-
-仅当 `$content` 元素为 `MessageSegment`（`{ type: string, data: Record<string, any> }`）且 `type` 匹配上表时会被提取；`MessageComponent` 或其它 type 会被安全跳过。
+仅当 `$content` 元素为 `MessageSegment`（`{ type, data, platform? }`）且 `type` 为 SSOT 所列 IM 可见类型时会被提取并转为 `ContentPart`；`MessageComponent` 或其它 type 会被安全跳过。
 
 ### 输出回传
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -9,6 +9,7 @@
 | 文档 | 说明 |
 |------|------|
 | [架构概览](../architecture-overview.md) | 分层（basic → kernel → ai → core → agent → zhin）、消息流程图 |
+| [Segment 内容模型](segment-content-model.md) | **SSOT**：`Segment[]` 形状、MediaRef、IM 可见性、AI 出站 JSON |
 | [ADR 0019 — 安装体积分层](../adr/0019-install-size-layering.md) | zhin.js 4.x：IM <10MB、agent/provider optional peer |
 | [ADR 0009 — agentLoop 统一栈](../adr/0009-pi-aligned-ai-agent-core.md) | Context + stream + agentLoop 迁移与完成定义 |
 | [仓库结构](../contributing/repo-structure.md) | pnpm workspace、`src→lib` / `client→dist` |

--- a/docs/architecture/segment-content-model.md
+++ b/docs/architecture/segment-content-model.md
@@ -1,0 +1,201 @@
+# Segment 内容模型（SSOT）
+
+破坏性改版（2026）：**`Segment[]` 为 IM、Console、`agent_messages` 与 AI 出站 JSON 的共享消息体契约**。Adapter 负责平台互转；Core 负责 schema 与校验；文档为本文件唯一权威表。
+
+## 规范态形状
+
+```typescript
+interface Segment {
+  type: string;
+  data: Record<string, unknown>;
+  platform?: Record<string, unknown>; // 与 type 同级；adapter 往返用，Console 一般不渲染
+}
+```
+
+- **`data` 与 `platform` 字段一律 snake_case**（如 `message_id`、`mime_type`、`forward_id`）。
+- **禁止**在规范 `data` 内混写 `url` / `file` / `src` 表示同一媒体；统一用 **MediaRef**。
+- 编写期可用 `MessageComponent`（html / keyboard 等）；**async render** 完成后再进入 `$content`、WebSocket、DB。
+
+### MediaRef
+
+```typescript
+interface MediaRef {
+  kind: 'url' | 'path' | 'base64';
+  value: string;
+  mime_type?: string;
+}
+```
+
+用于 `image` / `video` / `audio` / `voice` / `record` / `file` 等媒体类 `data.media`。
+
+## 数据流
+
+```mermaid
+flowchart LR
+  EP[Endpoint 入站]
+  MAP[adapter segment-mapper]
+  MSG["message.$content Segment[]"]
+  AGT["agent_messages.segments"]
+  OUT[AI 出站 JSON]
+  FILT[segmentsForImDelivery]
+  SEND["$reply / Console"]
+
+  EP --> MAP --> MSG
+  MSG --> AGT
+  OUT --> FILT
+  AGT --> FILT
+  FILT --> SEND
+```
+
+## Canonical type 总表
+
+| type | data（snake_case） | IM 可见 | 说明 |
+|------|-------------------|---------|------|
+| `text` | `{ text }` | yes | |
+| `image` | `{ media: MediaRef, alt? }` | yes | |
+| `video` | `{ media: MediaRef }` | yes | |
+| `audio` / `voice` / `record` | `{ media: MediaRef, duration?, text? }` | yes | `text` 可为 STT 转写 |
+| `file` | `{ media: MediaRef, name? }` | yes | |
+| `face` | `{ id, name? }` | yes | 入站 `sticker` / `emoji` normalize 为 `face` |
+| `mention` | `{ target, name? }` | yes | 全体：`target: 'all'`；原 `at` / `qq` |
+| `reply` | `{ message_id }` | yes | 与 `message.$quote_id` 双层同步 |
+| `forward` | `{ forward_id, title?, messages? }` | yes | `messages` 为嵌套 `Segment[][]` |
+| `link` | `{ url, text? }` | yes | |
+| `dice` / `rps` | `{}` 或 `{ result? }` | yes | 非 OneBot 出站降级 `text` |
+| `markdown` | `{ content, width?, background_color?, file_name? }` | yes | **存储 SSOT**；出站 rich render 见下 |
+| `html` / `qrcode` / `tts` | 见 [Rich Segment](../essentials/rich-segment-adapters.md) | yes | 存储 SSOT |
+| `keyboard` | 见 [Interactive Segment](../essentials/interactive-segments.md) | yes | |
+| `thinking` | `{ text }` | **no** | 仅 `agent_messages` / Console agent 面板 |
+| `tool_call` | `{ id, name, arguments }` | **no** | 仅 agent 持久化 |
+| ~~`json` / `xml`~~ | — | — | **非规范**；入站 normalize |
+
+### Rich / Interactive 与存储
+
+- `markdown` / `html` / `qrcode` / `tts`：**持久化保留原 type**；`resolveRichSegments` 出站可变为 `text` / `image` / `audio`，但不改写 SSOT 存储。
+- `keyboard`：同上，policy 见 [ADR 0022](../adr/0022-interactive-button-modes.md)。
+
+## 非规范：json / xml
+
+QQ 等平台入站常有 `{ type: 'json' }` / `{ type: 'xml' }` 包装。Adapter **入站**须 normalize 为 `forward` / `face` / `text` 等规范段；无法识别时降级 `text: '[卡片消息]'`。原始 payload 放 `platform`，不进 `data`。
+
+## reply 与 `$quote_id`（双层）
+
+```json
+{ "type": "reply", "data": { "message_id": "12345" } }
+```
+
+- **段级**：`$content` 内保留 `reply`，供 Console 展示与 adapter CQ/API 往返。
+- **消息级**：`message.$quote_id`、`SendOptions.quoteId` 供框架与 AI quote context。
+- 入站：adapter 从 reply 段或平台 raw 解析 → 写 `$content` 并 `syncQuoteId`。
+- 出站：`alignReplySegments` 写回 `data.message_id`（单字段，废弃 `id` / `message_id` 双写）。
+
+## forward 示例
+
+```json
+{
+  "type": "forward",
+  "data": {
+    "forward_id": "ABC123",
+    "title": "群聊的聊天记录",
+    "messages": [[{ "type": "text", "data": { "text": "..." } }]]
+  },
+  "platform": { "resid": "ABC123" }
+}
+```
+
+`messages` 由 adapter `get_forward_msg` enrich 后可选填入。
+
+## AI 交互层
+
+### AgentMessage 信封 vs Segment[]
+
+持久化使用 **信封 + 段** 双层，不新增 `type=tool_result` 段：
+
+| 角色 | 形状 | segments 内容 |
+|------|------|----------------|
+| `user` | `{ role: 'user', segments }` | 多为 text / image / … |
+| `assistant` | `{ role: 'assistant', segments, api, model, … }` | 可含 `text` + `thinking` + `tool_call` |
+| `toolResult` | `{ role: 'toolResult', tool_call_id, tool_name, segments, is_error }` | 多为 text / image |
+
+### IM 可见性白名单
+
+`segmentsForImDelivery(segments)` 过滤 **AI-only** 段后再进 `$reply` / 用户 IM：
+
+- **剔除**：`thinking`、`tool_call`
+- **保留**：上表 IM 可见 = yes 的 type
+
+### ZhinAiOutboundPayload（ADR 0025）
+
+AI 结构化出站 JSON 的 `segments` 与 canonical **同形**（`type` / `data` / `platform`），**废弃** `{ kind, mode, data }` DSL。
+
+```json
+{
+  "text": "可选正文",
+  "mentions": ["researcher"],
+  "segments": [
+    { "type": "mention", "data": { "target": "123", "name": "Bot" } },
+    { "type": "text", "data": { "text": " 请看一下" } }
+  ],
+  "extensions": { "onebot.keyboard": { } }
+}
+```
+
+- `mentions` + `text` 为便捷字段；resolve 后合并为 canonical `mention` + `text`。
+- **禁止** AI 直接输出平台原生 CQ 码；`extensions` → adapter `toMessageElements`。
+
+### LLM 序列化
+
+- **废弃** agent 路径上的 segment XML（`segment.from` / `segment.toString` 对模型输入）。
+- LLM 只收 **JSON `Segment[]`** 或 **纯 text**。
+
+## Legacy 映射（adapter 责任）
+
+| 入站 legacy | 规范态 |
+|-------------|--------|
+| `image.url` / `file` / `src` | `data.media` |
+| `at.qq` / `at.id` | `mention.target` |
+| `face_id` | `face.id` |
+| `reply.id` / `message_id` | `reply.message_id` |
+| `forward.id` / `resid` | `forward.forward_id` + `platform` |
+| `json` / `xml` 卡片 | forward / face / text 或 `[卡片消息]` |
+| Telegram `file_id` | `platform.file_id` |
+
+Core **不**自动 normalize legacy；各 adapter `segment-mapper` 实现互转。CI：`pnpm check:segments`。
+
+## Adapter 互转 checklist
+
+- [ ] 入站：平台 payload → `toCanonicalSegments()` → `message.$content`
+- [ ] 出站：`fromCanonicalSegments()` → 平台 API / CQ
+- [ ] `tests/segment-contract.test.ts` golden round-trip
+- [ ] 平台专有字段仅放 `platform`，不进规范 `data`
+
+## Console 双视图
+
+| 视图 | 数据源 | 展示 |
+|------|--------|------|
+| **endpoint inbox** | `message.$content` 经 IM-visible 过滤 | text / image / face / mention / reply / forward / … |
+| **agent 面板** | `agent_messages.segments` 全量 | 含 `thinking` / `tool_call` |
+
+### 发送示例（`endpoint:sendMessage`）
+
+```json
+{
+  "adapter": "icqq",
+  "endpointId": "8596238",
+  "id": "634415832",
+  "type": "channel",
+  "parent": { "type": "guild", "id": "650779094005186335" },
+  "content": [
+    { "type": "text", "data": { "text": "你好" } },
+    { "type": "mention", "data": { "target": "123456", "name": "Alice" } }
+  ]
+}
+```
+
+## 相关
+
+- [Rich Segment 适配器矩阵](../essentials/rich-segment-adapters.md)
+- [Interactive / Keyboard Segment](../essentials/interactive-segments.md)
+- [ADR 0025 — AI 结构化出站 JSON](../adr/0025-adapter-ai-outbound-json.md)
+- [ADR 0009 — agentLoop](../adr/0009-pi-aligned-ai-agent-core.md)
+- [AI 模块](../advanced/ai.md)（多模态与 agent 配置；段字段见本文）

--- a/docs/essentials/interactive-segments.md
+++ b/docs/essentials/interactive-segments.md
@@ -1,5 +1,7 @@
 # Interactive / Keyboard Segment 适配器矩阵
 
+Canonical `keyboard` 段形状见 [Segment 内容模型](../architecture/segment-content-model.md)。
+
 交互按钮在 **Adapter.renderSendMessage** 中于 `resolveRichSegments` 之后由 `resolveKeyboardSegments`（别名 `resolveInteractiveSegments`）处理。
 
 详见 [ADR 0022](../adr/0022-interactive-button-modes.md)。

--- a/docs/essentials/rich-segment-adapters.md
+++ b/docs/essentials/rich-segment-adapters.md
@@ -1,5 +1,7 @@
 # Rich Segment 适配器矩阵
 
+Canonical 存储形状见 [Segment 内容模型](../architecture/segment-content-model.md)（`markdown` / `html` / `qrcode` / `tts` 保留原 type；出站 rich render 不改写 SSOT）。
+
 Rich Segment 在 **Adapter.renderSendMessage** 首步由 `resolveRichSegments` 渲染为标准 IM 段；Endpoint 可选 **materializeOutboundMedia** 将 base64/本地文件转为平台 URL。
 
 Install tiers：[Rich media](/getting-started/#install-tierszhinjs-4x)（`@zhin.js/html-renderer`）、[Speech](/getting-started/#install-tierszhinjs-4x)（`@zhin.js/speech`）。


### PR DESCRIPTION
## Summary
- Add `docs/architecture/segment-content-model.md` as the canonical SSOT for `Segment[]`, MediaRef, IM visibility, AI outbound JSON, and Console dual-view.
- Link ADR 0025, `ai.md`, rich/interactive segment docs, and architecture index to the SSOT.
- Remove duplicate MessageElement field tables from `ai.md`.

## Test plan
- [x] `pnpm check:doc-links`

Closes #549

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Establishes a single source of truth for the `Segment[]` content model in `docs/architecture/segment-content-model.md`, defining `MediaRef`, IM-visible types, Console dual-view, and aligning AI outbound JSON to the same shape (deprecates `{ kind, mode, data }`).
Links ADR 0025, the architecture index, and rich/interactive segment docs and `ai.md` to the SSOT, and removes duplicate MessageElement field tables to prevent drift.

<sup>Written for commit c1fb6c9805d8582df9dac77a0563887ce6c0d58c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zhinjs/zhin/pull/558?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

