### PR TITLE
feat(core): segment contract + Sandbox text/mention (#550)

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "check:rich-segments": "node scripts/check-rich-segment-adapters.mjs",
     "check:ai-outbound": "node scripts/check-ai-outbound-adapters.mjs",
     "check:interactive-segments": "node scripts/check-interactive-segment-adapters.mjs",
+    "check:segments": "node scripts/check-segment-adapters.mjs",
     "check:use-plugin-top-level": "node scripts/check-use-plugin-top-level.mjs",
     "check:get-plugin-runtime": "node scripts/check-get-plugin-runtime.mjs",
     "check:all": "node scripts/check-all-harness.mjs",

--- a/packages/console/client/client/types.ts
+++ b/packages/console/client/client/types.ts
@@ -1,8 +1,9 @@
-// 消息段类型定义 - 客户端版本
+// 消息段类型定义 - 客户端版本（对齐 core Segment SSOT）
 export interface MessageSegment {
   /** record：如 ICQQ 语音等，展示时按音频处理 */
-  type: 'text' | 'image' | 'at' | 'face' | 'video' | 'audio' | 'record' | 'file' | 'reply'
-  data: Record<string, any>
+  type: 'text' | 'mention' | 'at' | 'image' | 'face' | 'video' | 'audio' | 'record' | 'file' | 'reply' | 'keyboard' | 'action' | string
+  data: Record<string, unknown>
+  platform?: Record<string, unknown>
 }
 
 // 消息元素别名（兼容不同命名习惯）
@@ -10,4 +11,3 @@ export type MessageElement = MessageSegment
 
 // 发送内容类型
 export type SendContent = MessageSegment | MessageSegment[] | string
-

--- a/packages/im/core/package.json
+++ b/packages/im/core/package.json
@@ -52,7 +52,8 @@
     "qrcode": "^1.5.4",
     "segment-matcher": "^1.0.5",
     "smol-toml": "^1.7.0",
-    "yaml": "^2.9.0"
+    "yaml": "^2.9.0",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@types/node": "^25.9.2",

--- a/packages/im/core/src/built/segment-contract/assert.ts
+++ b/packages/im/core/src/built/segment-contract/assert.ts
@@ -1,0 +1,32 @@
+import type { Segment } from './types.js';
+import { canonicalSegmentSchema } from './schema.js';
+
+const STRICT_CANONICAL_TYPES = new Set(['text', 'mention']);
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/** 宽松判断：text/mention 走 Zod；未知 type 仅校验顶层形状（adapter 渐进迁移） */
+export function isCanonicalSegment(value: unknown): value is Segment {
+  if (!isPlainObject(value) || typeof value.type !== 'string') return false;
+  if (!isPlainObject(value.data)) return false;
+  if (value.platform !== undefined && !isPlainObject(value.platform)) return false;
+
+  if (!STRICT_CANONICAL_TYPES.has(value.type)) {
+    return true;
+  }
+
+  return canonicalSegmentSchema.safeParse(value).success;
+}
+
+export function assertCanonicalSegments(segments: unknown): asserts segments is Segment[] {
+  if (!Array.isArray(segments)) {
+    throw new Error('segments must be an array');
+  }
+  for (let i = 0; i < segments.length; i++) {
+    if (!isCanonicalSegment(segments[i])) {
+      throw new Error(`segment[${i}] is not canonical`);
+    }
+  }
+}

--- a/packages/im/core/src/built/segment-contract/delivery.ts
+++ b/packages/im/core/src/built/segment-contract/delivery.ts
@@ -1,0 +1,41 @@
+import type { Segment } from './types.js';
+import { isCanonicalSegment } from './assert.js';
+
+/** IM 可见段白名单（thinking / tool_call 等 AI-only 段过滤） */
+const IM_VISIBLE_TYPES = new Set([
+  'text',
+  'mention',
+  'image',
+  'video',
+  'audio',
+  'voice',
+  'record',
+  'file',
+  'face',
+  'reply',
+  'forward',
+  'link',
+  'dice',
+  'rps',
+  'markdown',
+  'html',
+  'qrcode',
+  'tts',
+  'keyboard',
+]);
+
+const AI_ONLY_TYPES = new Set(['thinking', 'tool_call']);
+
+/**
+ * 过滤 agent / AI 出站段，仅保留可经 IM 投递的 canonical 段。
+ */
+export function segmentsForImDelivery(segments: readonly unknown[]): Segment[] {
+  const out: Segment[] = [];
+  for (const item of segments) {
+    if (!isCanonicalSegment(item)) continue;
+    if (AI_ONLY_TYPES.has(item.type)) continue;
+    if (!IM_VISIBLE_TYPES.has(item.type)) continue;
+    out.push(item);
+  }
+  return out;
+}

--- a/packages/im/core/src/built/segment-contract/index.ts
+++ b/packages/im/core/src/built/segment-contract/index.ts
@@ -1,0 +1,17 @@
+export type {
+  Segment,
+  SegmentBase,
+  MediaRef,
+  TextSegment,
+  MentionSegment,
+  MessageSegment,
+} from './types.js';
+export {
+  mediaRefSchema,
+  textSegmentSchema,
+  mentionSegmentSchema,
+  canonicalSegmentSchema,
+  segmentArraySchema,
+} from './schema.js';
+export { assertCanonicalSegments, isCanonicalSegment } from './assert.js';
+export { segmentsForImDelivery } from './delivery.js';

--- a/packages/im/core/src/built/segment-contract/schema.ts
+++ b/packages/im/core/src/built/segment-contract/schema.ts
@@ -1,0 +1,32 @@
+import { z } from 'zod';
+
+export const mediaRefSchema = z.object({
+  kind: z.enum(['url', 'path', 'base64']),
+  value: z.string(),
+  mime_type: z.string().optional(),
+});
+
+export const textSegmentSchema = z.object({
+  type: z.literal('text'),
+  data: z.object({
+    text: z.string(),
+  }),
+  platform: z.record(z.string(), z.unknown()).optional(),
+});
+
+export const mentionSegmentSchema = z.object({
+  type: z.literal('mention'),
+  data: z.object({
+    target: z.string(),
+    name: z.string().optional(),
+  }),
+  platform: z.record(z.string(), z.unknown()).optional(),
+});
+
+/** 当前已严格校验的 canonical 段（其余 type 由 assert 宽松接受） */
+export const canonicalSegmentSchema = z.discriminatedUnion('type', [
+  textSegmentSchema,
+  mentionSegmentSchema,
+]);
+
+export const segmentArraySchema = z.array(canonicalSegmentSchema);

--- a/packages/im/core/src/built/segment-contract/types.ts
+++ b/packages/im/core/src/built/segment-contract/types.ts
@@ -1,0 +1,33 @@
+/**
+ * Canonical Segment SSOT — IM + AI 共用 JSON 形状（snake_case data）。
+ * @see docs/architecture/segment-content-model.md
+ */
+
+export interface SegmentBase {
+  type: string;
+  data: Record<string, unknown>;
+  platform?: Record<string, unknown>;
+}
+
+/** 媒体引用占位（完整 schema 随 adapter 迁移补齐） */
+export interface MediaRef {
+  kind: 'url' | 'path' | 'base64';
+  value: string;
+  mime_type?: string;
+}
+
+export interface TextSegment extends SegmentBase {
+  type: 'text';
+  data: { text: string };
+}
+
+export interface MentionSegment extends SegmentBase {
+  type: 'mention';
+  data: { target: string; name?: string };
+}
+
+/** 规范态 segment（#550 起：text + mention 严格校验；其余 type 宽松透传） */
+export type Segment = TextSegment | MentionSegment | SegmentBase;
+
+/** @deprecated 使用 Segment；保留别名供 Console / adapter 渐进迁移 */
+export type MessageSegment = Segment;

--- a/packages/im/core/src/index.ts
+++ b/packages/im/core/src/index.ts
@@ -54,6 +54,7 @@ export { loadSpeechPipeline, seedSpeechPipeline, SPEECH_PACKAGE } from './built/
 export * from './built/outbound-media-utils.js'
 export * from './built/outbound-media-contract.js'
 export * from './built/interactive-segment-contract.js'
+export * from './built/segment-contract/index.js'
 export * from './built/adapter-process.js'
 export * from './built/component.js'
 export * from './built/inbound-runner.js'

--- a/packages/im/core/src/utils.ts
+++ b/packages/im/core/src/utils.ts
@@ -101,6 +101,9 @@ export namespace segment {
   export function text(text: string) {
     return segment("text", { text });
   }
+  export function mention(target: string, name?: string) {
+    return segment("mention", name ? { target, name } : { target });
+  }
   export function face(id: string, text?: string) {
     return segment("face", { id, text });
   }

--- a/packages/im/core/tests/helpers/segment-adapter-contract.ts
+++ b/packages/im/core/tests/helpers/segment-adapter-contract.ts
@@ -1,0 +1,36 @@
+/**
+ * Segment adapter 契约测试 helper
+ */
+import { expect } from 'vitest';
+import {
+  assertCanonicalSegments,
+  isCanonicalSegment,
+  type Segment,
+} from '@zhin.js/core';
+
+export type SegmentMapper = {
+  toCanonicalSegments: (content: readonly unknown[]) => Segment[];
+  fromCanonicalSegments?: (segments: readonly Segment[]) => unknown[];
+};
+
+export function assertSegmentRoundTrip(
+  mapper: SegmentMapper,
+  wire: unknown[],
+  expectedCanonical: Segment[],
+): void {
+  const canonical = mapper.toCanonicalSegments(wire);
+  assertCanonicalSegments(canonical);
+  expect(canonical).toEqual(expectedCanonical);
+
+  if (mapper.fromCanonicalSegments) {
+    const roundTrip = mapper.toCanonicalSegments(mapper.fromCanonicalSegments(canonical));
+    expect(roundTrip).toEqual(expectedCanonical);
+  }
+}
+
+export function smokeCanonicalMentionTarget(seg: unknown): void {
+  expect(isCanonicalSegment(seg)).toBe(true);
+  if (!isCanonicalSegment(seg) || seg.type !== 'mention') return;
+  expect(typeof seg.data.target).toBe('string');
+  expect(seg.data.target.length).toBeGreaterThan(0);
+}

--- a/packages/im/core/tests/segment-contract.test.ts
+++ b/packages/im/core/tests/segment-contract.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest';
+import {
+  assertCanonicalSegments,
+  isCanonicalSegment,
+  segmentsForImDelivery,
+  textSegmentSchema,
+  mentionSegmentSchema,
+} from '../src/built/segment-contract/index.js';
+
+describe('segment-contract schema', () => {
+  it('accepts text segment', () => {
+    const seg = { type: 'text', data: { text: 'hello' } };
+    expect(textSegmentSchema.safeParse(seg).success).toBe(true);
+    expect(isCanonicalSegment(seg)).toBe(true);
+  });
+
+  it('accepts mention segment with target all', () => {
+    const seg = { type: 'mention', data: { target: 'all', name: '全体成员' } };
+    expect(mentionSegmentSchema.safeParse(seg).success).toBe(true);
+    expect(isCanonicalSegment(seg)).toBe(true);
+  });
+
+  it('rejects mention without target', () => {
+    const seg = { type: 'mention', data: { name: 'bob' } };
+    expect(mentionSegmentSchema.safeParse(seg).success).toBe(false);
+    expect(isCanonicalSegment(seg)).toBe(false);
+  });
+
+  it('loosely accepts non-strict types with valid shape', () => {
+    const seg = { type: 'image', data: { url: 'https://cdn.example/a.jpg' } };
+    expect(isCanonicalSegment(seg)).toBe(true);
+  });
+});
+
+describe('assertCanonicalSegments', () => {
+  it('passes valid array', () => {
+    const segments = [
+      { type: 'text', data: { text: 'hi' } },
+      { type: 'mention', data: { target: '10001', name: 'Alice' } },
+    ];
+    expect(() => assertCanonicalSegments(segments)).not.toThrow();
+  });
+
+  it('throws on invalid mention', () => {
+    expect(() =>
+      assertCanonicalSegments([{ type: 'mention', data: {} }]),
+    ).toThrow(/segment\[0\]/);
+  });
+});
+
+describe('segmentsForImDelivery', () => {
+  it('keeps text and mention', () => {
+    const input = [
+      { type: 'text', data: { text: 'a' } },
+      { type: 'mention', data: { target: 'all' } },
+    ];
+    expect(segmentsForImDelivery(input)).toEqual(input);
+  });
+
+  it('drops thinking and tool_call', () => {
+    const input = [
+      { type: 'text', data: { text: 'visible' } },
+      { type: 'thinking', data: { text: 'hidden' } },
+      { type: 'tool_call', data: { id: '1', name: 'x', arguments: '{}' } },
+    ];
+    expect(segmentsForImDelivery(input)).toEqual([
+      { type: 'text', data: { text: 'visible' } },
+    ]);
+  });
+
+  it('drops unknown non-IM types', () => {
+    const input = [
+      { type: 'text', data: { text: 'ok' } },
+      { type: 'custom_internal', data: {} },
+    ];
+    expect(segmentsForImDelivery(input)).toEqual([
+      { type: 'text', data: { text: 'ok' } },
+    ]);
+  });
+
+  it('keeps IM-visible whitelist types', () => {
+    const cases: Array<{ type: string; data: Record<string, unknown> }> = [
+      { type: 'text', data: { text: 'x' } },
+      { type: 'mention', data: { target: 'all' } },
+      { type: 'image', data: { url: 'https://x/y.jpg' } },
+      { type: 'markdown', data: { content: '# hi' } },
+      { type: 'keyboard', data: { rows: [] } },
+    ];
+    for (const seg of cases) {
+      expect(segmentsForImDelivery([seg])).toEqual([seg]);
+    }
+  });
+});

--- a/plugins/adapters/sandbox/client/RichTextEditor.tsx
+++ b/plugins/adapters/sandbox/client/RichTextEditor.tsx
@@ -1,7 +1,7 @@
 import { useRef, useEffect, forwardRef, useImperativeHandle } from 'react'
 
 export interface MessageSegment {
-    type: 'text' | 'at' | 'face' | 'image' | 'video' | 'audio' | 'record' | 'file'
+    type: 'text' | 'mention' | 'at' | 'face' | 'image' | 'video' | 'audio' | 'record' | 'file'
     data: Record<string, any>
 }
 
@@ -69,7 +69,10 @@ const RichTextEditor = forwardRef<RichTextEditorRef, RichTextEditorProps>(
                         const name = el.dataset.name
                         const id = el.dataset.id
                         text += `[@${name}]`
-                        segments.push({ type: 'at', data: { name, qq: id } })
+                        segments.push({
+                            type: 'mention',
+                            data: id ? { target: id, name } : { target: name, name },
+                        })
                     } else if (el.tagName === 'BR') {
                         text += '\n'
                     }

--- a/plugins/adapters/sandbox/client/Sandbox.tsx
+++ b/plugins/adapters/sandbox/client/Sandbox.tsx
@@ -128,7 +128,7 @@ export default function Sandbox() {
                 const t = text.substring(lastIndex, match.index)
                 if (t) segments.push({ type: 'text', data: { text: t } })
             }
-            if (match[1]) segments.push({ type: 'at', data: { qq: match[1], name: match[1] } })
+            if (match[1]) segments.push({ type: 'mention', data: { target: match[1], name: match[1] } })
             else if (match[2]) segments.push({ type: 'face', data: { id: parseInt(match[2], 10) } })
             else if (match[3]) segments.push({ type: 'image', data: { url: match[3] } })
             else if (match[4]) segments.push({ type: 'video', data: { url: match[4] } })
@@ -161,8 +161,9 @@ export default function Sandbox() {
             switch (segment.type) {
                 case 'text':
                     return <span key={index}>{String(d.text ?? '').split('\n').map((part: string, i: number) => <React.Fragment key={i}>{part}{i < String(d.text ?? '').split('\n').length - 1 && <br />}</React.Fragment>)}</span>
+                case 'mention':
                 case 'at':
-                    return <span key={index} className="inline-flex items-center px-1.5 py-0.5 rounded bg-accent text-accent-foreground text-xs mx-0.5">@{String(d.name ?? d.qq ?? '')}</span>
+                    return <span key={index} className="inline-flex items-center px-1.5 py-0.5 rounded bg-accent text-accent-foreground text-xs mx-0.5">@{String(d.name ?? d.target ?? d.qq ?? '')}</span>
                 case 'face':
                     return <img key={index} src={`https://face.viki.moe/apng/${d.id}.png`} alt="" className="w-6 h-6 inline-block align-middle mx-0.5" />
                 case 'image': {

--- a/plugins/adapters/sandbox/src/sandbox-ws.ts
+++ b/plugins/adapters/sandbox/src/sandbox-ws.ts
@@ -10,6 +10,7 @@ import {
   type Plugin,
   type SendContent,
   type SendOptions,} from 'zhin.js';
+import { fromCanonicalSegments, toCanonicalSegments } from './segment-mapper.js';
 
 export interface SandboxWsConfig {
   context: "sandbox";
@@ -172,7 +173,7 @@ export function parseSandboxWsPayload(raw: string): {
   const content: MessageElement[] = typeof payload.content === "string"
     ? [{ type: "text", data: { text: payload.content } }]
     : Array.isArray(payload.content)
-    ? payload.content
+    ? toCanonicalSegments(payload.content)
     : [{ type: "text", data: { text: payload.text ?? raw } }];
   return { type, id, content, timestamp: payload.timestamp ?? Date.now() };
 }
@@ -238,6 +239,7 @@ export class SandboxWsEndpoint extends EventEmitter implements Endpoint<SandboxW
 
   $formatMessage({ content, type, id, ts }: EndpointEvent) {
     if (!this.$config.owner) this.$config.owner = id;
+    const canonical = toCanonicalSegments(content);
     const message = Message.from<EndpointEvent>(
       { content, type, id, ts },
       {
@@ -246,8 +248,8 @@ export class SandboxWsEndpoint extends EventEmitter implements Endpoint<SandboxW
         $endpoint: this.$config.name,
         $sender: { id, name: "mock" },
         $channel: { id, type },
-        $content: content,
-        $raw: segment.raw(content),
+        $content: canonical,
+        $raw: segment.raw(canonical),
         $timestamp: ts,
         $recall: async () => {},
         $reply: async (replyContent: SendContent, quote?: boolean | string) => {
@@ -282,11 +284,15 @@ export class SandboxWsEndpoint extends EventEmitter implements Endpoint<SandboxW
     const ws = this.$config.ws;
     if (!ws) return "";
     const messageId = `sb_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+    const normalized = (Array.isArray(options.content) ? options.content : [options.content]).map((s) =>
+      typeof s === 'string' ? { type: 'text' as const, data: { text: s } } : s,
+    );
+    const wire = fromCanonicalSegments(toCanonicalSegments(normalized));
     ws.send(
       JSON.stringify({
         ...options,
         messageId,
-        content: options.content,
+        content: wire,
         timestamp: Date.now(),
       }),
     );

--- a/plugins/adapters/sandbox/src/segment-mapper.ts
+++ b/plugins/adapters/sandbox/src/segment-mapper.ts
@@ -1,0 +1,47 @@
+import type { MessageElement, Segment } from '@zhin.js/core';
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function readMentionTarget(data: Record<string, unknown>): string {
+  const raw = data.target ?? data.user_id ?? data.qq ?? data.id;
+  if (raw === 'all') return 'all';
+  return raw != null ? String(raw) : '';
+}
+
+function normalizeMentionData(data: Record<string, unknown>): { target: string; name?: string } {
+  const target = readMentionTarget(data);
+  const name = typeof data.name === 'string' && data.name ? data.name : undefined;
+  return name ? { target, name } : { target };
+}
+
+/** 入站 / 内部 content → canonical Segment[] */
+export function toCanonicalSegments(content: readonly MessageElement[] | readonly unknown[]): Segment[] {
+  const out: Segment[] = [];
+  for (const item of content) {
+    if (typeof item === 'string') {
+      out.push({ type: 'text', data: { text: item } });
+      continue;
+    }
+    if (!isRecord(item) || typeof item.type !== 'string' || !isRecord(item.data)) {
+      continue;
+    }
+    if (item.type === 'at' || item.type === 'mention') {
+      const mention: Segment = {
+        type: 'mention',
+        data: normalizeMentionData(item.data),
+        ...(item.platform && isRecord(item.platform) ? { platform: item.platform } : {}),
+      };
+      out.push(mention);
+      continue;
+    }
+    out.push(item as Segment);
+  }
+  return out;
+}
+
+/** 出站 wire JSON（Sandbox 与 Console 一致，保留 canonical mention） */
+export function fromCanonicalSegments(segments: readonly Segment[]): MessageElement[] {
+  return segments.map((seg) => ({ ...seg }));
+}

--- a/plugins/adapters/sandbox/tests/segment-contract.test.ts
+++ b/plugins/adapters/sandbox/tests/segment-contract.test.ts
@@ -1,0 +1,45 @@
+/**
+ * sandbox segment contract — text + mention round-trip
+ */
+import { describe, expect, it } from 'vitest';
+import { SandboxWsHostAdapter } from '../src/sandbox-ws.js';
+import { fromCanonicalSegments, toCanonicalSegments } from '../src/segment-mapper.js';
+import { assertSegmentRoundTrip } from '../../../../packages/im/core/tests/helpers/segment-adapter-contract.js';
+
+const mapper = { toCanonicalSegments, fromCanonicalSegments };
+
+describe('sandbox segment contract', () => {
+  it('declares adapter class', () => {
+    expect(SandboxWsHostAdapter.interactivePolicy).toBe('native');
+  });
+
+  it('normalizes legacy at to mention', () => {
+    assertSegmentRoundTrip(
+      mapper,
+      [{ type: 'at', data: { qq: '10001', name: 'Alice' } }],
+      [{ type: 'mention', data: { target: '10001', name: 'Alice' } }],
+    );
+  });
+
+  it('normalizes mention target all', () => {
+    assertSegmentRoundTrip(
+      mapper,
+      [{ type: 'mention', data: { target: 'all', name: '全体成员' } }],
+      [{ type: 'mention', data: { target: 'all', name: '全体成员' } }],
+    );
+  });
+
+  it('round-trips text + mention', () => {
+    assertSegmentRoundTrip(
+      mapper,
+      [
+        { type: 'text', data: { text: '你好 ' } },
+        { type: 'mention', data: { target: '10002', name: 'Bob' } },
+      ],
+      [
+        { type: 'text', data: { text: '你好 ' } },
+        { type: 'mention', data: { target: '10002', name: 'Bob' } },
+      ],
+    );
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -957,6 +957,9 @@ importers:
       yaml:
         specifier: ^2.9.0
         version: 2.9.0
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       '@types/node':
         specifier: ^25.9.2

--- a/scripts/check-all-harness.mjs
+++ b/scripts/check-all-harness.mjs
@@ -116,6 +116,11 @@ const checks = [
     command: 'pnpm check:interactive-segments',
     description: '各 adapter 声明 interactivePolicy 与契约测试',
   },
+  {
+    name: 'Segment Adapters',
+    command: 'pnpm check:segments',
+    description: '各 adapter segment-mapper 契约（sandbox 必须达标）',
+  },
 ];
 
 console.log('Running all harness checks...\n');

--- a/scripts/check-segment-adapters.mjs
+++ b/scripts/check-segment-adapters.mjs
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+/**
+ * 校验 IM adapter segment-mapper 契约。
+ * #550：仅 sandbox 必须达标；其余 adapter 在 pending 白名单内。
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const adaptersDir = path.join(repoRoot, 'plugins/adapters');
+
+/** 必须含 segment-mapper + segment-contract.test.ts */
+const REQUIRED_ADAPTERS = new Set(['sandbox']);
+
+/** 尚未迁移 segment-mapper 的 adapter（不报错） */
+const PENDING_ADAPTERS = new Set([
+  'dingtalk',
+  'discord',
+  'email',
+  'github',
+  'icqq',
+  'kook',
+  'lark',
+  'line',
+  'milky',
+  'napcat',
+  'onebot11',
+  'onebot12',
+  'process',
+  'qq',
+  'satori',
+  'slack',
+  'telegram',
+  'wechat-mp',
+  'wecom',
+  'weixin-ilink',
+]);
+
+const entries = fs.readdirSync(adaptersDir, { withFileTypes: true })
+  .filter((d) => d.isDirectory())
+  .map((d) => d.name);
+
+const errors = [];
+
+for (const name of entries) {
+  const adapterPath = path.join(adaptersDir, name, 'src', 'adapter.ts');
+  const sandboxWs = path.join(adaptersDir, name, 'src', 'sandbox-ws.ts');
+  if (!fs.existsSync(adapterPath) && !fs.existsSync(sandboxWs)) continue;
+  if (PENDING_ADAPTERS.has(name)) continue;
+
+  const mapperPath = path.join(adaptersDir, name, 'src', 'segment-mapper.ts');
+  const contractTest = path.join(adaptersDir, name, 'tests', 'segment-contract.test.ts');
+
+  if (!fs.existsSync(mapperPath)) {
+    errors.push(`${name}: 缺少 src/segment-mapper.ts（或加入 PENDING_ADAPTERS）`);
+  }
+  if (!fs.existsSync(contractTest)) {
+    errors.push(`${name}: 缺少 tests/segment-contract.test.ts`);
+  }
+
+  if (REQUIRED_ADAPTERS.has(name) && errors.length) {
+    // keep errors for required adapters
+  }
+}
+
+if (errors.length > 0) {
+  console.error('check:segments failed:\n');
+  for (const e of errors) console.error(`  • ${e}`);
+  process.exit(1);
+}
+
+console.log(
+  `check:segments passed (${entries.length} adapter dirs; required: ${[...REQUIRED_ADAPTERS].join(', ')}; pending: ${PENDING_ADAPTERS.size}).\n`,
+);

--- a/tests/snapshots/api-surface.json
+++ b/tests/snapshots/api-surface.json
@@ -153,6 +153,7 @@
     "export * from './built/schedule.js'",
     "export * from './built/schema-endpoint-manager.js'",
     "export * from './built/schema-feature.js'",
+    "export * from './built/segment-contract/index.js'",
     "export * from './built/skill.js'",
     "export * from './built/tool.js'",
     "export * from './command.js'",


### PR DESCRIPTION
## Summary
- Add `segment-contract` module (text/mention Zod, `assertCanonicalSegments`, `segmentsForImDelivery`, MediaRef placeholder).
- Sandbox adapter: `segment-mapper` inbound/outbound text + mention; golden contract tests.
- Console client types + Sandbox UI render/send canonical `mention`.
- Add `pnpm check:segments` with pending whitelist (only sandbox required).

## Test plan
- [x] `pnpm vitest run packages/im/core/tests/segment-contract.test.ts`
- [x] `pnpm vitest run plugins/adapters/sandbox/tests/segment-contract.test.ts`
- [x] `pnpm check:segments`

Closes #550

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a canonical Segment contract for `text` and `mention` across core, Console, and Sandbox to unify message shape and enable validation. Normalizes legacy `at` to `mention`, filters non-IM segments on delivery, and adds a harness/test to keep adapters consistent. Fulfills #550.

- New Features
  - Core (`@zhin.js/core`)
    - New `segment-contract` module with Zod schemas, `isCanonicalSegment`/`assertCanonicalSegments`, and `segmentsForImDelivery`.
    - `segment.mention(target, name?)` helper; contract re-exported from core index.
  - Sandbox adapter
    - `segment-mapper` converts inbound/outbound `at` ↔ canonical `mention`; keeps `mention` on the wire.
    - `sandbox-ws` canonicalizes `$content`/`$raw`; UI renders/sends canonical `mention`.
  - Console client
    - Types now include `mention`, `platform?: Record<string, unknown>`, and `data: Record<string, unknown>`.
  - Tests & tooling
    - Golden contract tests for core and Sandbox; round-trip helper.
    - New `pnpm check:segments` added to `check:all` with a pending adapter whitelist.
  - Dependencies
    - Adds `zod`.

- Migration
  - Prefer `mention` over `at`; use `segment.mention(target, name?)` when composing content.
  - Adapters should add `src/segment-mapper.ts` and a `segment-contract.test.ts` (only `sandbox` is required now).
  - For outbound content, use `segmentsForImDelivery` to drop AI-only/unsupported types.

<sup>Written for commit 08a5c5d925875a6335dc70266cc4a13c98a1c844. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zhinjs/zhin/pull/559?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

