### PR TITLE
feat(segment): AI IM visibility filter + Console dual-view helpers (#554)

### DIFF
--- a/packages/console/client/client/index.ts
+++ b/packages/console/client/client/index.ts
@@ -4,6 +4,9 @@ export * from "./types";
 // Media URL resolution
 export { resolveMediaSrc, pickMediaRawUrl, type MediaKind } from "./mediaSrc";
 
+// Segment IM visibility (inbox vs agent panel)
+export { segmentsForImDelivery, segmentsForAgentPanel } from "./segments.js";
+
 // Console app singleton (pagemanager / registry style)
 export {
   app,

--- a/packages/console/client/client/segments.test.ts
+++ b/packages/console/client/client/segments.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { segmentsForAgentPanel, segmentsForImDelivery } from '../client/segments.js';
+
+describe('console segmentsForImDelivery', () => {
+  it('inbox view strips AI-only segments', () => {
+    const full = [
+      { type: 'thinking', data: { text: 'plan' } },
+      { type: 'text', data: { text: 'hi' } },
+      { type: 'tool_call', data: { name: 'bash' } },
+    ];
+    expect(segmentsForImDelivery(full)).toEqual([
+      { type: 'text', data: { text: 'hi' } },
+    ]);
+    expect(segmentsForAgentPanel(full)).toEqual(full);
+  });
+});

--- a/packages/console/client/client/segments.ts
+++ b/packages/console/client/client/segments.ts
@@ -1,0 +1,39 @@
+import type { MessageSegment } from './types.js';
+
+/** IM 可见段白名单（与 core segment-contract/delivery 对齐） */
+const IM_VISIBLE_TYPES = new Set([
+  'text', 'mention', 'image', 'video', 'audio', 'voice', 'record', 'file',
+  'face', 'reply', 'forward', 'link', 'dice', 'rps', 'markdown', 'html',
+  'qrcode', 'tts', 'keyboard', 'action',
+]);
+
+const AI_ONLY_TYPES = new Set(['thinking', 'tool_call']);
+
+function isSegmentLike(value: unknown): value is MessageSegment {
+  return (
+    typeof value === 'object'
+    && value !== null
+    && typeof (value as MessageSegment).type === 'string'
+    && 'data' in value
+  );
+}
+
+/**
+ * Inbox / 用户 IM 视图：仅展示 IM-visible 段（剔除 thinking、tool_call）。
+ * Agent 面板应使用全量 segments，勿调用此函数。
+ */
+export function segmentsForImDelivery(segments: readonly unknown[]): MessageSegment[] {
+  const out: MessageSegment[] = [];
+  for (const item of segments) {
+    if (!isSegmentLike(item)) continue;
+    if (AI_ONLY_TYPES.has(item.type)) continue;
+    if (!IM_VISIBLE_TYPES.has(item.type)) continue;
+    out.push(item);
+  }
+  return out;
+}
+
+/** Agent 面板全量 segments（identity，便于双视图 API 对称） */
+export function segmentsForAgentPanel(segments: readonly MessageSegment[]): MessageSegment[] {
+  return [...segments];
+}

--- a/packages/console/client/client/types.ts
+++ b/packages/console/client/client/types.ts
@@ -1,7 +1,7 @@
 // 消息段类型定义 - 客户端版本（对齐 core Segment SSOT）
 export interface MessageSegment {
-  /** record：如 ICQQ 语音等，展示时按音频处理 */
-  type: 'text' | 'mention' | 'at' | 'image' | 'face' | 'video' | 'audio' | 'record' | 'file' | 'reply' | 'forward' | 'keyboard' | 'action' | string
+  /** record：如 ICQQ 语音等，展示时按音频处理；thinking/tool_call 仅 agent 面板展示 */
+  type: 'text' | 'mention' | 'at' | 'image' | 'face' | 'video' | 'audio' | 'record' | 'file' | 'reply' | 'forward' | 'keyboard' | 'action' | 'thinking' | 'tool_call' | string
   data: Record<string, unknown>
   platform?: Record<string, unknown>
 }

--- a/packages/im/agent/src/index.ts
+++ b/packages/im/agent/src/index.ts
@@ -358,6 +358,8 @@ export {
 } from './media/index.js';
 export type { MediaBinaryPayload, MultimodalConfig, OutboundMediaCapabilities } from './media/index.js';
 
+export { filterImDeliveryContent } from './segment/filter-im-delivery.js';
+
 export {
   loadMemoryLayers,
   buildMemoryPrompt,

--- a/packages/im/agent/src/init.ts
+++ b/packages/im/agent/src/init.ts
@@ -33,6 +33,7 @@ import { registerInitWizardGuardrail } from './init/register-init-wizard-guardra
 import { registerBuiltinTools } from './init/register-builtin-tools.js';
 import { registerHomeTools } from './init/register-home-tools.js';
 import { registerTypingIndicator } from './init/register-typing-indicator.js';
+import { registerImSegmentFilter } from './init/register-im-segment-filter.js';
 import { registerAgentMeshMcp } from './init/register-agent-mesh-mcp.js';
 
 /**
@@ -66,4 +67,5 @@ export function initAgentModule(): void {
   registerBuiltinTools(refs);
   registerHomeTools();
   registerTypingIndicator(refs);
+  registerImSegmentFilter();
 }

--- a/packages/im/agent/src/init/register-im-segment-filter.ts
+++ b/packages/im/agent/src/init/register-im-segment-filter.ts
@@ -1,0 +1,21 @@
+/**
+ * AI 出站 IM 可见性过滤 — 经 dispatcher.addOutboundPolish 挂到 before.sendMessage。
+ * thinking / tool_call 等 AI-only 段写入 agent_messages，但不过网到用户 IM。
+ */
+import { getPlugin, type OutboundPolishMiddleware } from '@zhin.js/core';
+import { filterImDeliveryContent } from '../segment/filter-im-delivery.js';
+
+export function registerImSegmentFilter(): void {
+  const plugin = getPlugin();
+  const dispatcher = plugin.root.inject('dispatcher') as
+    | { extensions?: { addOutboundPolish?: (handler: OutboundPolishMiddleware) => () => void } }
+    | undefined;
+
+  if (!dispatcher?.extensions?.addOutboundPolish) return;
+
+  const dispose = dispatcher.extensions.addOutboundPolish((ctx) => {
+    if (ctx.source !== 'ai') return;
+    return filterImDeliveryContent(ctx.content as never);
+  });
+  plugin.onDispose(dispose);
+}

--- a/packages/im/agent/src/segment/filter-im-delivery.ts
+++ b/packages/im/agent/src/segment/filter-im-delivery.ts
@@ -1,0 +1,34 @@
+import { segmentsForImDelivery, type MessageElement, type SendContent } from '@zhin.js/core';
+
+function isSegmentLike(value: unknown): value is MessageElement {
+  return (
+    typeof value === 'object'
+    && value !== null
+    && typeof (value as MessageElement).type === 'string'
+    && 'data' in value
+  );
+}
+
+/**
+ * 过滤 AI 出站内容，仅保留 IM-visible canonical 段（剔除 thinking / tool_call）。
+ * 非 segment 形状（如 JSX MessageComponent）原样保留。
+ */
+export function filterImDeliveryContent(content: SendContent): SendContent {
+  if (typeof content === 'string') return content;
+
+  const items = Array.isArray(content) ? content : [content];
+  const filtered: MessageElement[] = [];
+
+  for (const item of items) {
+    if (!isSegmentLike(item)) {
+      filtered.push(item);
+      continue;
+    }
+    const visible = segmentsForImDelivery([item]);
+    if (visible.length) filtered.push(visible[0]!);
+  }
+
+  if (filtered.length === 0) return [];
+  if (filtered.length === 1 && !Array.isArray(content)) return filtered[0]!;
+  return filtered;
+}

--- a/packages/im/agent/tests/segment/filter-im-delivery.test.ts
+++ b/packages/im/agent/tests/segment/filter-im-delivery.test.ts
@@ -1,0 +1,39 @@
+import { filterImDeliveryContent } from '../../src/segment/filter-im-delivery.js';
+
+describe('filterImDeliveryContent', () => {
+  it('passes plain string unchanged', () => {
+    expect(filterImDeliveryContent('hello')).toBe('hello');
+  });
+
+  it('strips thinking and tool_call from segment arrays', () => {
+    const input = [
+      { type: 'thinking', data: { text: 'internal' } },
+      { type: 'text', data: { text: 'visible' } },
+      { type: 'tool_call', data: { name: 'bash', args: {} } },
+      { type: 'mention', data: { target: '1', name: 'Bot' } },
+    ];
+    expect(filterImDeliveryContent(input)).toEqual([
+      { type: 'text', data: { text: 'visible' } },
+      { type: 'mention', data: { target: '1', name: 'Bot' } },
+    ]);
+  });
+
+  it('returns empty array when only AI-only segments remain', () => {
+    expect(filterImDeliveryContent([
+      { type: 'thinking', data: { text: 'x' } },
+    ])).toEqual([]);
+  });
+
+  it('preserves non-segment elements (e.g. JSX components)', () => {
+    const component = { type: { name: 'Card' }, data: { title: 't' } };
+    const input = [
+      { type: 'tool_call', data: { name: 'x' } },
+      component,
+      { type: 'text', data: { text: 'ok' } },
+    ];
+    expect(filterImDeliveryContent(input as never)).toEqual([
+      component,
+      { type: 'text', data: { text: 'ok' } },
+    ]);
+  });
+});

--- a/packages/im/agent/tests/segment/no-segment-from-xml.test.ts
+++ b/packages/im/agent/tests/segment/no-segment-from-xml.test.ts
@@ -1,0 +1,35 @@
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const agentRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const aiRoot = path.resolve(agentRoot, '../ai');
+
+function walkTs(dir: string, out: string[] = []): string[] {
+  for (const name of readdirSync(dir)) {
+    const full = path.join(dir, name);
+    const st = statSync(full);
+    if (st.isDirectory()) {
+      if (name === 'node_modules' || name === 'lib') continue;
+      walkTs(full, out);
+    } else if (name.endsWith('.ts') && !name.endsWith('.test.ts')) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+describe('agent/ai LLM path — no segment.from XML', () => {
+  const agentFiles = walkTs(path.join(agentRoot, 'src'));
+  const aiFiles = walkTs(path.join(aiRoot, 'src'));
+
+  it('agent package does not call segment.from', () => {
+    const hits = agentFiles.filter((f) => readFileSync(f, 'utf8').includes('segment.from'));
+    expect(hits).toEqual([]);
+  });
+
+  it('ai package does not call segment.from', () => {
+    const hits = aiFiles.filter((f) => readFileSync(f, 'utf8').includes('segment.from'));
+    expect(hits).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- Agent AI 出站经 `addOutboundPolish` 统一调用 `segmentsForImDelivery`，剔除 `thinking` / `tool_call` 后再进 IM
- Console client 导出 `segmentsForImDelivery`（inbox）与 `segmentsForAgentPanel`（全量）双视图 helper
- 新增 agent/ai 包无 `segment.from` XML 路径的回归测试

## Test plan
- [x] `pnpm vitest run packages/im/agent/tests/segment/ packages/console/client/client/segments.test.ts`
- [x] thinking/tool_call 被过滤，text/mention 保留
- [x] agent/ai 源码无 `segment.from`

Closes #554

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Filters agent-generated 'thinking' and 'tool_call' segments from IM delivery while keeping them visible in the Agent panel. Adds console helpers for inbox vs panel views and wires the filter into outbound polish, implementing the IM visibility policy in #554.

- **New Features**
  - Outbound polish filters IM delivery content, stripping 'thinking'/'tool_call' while preserving other segments and non-segment items.
  - Console client exports dual-view helpers: segmentsForImDelivery (inbox) and segmentsForAgentPanel (full).
  - MessageSegment type updated to include 'thinking' and 'tool_call'.
  - Tests cover the filter, dual-view helpers, and a guard to prevent `segment.from` XML usage in agent and its sibling package.

<sup>Written for commit 89bfe4e3e1efdb880f7b1d196c0b5da646e3abde. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zhinjs/zhin/pull/563?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

