### PR TITLE
feat(segment): image MediaRef — ICQQ + Console (#551)

### DIFF
--- a/packages/console/client/client/mediaSrc.ts
+++ b/packages/console/client/client/mediaSrc.ts
@@ -43,9 +43,14 @@ export function resolveMediaSrc(
   return `data:${defaultMime};base64,${b64}`
 }
 
-/** 从 segment.data 取常见媒体字段 */
+/** 从 segment.data 取常见媒体字段（优先 canonical MediaRef） */
 export function pickMediaRawUrl(data: Record<string, unknown> | undefined): string | undefined {
   if (!data) return undefined
+  const media = data.media
+  if (media && typeof media === 'object' && media !== null) {
+    const value = (media as { value?: unknown }).value
+    if (typeof value === 'string' && value.trim()) return value.trim()
+  }
   const v = data.url ?? data.file ?? data.src ?? data.href
   return typeof v === 'string' && v.trim() ? v.trim() : undefined
 }

--- a/packages/im/core/src/built/segment-contract/assert.ts
+++ b/packages/im/core/src/built/segment-contract/assert.ts
@@ -1,7 +1,7 @@
 import type { Segment } from './types.js';
 import { canonicalSegmentSchema } from './schema.js';
 
-const STRICT_CANONICAL_TYPES = new Set(['text', 'mention']);
+const STRICT_CANONICAL_TYPES = new Set(['text', 'mention', 'image']);
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);

--- a/packages/im/core/src/built/segment-contract/image.ts
+++ b/packages/im/core/src/built/segment-contract/image.ts
@@ -1,0 +1,15 @@
+import type { MediaRef, Segment } from './types.js';
+
+export function createImageSegment(
+  media: MediaRef,
+  options?: { alt?: string; platform?: Record<string, unknown> },
+): Segment {
+  return {
+    type: 'image',
+    data: {
+      media,
+      ...(options?.alt ? { alt: options.alt } : {}),
+    },
+    ...(options?.platform ? { platform: options.platform } : {}),
+  };
+}

--- a/packages/im/core/src/built/segment-contract/index.ts
+++ b/packages/im/core/src/built/segment-contract/index.ts
@@ -4,14 +4,18 @@ export type {
   MediaRef,
   TextSegment,
   MentionSegment,
+  ImageSegment,
   MessageSegment,
 } from './types.js';
 export {
   mediaRefSchema,
   textSegmentSchema,
   mentionSegmentSchema,
+  imageSegmentSchema,
   canonicalSegmentSchema,
   segmentArraySchema,
 } from './schema.js';
 export { assertCanonicalSegments, isCanonicalSegment } from './assert.js';
 export { segmentsForImDelivery } from './delivery.js';
+export { isMediaRef, mediaRefFromLegacyData, mediaRefToLegacyFields } from './media.js';
+export { createImageSegment } from './image.js';

--- a/packages/im/core/src/built/segment-contract/media.ts
+++ b/packages/im/core/src/built/segment-contract/media.ts
@@ -1,0 +1,52 @@
+import type { MediaRef } from './types.js';
+import { mediaRefSchema } from './schema.js';
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+export function isMediaRef(value: unknown): value is MediaRef {
+  return mediaRefSchema.safeParse(value).success;
+}
+
+/** legacy url/file/src/base64 → MediaRef */
+export function mediaRefFromLegacyData(data: Record<string, unknown>): MediaRef | undefined {
+  if (isMediaRef(data.media)) {
+    return data.media;
+  }
+
+  const mimeType = typeof data.mime_type === 'string' ? data.mime_type : undefined;
+
+  const base64 =
+    typeof data.base64 === 'string' && data.base64.trim()
+      ? data.base64.trim()
+      : typeof data.data === 'string' && data.data.trim() && !String(data.data).startsWith('http')
+        ? data.data.trim()
+        : undefined;
+  if (base64) {
+    return { kind: 'base64', value: base64, ...(mimeType ? { mime_type: mimeType } : {}) };
+  }
+
+  const raw = [data.url, data.file, data.src, data.href]
+    .find((v) => typeof v === 'string' && v.trim());
+  if (!raw) return undefined;
+
+  const value = raw.trim();
+  if (value.startsWith('base64://')) {
+    return { kind: 'base64', value: value.slice('base64://'.length), ...(mimeType ? { mime_type: mimeType } : {}) };
+  }
+  if (value.startsWith('http://') || value.startsWith('https://')) {
+    return { kind: 'url', value, ...(mimeType ? { mime_type: mimeType } : {}) };
+  }
+  if (value.startsWith('/') || /^[a-zA-Z]:[\\/]/.test(value)) {
+    return { kind: 'path', value, ...(mimeType ? { mime_type: mimeType } : {}) };
+  }
+  return { kind: 'url', value, ...(mimeType ? { mime_type: mimeType } : {}) };
+}
+
+export function mediaRefToLegacyFields(media: MediaRef): { url?: string; file?: string } {
+  if (media.kind === 'url') return { url: media.value, file: media.value };
+  if (media.kind === 'path') return { file: media.value, url: media.value };
+  const encoded = media.value.startsWith('base64://') ? media.value : `base64://${media.value}`;
+  return { file: encoded, url: encoded };
+}

--- a/packages/im/core/src/built/segment-contract/schema.ts
+++ b/packages/im/core/src/built/segment-contract/schema.ts
@@ -23,10 +23,20 @@ export const mentionSegmentSchema = z.object({
   platform: z.record(z.string(), z.unknown()).optional(),
 });
 
+export const imageSegmentSchema = z.object({
+  type: z.literal('image'),
+  data: z.object({
+    media: mediaRefSchema,
+    alt: z.string().optional(),
+  }),
+  platform: z.record(z.string(), z.unknown()).optional(),
+});
+
 /** 当前已严格校验的 canonical 段（其余 type 由 assert 宽松接受） */
 export const canonicalSegmentSchema = z.discriminatedUnion('type', [
   textSegmentSchema,
   mentionSegmentSchema,
+  imageSegmentSchema,
 ]);
 
 export const segmentArraySchema = z.array(canonicalSegmentSchema);

--- a/packages/im/core/src/built/segment-contract/types.ts
+++ b/packages/im/core/src/built/segment-contract/types.ts
@@ -26,8 +26,13 @@ export interface MentionSegment extends SegmentBase {
   data: { target: string; name?: string };
 }
 
+export interface ImageSegment extends SegmentBase {
+  type: 'image';
+  data: { media: MediaRef; alt?: string };
+}
+
 /** 规范态 segment（#550 起：text + mention 严格校验；其余 type 宽松透传） */
-export type Segment = TextSegment | MentionSegment | SegmentBase;
+export type Segment = TextSegment | MentionSegment | ImageSegment | SegmentBase;
 
 /** @deprecated 使用 Segment；保留别名供 Console / adapter 渐进迁移 */
 export type MessageSegment = Segment;

--- a/packages/im/core/src/utils.ts
+++ b/packages/im/core/src/utils.ts
@@ -38,6 +38,7 @@ import { TtsSegment } from "./built/rich-segments/tts-segment.js";
 import { KeyboardSegment } from "./built/interactive-segments/keyboard-segment.js";
 import { ButtonSpec, normalizeKeyboardRows, type KeyboardRowInput } from "./built/interactive-segments/button-spec.js";
 import type { ButtonData, KeyboardFallback, KeyboardSegmentData } from "./built/interactive-segments/types.js";
+import type { MediaRef } from "./built/segment-contract/types.js";
 
 /**
  * 组合中间件,洋葱模型
@@ -103,6 +104,9 @@ export namespace segment {
   }
   export function mention(target: string, name?: string) {
     return segment("mention", name ? { target, name } : { target });
+  }
+  export function image(media: MediaRef, alt?: string) {
+    return segment("image", alt ? { media, alt } : { media });
   }
   export function face(id: string, text?: string) {
     return segment("face", { id, text });

--- a/packages/im/core/tests/segment-contract.test.ts
+++ b/packages/im/core/tests/segment-contract.test.ts
@@ -26,8 +26,19 @@ describe('segment-contract schema', () => {
     expect(isCanonicalSegment(seg)).toBe(false);
   });
 
-  it('loosely accepts non-strict types with valid shape', () => {
-    const seg = { type: 'image', data: { url: 'https://cdn.example/a.jpg' } };
+  it('rejects image without media', () => {
+    const seg = { type: 'image', data: { url: 'https://x/y.jpg' } };
+    expect(isCanonicalSegment(seg)).toBe(false);
+  });
+
+  it('accepts image segment with MediaRef', () => {
+    const seg = {
+      type: 'image',
+      data: {
+        media: { kind: 'url', value: 'https://cdn.example/a.jpg', mime_type: 'image/jpeg' },
+        alt: 'pic',
+      },
+    };
     expect(isCanonicalSegment(seg)).toBe(true);
   });
 });
@@ -82,7 +93,7 @@ describe('segmentsForImDelivery', () => {
     const cases: Array<{ type: string; data: Record<string, unknown> }> = [
       { type: 'text', data: { text: 'x' } },
       { type: 'mention', data: { target: 'all' } },
-      { type: 'image', data: { url: 'https://x/y.jpg' } },
+      { type: 'image', data: { media: { kind: 'url', value: 'https://x/y.jpg' } } },
       { type: 'markdown', data: { content: '# hi' } },
       { type: 'keyboard', data: { rows: [] } },
     ];

--- a/plugins/adapters/icqq/src/cq-message.ts
+++ b/plugins/adapters/icqq/src/cq-message.ts
@@ -98,6 +98,11 @@ export function toCqString(content: SendContent): string {
         case "face":
           return `[face:${data.id}]`;
         case "image": {
+          const media = data.media as { kind?: string; value?: string } | undefined;
+          if (media?.value) {
+            if (media.kind === "base64") return `[image:base64://${media.value}]`;
+            return `[image:${media.value}]`;
+          }
           const b64 =
             typeof data.base64 === "string"
               ? data.base64

--- a/plugins/adapters/icqq/src/icqq-inbound.ts
+++ b/plugins/adapters/icqq/src/icqq-inbound.ts
@@ -3,6 +3,7 @@
  */
 import { Message, type MessageSegment, type QuotedMessagePayload } from "zhin.js";
 import { parseCqMessage } from "./cq-message.js";
+import { toCanonicalSegments } from "./segment-mapper.js";
 import { extractForwardResidFromJsonElement } from "./forward-msg.js";
 import type { GroupRole } from "./types.js";
 
@@ -619,7 +620,7 @@ export function resolveInboundContent(
   } else {
     content = [{ type: "text", data: { text: "" } }];
   }
-  return mergeReplyFromSource(content, data);
+  return toCanonicalSegments(mergeReplyFromSource(content, data));
 }
 
 export function normalizeIcqqInboundMessage(

--- a/plugins/adapters/icqq/src/segment-mapper.ts
+++ b/plugins/adapters/icqq/src/segment-mapper.ts
@@ -1,0 +1,99 @@
+import type { MessageSegment, Segment } from '@zhin.js/core';
+import {
+  createImageSegment,
+  isMediaRef,
+  mediaRefFromLegacyData,
+  mediaRefToLegacyFields,
+} from '@zhin.js/core';
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function readMentionTarget(data: Record<string, unknown>): string {
+  const raw = data.target ?? data.user_id ?? data.qq ?? data.id;
+  if (raw === 'all') return 'all';
+  return raw != null ? String(raw) : '';
+}
+
+function normalizeMention(seg: MessageSegment): Segment {
+  const data = seg.data as Record<string, unknown>;
+  const target = readMentionTarget(data);
+  const name = typeof data.name === 'string' && data.name ? data.name : undefined;
+  return {
+    type: 'mention',
+    data: name ? { target, name } : { target },
+    ...(seg.platform ? { platform: seg.platform } : {}),
+  };
+}
+
+function normalizeImage(seg: MessageSegment): Segment {
+  const data = seg.data as Record<string, unknown>;
+  if (isMediaRef(data.media)) {
+    return {
+      type: 'image',
+      data: {
+        media: data.media,
+        ...(typeof data.alt === 'string' ? { alt: data.alt } : {}),
+      },
+      ...(seg.platform ? { platform: seg.platform } : {}),
+    };
+  }
+  const media = mediaRefFromLegacyData(data);
+  if (!media) return seg as Segment;
+
+  const platform: Record<string, unknown> = { ...(seg.platform ?? {}) };
+  for (const key of ['url', 'file', 'src'] as const) {
+    if (typeof data[key] === 'string' && data[key]) platform[key] = data[key];
+  }
+
+  return createImageSegment(media, {
+    alt: typeof data.alt === 'string' ? data.alt : undefined,
+    platform: Object.keys(platform).length ? platform : undefined,
+  });
+}
+
+function normalizeSegment(seg: MessageSegment): Segment {
+  if (seg.type === 'at' || seg.type === 'mention') return normalizeMention(seg);
+  if (seg.type === 'image') return normalizeImage(seg);
+  return seg as Segment;
+}
+
+/** 入站 legacy / CQ 段 → canonical Segment[] */
+export function toCanonicalSegments(content: readonly MessageSegment[]): Segment[] {
+  return content.map((seg) => {
+    if (typeof seg === 'string') return { type: 'text', data: { text: seg } };
+    return normalizeSegment(seg);
+  });
+}
+
+/** 出站：canonical → ICQQ wire（CQ 构建仍读 url/file + media） */
+export function fromCanonicalSegments(segments: readonly Segment[]): MessageSegment[] {
+  return segments.map((seg) => {
+    if (seg.type === 'image' && isRecord(seg.data) && seg.data.media) {
+      const media = seg.data.media as import('@zhin.js/core').MediaRef;
+      const legacy = mediaRefToLegacyFields(media);
+      return {
+        type: 'image',
+        data: {
+          ...legacy,
+          media,
+          ...(typeof seg.data.alt === 'string' ? { alt: seg.data.alt } : {}),
+        },
+        ...(seg.platform ? { platform: seg.platform } : {}),
+      };
+    }
+    if (seg.type === 'mention') {
+      const data = seg.data as { target: string; name?: string };
+      return {
+        type: 'at',
+        data: {
+          qq: data.target,
+          ...(data.name ? { name: data.name } : {}),
+        },
+        ...(seg.platform ? { platform: seg.platform } : {}),
+      };
+    }
+    return seg as MessageSegment;
+  });
+}

--- a/plugins/adapters/icqq/tests/segment-contract.test.ts
+++ b/plugins/adapters/icqq/tests/segment-contract.test.ts
@@ -1,0 +1,35 @@
+/**
+ * icqq segment contract — image MediaRef round-trip
+ */
+import { describe, it } from 'vitest';
+import { fromCanonicalSegments, toCanonicalSegments } from '../src/segment-mapper.js';
+import { assertSegmentRoundTrip } from '../../../../packages/im/core/tests/helpers/segment-adapter-contract.js';
+
+const mapper = { toCanonicalSegments, fromCanonicalSegments };
+
+describe('icqq segment contract', () => {
+  it('normalizes legacy CQ image url to MediaRef', () => {
+    assertSegmentRoundTrip(
+      mapper,
+      [{ type: 'image', data: { url: 'https://cdn.example/cat.jpg', file: 'https://cdn.example/cat.jpg' } }],
+      [{
+        type: 'image',
+        data: {
+          media: { kind: 'url', value: 'https://cdn.example/cat.jpg' },
+        },
+        platform: { url: 'https://cdn.example/cat.jpg', file: 'https://cdn.example/cat.jpg' },
+      }],
+    );
+  });
+
+  it('round-trips canonical image MediaRef', () => {
+    const canonical = [{
+      type: 'image' as const,
+      data: {
+        media: { kind: 'url' as const, value: 'https://img.test/a.png', mime_type: 'image/png' },
+        alt: 'a',
+      },
+    }];
+    assertSegmentRoundTrip(mapper, canonical, canonical);
+  });
+});

--- a/scripts/check-segment-adapters.mjs
+++ b/scripts/check-segment-adapters.mjs
@@ -11,7 +11,7 @@ const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..'
 const adaptersDir = path.join(repoRoot, 'plugins/adapters');
 
 /** 必须含 segment-mapper + segment-contract.test.ts */
-const REQUIRED_ADAPTERS = new Set(['sandbox']);
+const REQUIRED_ADAPTERS = new Set(['sandbox', 'icqq']);
 
 /** 尚未迁移 segment-mapper 的 adapter（不报错） */
 const PENDING_ADAPTERS = new Set([
@@ -19,7 +19,6 @@ const PENDING_ADAPTERS = new Set([
   'discord',
   'email',
   'github',
-  'icqq',
   'kook',
   'lark',
   'line',


### PR DESCRIPTION
## Summary
- Strict `image` segment schema with required `data.media` (MediaRef).
- ICQQ `segment-mapper` + inbound normalize; CQ `toCqString` reads canonical media.
- Console `pickMediaRawUrl` prefers `data.media.value`.
- `createImageSegment` / `segment.image()` in core; `check:segments` requires icqq.

## Test plan
- [x] `pnpm vitest run packages/im/core/tests/segment-contract.test.ts`
- [x] `pnpm vitest run plugins/adapters/icqq/tests/segment-contract.test.ts`
- [x] `pnpm check:segments`

Closes #551

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardizes image segments around a required MediaRef and wires up ICQQ inbound/outbound mapping, with Console preferring canonical media. This makes image handling consistent and reduces reliance on legacy url/file fields.

- New Features
  - Core (`@zhin.js/core`): strict `image` schema requiring `data.media`; added `createImageSegment`, `segment.image()`, and `isMediaRef`/`mediaRefFromLegacyData`/`mediaRefToLegacyFields`; `assertCanonicalSegments` now treats `image` as strict.
  - ICQQ: added `segment-mapper` to normalize inbound CQ image fields to `MediaRef`, and CQ output now reads canonical `data.media` in `toCqString`; added round‑trip tests; `check:segments` now requires `icqq`.
  - Console: `pickMediaRawUrl` now prefers `data.media.value`.

- Migration
  - Create images via `segment.image(media)` or `createImageSegment(media, { alt })`; do not send `image` segments without `data.media`.
  - If you call `assertCanonicalSegments`, update any legacy `image` segments to include `MediaRef` or use `mediaRefFromLegacyData` to migrate.

<sup>Written for commit 623ea6f279468356b9936581914260f23bd1d44d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zhinjs/zhin/pull/560?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

