### PR TITLE
feat(segment): ICQQ face/dice/rps (#553)

### DIFF
--- a/packages/im/core/src/built/segment-contract/assert.ts
+++ b/packages/im/core/src/built/segment-contract/assert.ts
@@ -1,7 +1,9 @@
 import type { Segment } from './types.js';
 import { canonicalSegmentSchema } from './schema.js';
 
-const STRICT_CANONICAL_TYPES = new Set(['text', 'mention', 'image', 'reply', 'forward']);
+const STRICT_CANONICAL_TYPES = new Set([
+  'text', 'mention', 'image', 'reply', 'forward', 'face', 'dice', 'rps',
+]);
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);

--- a/packages/im/core/src/built/segment-contract/index.ts
+++ b/packages/im/core/src/built/segment-contract/index.ts
@@ -7,6 +7,9 @@ export type {
   ImageSegment,
   ReplySegment,
   ForwardSegment,
+  FaceSegment,
+  DiceSegment,
+  RpsSegment,
   MessageSegment,
 } from './types.js';
 export {
@@ -16,6 +19,9 @@ export {
   imageSegmentSchema,
   replySegmentSchema,
   forwardSegmentSchema,
+  faceSegmentSchema,
+  diceSegmentSchema,
+  rpsSegmentSchema,
   canonicalSegmentSchema,
   segmentArraySchema,
 } from './schema.js';

--- a/packages/im/core/src/built/segment-contract/schema.ts
+++ b/packages/im/core/src/built/segment-contract/schema.ts
@@ -50,6 +50,31 @@ export const forwardSegmentSchema = z.object({
   platform: z.record(z.string(), z.unknown()).optional(),
 });
 
+export const faceSegmentSchema = z.object({
+  type: z.literal('face'),
+  data: z.object({
+    id: z.union([z.string(), z.number()]),
+    name: z.string().optional(),
+  }),
+  platform: z.record(z.string(), z.unknown()).optional(),
+});
+
+export const diceSegmentSchema = z.object({
+  type: z.literal('dice'),
+  data: z.object({
+    result: z.number().optional(),
+  }),
+  platform: z.record(z.string(), z.unknown()).optional(),
+});
+
+export const rpsSegmentSchema = z.object({
+  type: z.literal('rps'),
+  data: z.object({
+    result: z.number().optional(),
+  }),
+  platform: z.record(z.string(), z.unknown()).optional(),
+});
+
 /** 当前已严格校验的 canonical 段（其余 type 由 assert 宽松接受） */
 export const canonicalSegmentSchema = z.discriminatedUnion('type', [
   textSegmentSchema,
@@ -57,6 +82,9 @@ export const canonicalSegmentSchema = z.discriminatedUnion('type', [
   imageSegmentSchema,
   replySegmentSchema,
   forwardSegmentSchema,
+  faceSegmentSchema,
+  diceSegmentSchema,
+  rpsSegmentSchema,
 ]);
 
 export const segmentArraySchema = z.array(canonicalSegmentSchema);

--- a/packages/im/core/src/built/segment-contract/types.ts
+++ b/packages/im/core/src/built/segment-contract/types.ts
@@ -45,13 +45,31 @@ export interface ForwardSegment extends SegmentBase {
   };
 }
 
-/** 规范态 segment（严格校验 text / mention / image / reply / forward） */
+export interface FaceSegment extends SegmentBase {
+  type: 'face';
+  data: { id: string | number; name?: string };
+}
+
+export interface DiceSegment extends SegmentBase {
+  type: 'dice';
+  data: { result?: number };
+}
+
+export interface RpsSegment extends SegmentBase {
+  type: 'rps';
+  data: { result?: number };
+}
+
+/** 规范态 segment（严格校验 text / mention / image / reply / forward / face / dice / rps） */
 export type Segment =
   | TextSegment
   | MentionSegment
   | ImageSegment
   | ReplySegment
   | ForwardSegment
+  | FaceSegment
+  | DiceSegment
+  | RpsSegment
   | SegmentBase;
 
 /** @deprecated 使用 Segment；保留别名供 Console / adapter 渐进迁移 */

--- a/packages/im/core/tests/segment-contract.test.ts
+++ b/packages/im/core/tests/segment-contract.test.ts
@@ -56,6 +56,12 @@ describe('segment-contract schema', () => {
     const seg = { type: 'forward', data: { forward_id: 'resid-1', title: '群聊' } };
     expect(isCanonicalSegment(seg)).toBe(true);
   });
+
+  it('accepts face and dice/rps', () => {
+    expect(isCanonicalSegment({ type: 'face', data: { id: 66, name: '笑哭' } })).toBe(true);
+    expect(isCanonicalSegment({ type: 'dice', data: {} })).toBe(true);
+    expect(isCanonicalSegment({ type: 'rps', data: { result: 2 } })).toBe(true);
+  });
 });
 
 describe('assertCanonicalSegments', () => {

--- a/plugins/adapters/icqq/src/segment-mapper.ts
+++ b/plugins/adapters/icqq/src/segment-mapper.ts
@@ -83,11 +83,45 @@ function normalizeForward(seg: MessageSegment): Segment {
   };
 }
 
+function normalizeFace(seg: MessageSegment): Segment {
+  const data = seg.data as Record<string, unknown>;
+  const id = data.id ?? data.face_id;
+  if (id == null || id === '') return seg as Segment;
+  const name =
+    typeof data.name === 'string' && data.name
+      ? data.name
+      : typeof data.text === 'string' && data.text
+        ? data.text
+        : undefined;
+  return {
+    type: 'face',
+    data: {
+      id: typeof id === 'number' ? id : String(id),
+      ...(name ? { name } : {}),
+    },
+    ...(seg.platform ? { platform: seg.platform } : {}),
+  };
+}
+
+function normalizeGame(seg: MessageSegment, type: 'dice' | 'rps'): Segment {
+  const data = seg.data as Record<string, unknown>;
+  const result = typeof data.result === 'number' ? data.result : undefined;
+  return {
+    type,
+    data: result != null ? { result } : {},
+    ...(seg.platform ? { platform: seg.platform } : {}),
+  };
+}
+
 function normalizeSegment(seg: MessageSegment): Segment {
   if (seg.type === 'at' || seg.type === 'mention') return normalizeMention(seg);
   if (seg.type === 'image') return normalizeImage(seg);
   if (seg.type === 'reply') return normalizeReply(seg);
   if (seg.type === 'forward') return normalizeForward(seg);
+  if (seg.type === 'face' || seg.type === 'sticker' || seg.type === 'emoji') {
+    return normalizeFace(seg);
+  }
+  if (seg.type === 'dice' || seg.type === 'rps') return normalizeGame(seg, seg.type);
   return seg as Segment;
 }
 

--- a/plugins/adapters/icqq/tests/segment-contract.test.ts
+++ b/plugins/adapters/icqq/tests/segment-contract.test.ts
@@ -52,4 +52,25 @@ describe('icqq segment contract', () => {
       }],
     );
   });
+
+  it('normalizes sticker/emoji to face', () => {
+    assertSegmentRoundTrip(
+      mapper,
+      [{ type: 'sticker', data: { id: '66', text: '笑哭' } }],
+      [{ type: 'face', data: { id: '66', name: '笑哭' } }],
+    );
+  });
+
+  it('round-trips mention via CQ at wire', () => {
+    assertSegmentRoundTrip(
+      mapper,
+      [{ type: 'at', data: { qq: '10001', name: 'Alice' } }],
+      [{ type: 'mention', data: { target: '10001', name: 'Alice' } }],
+    );
+  });
+
+  it('round-trips dice and rps', () => {
+    assertSegmentRoundTrip(mapper, [{ type: 'dice', data: {} }], [{ type: 'dice', data: {} }]);
+    assertSegmentRoundTrip(mapper, [{ type: 'rps', data: { result: 1 } }], [{ type: 'rps', data: { result: 1 } }]);
+  });
 });

--- a/plugins/adapters/sandbox/client/Sandbox.tsx
+++ b/plugins/adapters/sandbox/client/Sandbox.tsx
@@ -165,7 +165,11 @@ export default function Sandbox() {
                 case 'at':
                     return <span key={index} className="inline-flex items-center px-1.5 py-0.5 rounded bg-accent text-accent-foreground text-xs mx-0.5">@{String(d.name ?? d.target ?? d.qq ?? '')}</span>
                 case 'face':
-                    return <img key={index} src={`https://face.viki.moe/apng/${d.id}.png`} alt="" className="w-6 h-6 inline-block align-middle mx-0.5" />
+                    return <img key={index} src={`https://face.viki.moe/apng/${d.id}.png`} alt={String(d.name ?? '')} className="w-6 h-6 inline-block align-middle mx-0.5" title={String(d.name ?? d.id ?? '')} />
+                case 'dice':
+                    return <span key={index} className="inline-flex items-center px-1.5 py-0.5 rounded bg-secondary text-xs mx-0.5">🎲 {d.result != null ? `点数 ${String(d.result)}` : '骰子'}</span>
+                case 'rps':
+                    return <span key={index} className="inline-flex items-center px-1.5 py-0.5 rounded bg-secondary text-xs mx-0.5">✊ {d.result != null ? `结果 ${String(d.result)}` : '猜拳'}</span>
                 case 'image': {
                     const raw = pickMediaRawUrl(d)
                     const src = resolveMediaSrc(raw, 'image')


### PR DESCRIPTION
## Summary
- Strict `face` / `dice` / `rps` segment schemas.
- ICQQ mapper: sticker/emoji → face; mention CQ round-trip; dice/rps golden tests.
- Sandbox Console renders face/dice/rps.

Closes #553

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add strict schemas for `face`, `dice`, and `rps` segments, and update the ICQQ adapter to normalize `sticker`/`emoji` to `face` with Sandbox rendering. This aligns ICQQ with the canonical contract and adds round‑trip coverage for CQ `mention`, `dice`, and `rps`. Closes #553.

- **New Features**
  - Core contract: add and export `faceSegmentSchema`, `diceSegmentSchema`, `rpsSegmentSchema`; include them in canonical checks; add types and tests.
  - ICQQ mapper: normalize `sticker`/`emoji` → `face` (id/name); support `dice`/`rps` with optional `result`; ensure `at` ↔ `mention` CQ round‑trip; add tests.
  - Sandbox: render `face` with alt/title; show badges for `dice` and `rps`.

<sup>Written for commit 5b9178035456a00f809f4bdd6de51a7f41ec6ec1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zhinjs/zhin/pull/562?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

