### PR TITLE
feat(segment): ICQQ reply/forward + Console (#552)

### DIFF
--- a/packages/console/client/client/types.ts
+++ b/packages/console/client/client/types.ts
@@ -1,7 +1,7 @@
 // 消息段类型定义 - 客户端版本（对齐 core Segment SSOT）
 export interface MessageSegment {
   /** record：如 ICQQ 语音等，展示时按音频处理 */
-  type: 'text' | 'mention' | 'at' | 'image' | 'face' | 'video' | 'audio' | 'record' | 'file' | 'reply' | 'keyboard' | 'action' | string
+  type: 'text' | 'mention' | 'at' | 'image' | 'face' | 'video' | 'audio' | 'record' | 'file' | 'reply' | 'forward' | 'keyboard' | 'action' | string
   data: Record<string, unknown>
   platform?: Record<string, unknown>
 }

--- a/packages/im/core/src/built/segment-contract/assert.ts
+++ b/packages/im/core/src/built/segment-contract/assert.ts
@@ -1,7 +1,7 @@
 import type { Segment } from './types.js';
 import { canonicalSegmentSchema } from './schema.js';
 
-const STRICT_CANONICAL_TYPES = new Set(['text', 'mention', 'image']);
+const STRICT_CANONICAL_TYPES = new Set(['text', 'mention', 'image', 'reply', 'forward']);
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);

--- a/packages/im/core/src/built/segment-contract/index.ts
+++ b/packages/im/core/src/built/segment-contract/index.ts
@@ -5,6 +5,8 @@ export type {
   TextSegment,
   MentionSegment,
   ImageSegment,
+  ReplySegment,
+  ForwardSegment,
   MessageSegment,
 } from './types.js';
 export {
@@ -12,6 +14,8 @@ export {
   textSegmentSchema,
   mentionSegmentSchema,
   imageSegmentSchema,
+  replySegmentSchema,
+  forwardSegmentSchema,
   canonicalSegmentSchema,
   segmentArraySchema,
 } from './schema.js';

--- a/packages/im/core/src/built/segment-contract/schema.ts
+++ b/packages/im/core/src/built/segment-contract/schema.ts
@@ -32,11 +32,31 @@ export const imageSegmentSchema = z.object({
   platform: z.record(z.string(), z.unknown()).optional(),
 });
 
+export const replySegmentSchema = z.object({
+  type: z.literal('reply'),
+  data: z.object({
+    message_id: z.string(),
+  }),
+  platform: z.record(z.string(), z.unknown()).optional(),
+});
+
+export const forwardSegmentSchema = z.object({
+  type: z.literal('forward'),
+  data: z.object({
+    forward_id: z.string(),
+    title: z.string().optional(),
+    messages: z.array(z.array(z.record(z.string(), z.unknown()))).optional(),
+  }),
+  platform: z.record(z.string(), z.unknown()).optional(),
+});
+
 /** 当前已严格校验的 canonical 段（其余 type 由 assert 宽松接受） */
 export const canonicalSegmentSchema = z.discriminatedUnion('type', [
   textSegmentSchema,
   mentionSegmentSchema,
   imageSegmentSchema,
+  replySegmentSchema,
+  forwardSegmentSchema,
 ]);
 
 export const segmentArraySchema = z.array(canonicalSegmentSchema);

--- a/packages/im/core/src/built/segment-contract/types.ts
+++ b/packages/im/core/src/built/segment-contract/types.ts
@@ -31,8 +31,28 @@ export interface ImageSegment extends SegmentBase {
   data: { media: MediaRef; alt?: string };
 }
 
-/** 规范态 segment（#550 起：text + mention 严格校验；其余 type 宽松透传） */
-export type Segment = TextSegment | MentionSegment | ImageSegment | SegmentBase;
+export interface ReplySegment extends SegmentBase {
+  type: 'reply';
+  data: { message_id: string };
+}
+
+export interface ForwardSegment extends SegmentBase {
+  type: 'forward';
+  data: {
+    forward_id: string;
+    title?: string;
+    messages?: Segment[][];
+  };
+}
+
+/** 规范态 segment（严格校验 text / mention / image / reply / forward） */
+export type Segment =
+  | TextSegment
+  | MentionSegment
+  | ImageSegment
+  | ReplySegment
+  | ForwardSegment
+  | SegmentBase;
 
 /** @deprecated 使用 Segment；保留别名供 Console / adapter 渐进迁移 */
 export type MessageSegment = Segment;

--- a/packages/im/core/src/message-quote.ts
+++ b/packages/im/core/src/message-quote.ts
@@ -73,14 +73,14 @@ export function syncQuoteId(message: Message<any>): void {
   if (id) message.$quote_id = id;
 }
 
-/** 将 reply 段的 id / message_id 与 $quote_id 对齐 */
+/** 将 reply 段与 $quote_id 对齐（canonical 仅保留 message_id） */
 export function alignReplySegments(content: MessageElement[], quoteId?: string): void {
   const id = quoteId ?? quoteIdFromContent(content);
   if (!id) return;
   for (const seg of content) {
     if (seg.type !== 'reply' || !seg.data || typeof seg.data !== 'object') continue;
     const data = seg.data as Record<string, unknown>;
-    data.id = id;
     data.message_id = id;
+    delete data.id;
   }
 }

--- a/packages/im/core/tests/message-quote.test.ts
+++ b/packages/im/core/tests/message-quote.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { Message } from '../src/message.js';
-import { quoteIdFromContent, quoteIdFromRaw, syncQuoteId } from '../src/message-quote.js';
+import { quoteIdFromContent, quoteIdFromRaw, syncQuoteId, alignReplySegments } from '../src/message-quote.js';
 import {
   buildUserTurnWithQuoteContext,
   CURRENT_USER_MESSAGE_MARKER,
@@ -61,7 +61,7 @@ describe('Message.quote helpers', () => {
         $id: '1',
         $adapter: 'icqq',
         $endpoint: 'b',
-        $content: [{ type: 'reply', data: { id: 'q1' } }],
+        $content: [{ type: 'reply', data: { message_id: 'q1' } }],
         $sender: { id: 'u' },
         $reply: async () => '1',
         $recall: async () => {},
@@ -72,6 +72,12 @@ describe('Message.quote helpers', () => {
     );
     Message.syncQuoteId(msg);
     expect(msg.$quote_id).toBe('q1');
+  });
+
+  it('alignReplySegments writes message_id only', () => {
+    const content = [{ type: 'reply', data: { id: 'old' } }, { type: 'text', data: { text: 'x' } }] as import('../src/types.js').MessageElement[];
+    alignReplySegments(content, 'new-id');
+    expect(content[0]).toEqual({ type: 'reply', data: { message_id: 'new-id' } });
   });
 });
 

--- a/packages/im/core/tests/segment-contract.test.ts
+++ b/packages/im/core/tests/segment-contract.test.ts
@@ -41,6 +41,21 @@ describe('segment-contract schema', () => {
     };
     expect(isCanonicalSegment(seg)).toBe(true);
   });
+
+  it('accepts reply with message_id', () => {
+    const seg = { type: 'reply', data: { message_id: '123' } };
+    expect(isCanonicalSegment(seg)).toBe(true);
+  });
+
+  it('rejects reply with only legacy id', () => {
+    const seg = { type: 'reply', data: { id: '123' } };
+    expect(isCanonicalSegment(seg)).toBe(false);
+  });
+
+  it('accepts forward with forward_id', () => {
+    const seg = { type: 'forward', data: { forward_id: 'resid-1', title: '群聊' } };
+    expect(isCanonicalSegment(seg)).toBe(true);
+  });
 });
 
 describe('assertCanonicalSegments', () => {

--- a/plugins/adapters/icqq/src/cq-message.ts
+++ b/plugins/adapters/icqq/src/cq-message.ts
@@ -35,7 +35,7 @@ function pushCqSegment(segments: MessageSegment[], type: string, arg: string): v
       segments.push({ type: "video", data: { file: arg } });
       break;
     case "reply":
-      segments.push({ type: "reply", data: { id: arg } });
+      segments.push({ type: "reply", data: { message_id: arg } });
       break;
     default:
       segments.push({ type, data: { text: `[${type}:${arg}]` } });
@@ -135,7 +135,7 @@ export function toCqString(content: SendContent): string {
           return `[video:${data.file || data.url}]`;
         }
         case "reply":
-          return `[reply:${data.id}]`;
+          return `[reply:${data.message_id ?? data.id}]`;
         default:
           return segment.toString(seg);
       }

--- a/plugins/adapters/icqq/src/icqq-inbound.ts
+++ b/plugins/adapters/icqq/src/icqq-inbound.ts
@@ -587,7 +587,7 @@ function mergeReplyFromRawMessage(
   const quoteFromRaw = Message.quoteIdFromContent(fromRaw);
   if (!quoteFromRaw) return content;
   return [
-    { type: "reply", data: { id: quoteFromRaw, message_id: quoteFromRaw } },
+    { type: "reply", data: { message_id: quoteFromRaw } },
     ...content.filter((s) => s.type !== "reply"),
   ];
 }
@@ -602,7 +602,7 @@ function mergeReplyFromSource(
     resolveQuoteIdFromIcqqSource(findIcqqNestedMessageSource(data));
   if (!quoteId) return content;
   return [
-    { type: "reply", data: { id: quoteId, message_id: quoteId } },
+    { type: "reply", data: { message_id: quoteId } },
     ...content.filter((s) => s.type !== "reply"),
   ];
 }

--- a/plugins/adapters/icqq/src/segment-mapper.ts
+++ b/plugins/adapters/icqq/src/segment-mapper.ts
@@ -53,9 +53,41 @@ function normalizeImage(seg: MessageSegment): Segment {
   });
 }
 
+function normalizeReply(seg: MessageSegment): Segment {
+  const data = seg.data as Record<string, unknown>;
+  const messageId = String(data.message_id ?? data.id ?? '').trim();
+  if (!messageId) return seg as Segment;
+  return { type: 'reply', data: { message_id: messageId } };
+}
+
+function normalizeForward(seg: MessageSegment): Segment {
+  const data = seg.data as Record<string, unknown>;
+  const forwardId = String(
+    data.forward_id ?? data.id ?? data.resid ?? data.res_id ?? '',
+  ).trim();
+  if (!forwardId) return seg as Segment;
+
+  const platform: Record<string, unknown> = { ...(seg.platform ?? {}) };
+  for (const key of ['resid', 'res_id'] as const) {
+    if (typeof data[key] === 'string' && data[key]) platform[key] = data[key];
+  }
+
+  return {
+    type: 'forward',
+    data: {
+      forward_id: forwardId,
+      ...(typeof data.title === 'string' && data.title ? { title: data.title } : {}),
+      ...(Array.isArray(data.messages) ? { messages: data.messages as Segment[][] } : {}),
+    },
+    ...(Object.keys(platform).length ? { platform } : {}),
+  };
+}
+
 function normalizeSegment(seg: MessageSegment): Segment {
   if (seg.type === 'at' || seg.type === 'mention') return normalizeMention(seg);
   if (seg.type === 'image') return normalizeImage(seg);
+  if (seg.type === 'reply') return normalizeReply(seg);
+  if (seg.type === 'forward') return normalizeForward(seg);
   return seg as Segment;
 }
 
@@ -92,6 +124,34 @@ export function fromCanonicalSegments(segments: readonly Segment[]): MessageSegm
           ...(data.name ? { name: data.name } : {}),
         },
         ...(seg.platform ? { platform: seg.platform } : {}),
+      };
+    }
+    if (seg.type === 'reply') {
+      const messageId = String((seg.data as { message_id: string }).message_id);
+      return {
+        type: 'reply',
+        data: { id: messageId, message_id: messageId },
+        ...(seg.platform ? { platform: seg.platform } : {}),
+      };
+    }
+    if (seg.type === 'forward') {
+      const data = seg.data as {
+        forward_id: string;
+        title?: string;
+        messages?: unknown;
+      };
+      const platform = { ...(seg.platform ?? {}) };
+      const resid = platform.resid ?? data.forward_id;
+      return {
+        type: 'forward',
+        data: {
+          id: data.forward_id,
+          forward_id: data.forward_id,
+          resid,
+          ...(data.title ? { title: data.title } : {}),
+          ...(data.messages ? { messages: data.messages } : {}),
+        },
+        platform: { ...platform, resid },
       };
     }
     return seg as MessageSegment;

--- a/plugins/adapters/icqq/tests/segment-contract.test.ts
+++ b/plugins/adapters/icqq/tests/segment-contract.test.ts
@@ -32,4 +32,24 @@ describe('icqq segment contract', () => {
     }];
     assertSegmentRoundTrip(mapper, canonical, canonical);
   });
+
+  it('normalizes legacy reply id to message_id', () => {
+    assertSegmentRoundTrip(
+      mapper,
+      [{ type: 'reply', data: { id: 'q-1' } }],
+      [{ type: 'reply', data: { message_id: 'q-1' } }],
+    );
+  });
+
+  it('normalizes legacy forward id/resid to forward_id', () => {
+    assertSegmentRoundTrip(
+      mapper,
+      [{ type: 'forward', data: { id: 'fwd-9', resid: 'fwd-9', title: '群聊' } }],
+      [{
+        type: 'forward',
+        data: { forward_id: 'fwd-9', title: '群聊' },
+        platform: { resid: 'fwd-9' },
+      }],
+    );
+  });
 });

--- a/plugins/adapters/sandbox/client/Sandbox.tsx
+++ b/plugins/adapters/sandbox/client/Sandbox.tsx
@@ -206,8 +206,37 @@ export default function Sandbox() {
                         />
                     )
                 }
-                case 'file':
-                    return <span key={index} className="inline-flex items-center px-1.5 py-0.5 rounded border text-xs mx-0.5">📎 {String(d.name || '文件')}</span>
+                case 'reply':
+                    return (
+                        <div key={index} className="mb-1 rounded-md border border-dashed px-2 py-1 text-xs opacity-90">
+                            ↩ 引用消息 #{String(d.message_id ?? d.id ?? '')}
+                        </div>
+                    )
+                case 'forward': {
+                    const messages = d.messages as Array<Array<{ type?: string; data?: Record<string, unknown> }>> | undefined
+                    const title = String(d.title ?? '聊天记录')
+                    return (
+                        <div key={index} className="my-1 rounded-md border bg-background/40 px-2 py-2 text-xs space-y-1">
+                            <div className="font-medium">📨 {title}</div>
+                            {Array.isArray(messages) && messages.length > 0 ? (
+                                <div className="space-y-1 pl-2 border-l-2 border-muted">
+                                    {messages.slice(0, 3).map((batch, bi) => (
+                                        <div key={bi} className="opacity-90">
+                                            {batch.map((s, si) => (
+                                                <span key={si}>
+                                                    {s.type === 'text' ? String(s.data?.text ?? '') : `[${s.type ?? 'seg'}]`}
+                                                </span>
+                                            ))}
+                                        </div>
+                                    ))}
+                                    {messages.length > 3 && <div className="opacity-60">…共 {messages.length} 条</div>}
+                                </div>
+                            ) : (
+                                <div className="opacity-70">[合并转发]</div>
+                            )}
+                        </div>
+                    )
+                }
                 case 'keyboard': {
                     const rows = (d.rows as Array<Array<{ label: string; payload: string; disabled?: boolean }>>) ?? []
                     return (


### PR DESCRIPTION
## Summary
- Strict `reply` (`message_id`) and `forward` (`forward_id`) segment schemas.
- ICQQ segment-mapper + inbound merge; CQ `[reply:id]` round-trip.
- `alignReplySegments` writes canonical `message_id` only.
- Console/Sandbox: reply bar + forward fold card.

## Test plan
- [x] segment-contract + message-quote + icqq contract tests

Closes #552

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds strict reply/forward segment schemas and ICQQ normalization, with Console UI for quotes and merged forwards. This standardizes on `message_id`/`forward_id` and preserves CQ round-trip behavior.

- **New Features**
  - Strict `reply` and `forward` schemas with canonical `message_id` and `forward_id`.
  - ICQQ mapper normalizes legacy `id`/`resid` to canonical and supports CQ `[reply:id]` round-trip.
  - `alignReplySegments` now writes `message_id` only.
  - Console/Sandbox renders a reply bar and a forward fold card.
  - Added tests for segment contract, message quote, and ICQQ mapping.

- **Migration**
  - Use `reply.data.message_id` instead of `reply.data.id`.
  - Use `forward.data.forward_id` instead of `forward.data.id`/`resid` (keep `resid` in `platform` if needed).
  - If you build segments manually, emit the canonical shapes; adapter fallbacks remain for compatibility.

<sup>Written for commit 8cbf5e78591acdbce954459bf360e902009dd21b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zhinjs/zhin/pull/561?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

