### PR TITLE
feat(segment): merge AI outbound JSON with canonical Segment[] (#555)

### DIFF
--- a/packages/im/core/src/built/ai-outbound/parse.ts
+++ b/packages/im/core/src/built/ai-outbound/parse.ts
@@ -1,4 +1,28 @@
+import { isCanonicalSegment } from '../segment-contract/assert.js';
+import type { Segment } from '../segment-contract/types.js';
 import type { ZhinAiOutboundPayload } from './types.js';
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/** 解析单条 outbound segment（canonical 或 legacy kind/mode）。 */
+export function parseOutboundSegment(raw: unknown): Segment | null {
+  if (!isPlainObject(raw)) return null;
+
+  const type =
+    typeof raw.type === 'string' && raw.type.trim()
+      ? raw.type.trim()
+      : typeof raw.kind === 'string' && raw.kind.trim()
+        ? raw.kind.trim()
+        : undefined;
+  if (!type) return null;
+
+  const data = isPlainObject(raw.data) ? raw.data : {};
+  const platform = isPlainObject(raw.platform) ? raw.platform : undefined;
+  const segment = platform ? { type, data, platform } : { type, data };
+  return isCanonicalSegment(segment) ? segment : null;
+}
 
 /** 去掉嵌入 JSON 候选末尾的 markdown 围栏（模型常见 ```json … ``` 误输出）。 */
 export function trimTrailingMarkdownFence(raw: string): string {
@@ -61,15 +85,8 @@ export function parseAiOutboundJson(raw: string): ZhinAiOutboundPayload | null {
     const segmentsRaw = parsed.segments;
     const segments = Array.isArray(segmentsRaw)
       ? segmentsRaw
-          .filter((s): s is Record<string, unknown> => s != null && typeof s === 'object')
-          .map((s) => ({
-            kind: String(s.kind ?? ''),
-            mode: typeof s.mode === 'string' ? s.mode : undefined,
-            data: s.data != null && typeof s.data === 'object'
-              ? (s.data as Record<string, unknown>)
-              : undefined,
-          }))
-          .filter((s) => s.kind)
+          .map((item) => parseOutboundSegment(item))
+          .filter((s): s is Segment => s != null)
       : undefined;
     const extensions =
       parsed.extensions != null && typeof parsed.extensions === 'object' && !Array.isArray(parsed.extensions)

--- a/packages/im/core/src/built/ai-outbound/resolve.ts
+++ b/packages/im/core/src/built/ai-outbound/resolve.ts
@@ -1,15 +1,17 @@
+import { segmentsForImDelivery } from '../segment-contract/delivery.js';
+import type { Segment } from '../segment-contract/types.js';
 import type { MessageElement } from '../../types.js';
 import type { AiOutboundParseContext, ZhinAiOutboundPayload } from './types.js';
 
-function buildAtSegments(
+function buildMentionSegments(
   endpointIds: string[],
   text: string,
   ctx: AiOutboundParseContext,
-): MessageElement[] {
-  const segments: MessageElement[] = [];
+): Segment[] {
+  const segments: Segment[] = [];
   for (const endpointId of endpointIds) {
-    const atId = ctx.atIdResolver?.(endpointId) ?? endpointId;
-    segments.push({ type: 'at', data: { id: atId, qq: atId } });
+    const target = ctx.atIdResolver?.(endpointId) ?? endpointId;
+    segments.push({ type: 'mention', data: { target } });
   }
   const body = text.trim();
   segments.push({
@@ -40,22 +42,30 @@ function resolveMentionEndpointIds(
   return { ok: true, endpointIds };
 }
 
-/** 将 ZhinAiOutboundPayload 转为 MessageElement[]（核心字段 + extensions）。 */
+/** 将 ZhinAiOutboundPayload 转为 MessageElement[]（canonical segments + extensions）。 */
 export async function resolveAiOutboundToMessageElements(
   payload: ZhinAiOutboundPayload,
   ctx: AiOutboundParseContext,
 ): Promise<MessageElement[] | null> {
-  const parts: MessageElement[] = [];
+  const segments: Segment[] = [];
 
   if (payload.mentions?.length) {
     const resolved = resolveMentionEndpointIds(payload.mentions, ctx);
     if (!resolved.ok) return null;
     const text = payload.text?.trim() ?? '';
     if (!text) return null;
-    parts.push(...buildAtSegments(resolved.endpointIds, text, ctx));
+    segments.push(...buildMentionSegments(resolved.endpointIds, text, ctx));
   } else if (payload.text?.trim()) {
-    parts.push({ type: 'text', data: { text: payload.text.trim() } });
+    segments.push({ type: 'text', data: { text: payload.text.trim() } });
   }
+
+  if (payload.segments?.length) {
+    segments.push(...payload.segments);
+  }
+
+  const parts: MessageElement[] = segments.length
+    ? segmentsForImDelivery(segments)
+    : [];
 
   if (payload.extensions && ctx.extensions?.length) {
     for (const def of ctx.extensions) {

--- a/packages/im/core/src/built/ai-outbound/types.ts
+++ b/packages/im/core/src/built/ai-outbound/types.ts
@@ -1,15 +1,20 @@
 import type { Message } from '../../message.js';
 import type { MessageElement } from '../../types.js';
 import type { InteractivePolicy } from '../interactive-segments/types.js';
+import type { Segment } from '../segment-contract/types.js';
 
 /** AI 结构化出站 payload — 平台无关 DSL（Adapter extensions 承载平台特有段）。 */
 export interface ZhinAiOutboundPayload {
   text?: string;
   mentions?: string[];
-  segments?: AiOutboundSegment[];
+  segments?: Segment[];
   extensions?: Record<string, unknown>;
 }
 
+/**
+ * @deprecated 使用 canonical `Segment`（`type` + `data` + 可选 `platform`）。
+ * 历史 `kind` → `type`；`mode` 已删除。
+ */
 export interface AiOutboundSegment {
   kind: string;
   mode?: string;

--- a/packages/im/core/tests/ai-outbound/ai-outbound.test.ts
+++ b/packages/im/core/tests/ai-outbound/ai-outbound.test.ts
@@ -1,12 +1,33 @@
 import { describe, it, expect } from 'vitest';
 import {
   parseAiOutboundJson,
+  parseOutboundSegment,
   extractEmbeddedAiOutboundJson,
   rewritePlainTextMentions,
   buildAiOutboundPromptHint,
   detectInboundHandoffIntent,
   isStructuredOutboundRequired,
+  resolveAiOutboundToMessageElements,
 } from '../../src/built/ai-outbound/index.js';
+import type { Message } from '../../src/message.js';
+
+const stubMessage = { $adapter: 'sandbox', $endpoint: 'ep1' } as Message;
+
+describe('parseOutboundSegment', () => {
+  it('parses canonical segment', () => {
+    expect(parseOutboundSegment({ type: 'text', data: { text: 'hi' } })).toEqual({
+      type: 'text',
+      data: { text: 'hi' },
+    });
+  });
+
+  it('maps legacy kind to type', () => {
+    expect(parseOutboundSegment({ kind: 'mention', data: { target: '1' } })).toEqual({
+      type: 'mention',
+      data: { target: '1' },
+    });
+  });
+});
 
 describe('parseAiOutboundJson', () => {
   it('parses mentions and text', () => {
@@ -23,6 +44,23 @@ describe('parseAiOutboundJson', () => {
       text: 'hi',
       mentions: undefined,
       segments: undefined,
+      extensions: undefined,
+    });
+  });
+
+  it('parses canonical segments array', () => {
+    expect(parseAiOutboundJson(JSON.stringify({
+      segments: [
+        { type: 'text', data: { text: 'a' } },
+        { kind: 'mention', data: { target: '9' } },
+      ],
+    }))).toEqual({
+      text: undefined,
+      mentions: undefined,
+      segments: [
+        { type: 'text', data: { text: 'a' } },
+        { type: 'mention', data: { target: '9' } },
+      ],
       extensions: undefined,
     });
   });
@@ -87,5 +125,60 @@ describe('buildAiOutboundPromptHint', () => {
   it('includes force json line', () => {
     const hint = buildAiOutboundPromptHint({ forceJsonOnly: true });
     expect(hint).toContain('MUST reply with JSON only');
+  });
+});
+
+describe('resolveAiOutboundToMessageElements', () => {
+  const ctx = {
+    message: stubMessage,
+    mentionResolver: (ref: string) => (ref === 'researcher' ? 'ep-researcher' : undefined),
+    atIdResolver: (endpointId: string) => `qq:${endpointId}`,
+  };
+
+  it('resolves mentions to canonical mention segments', async () => {
+    const result = await resolveAiOutboundToMessageElements(
+      { mentions: ['researcher'], text: 'hello' },
+      ctx,
+    );
+    expect(result).toEqual([
+      { type: 'mention', data: { target: 'qq:ep-researcher' } },
+      { type: 'text', data: { text: ' hello' } },
+    ]);
+  });
+
+  it('consumes payload.segments and filters AI-only types', async () => {
+    const result = await resolveAiOutboundToMessageElements(
+      {
+        text: 'visible',
+        segments: [
+          { type: 'thinking', data: { text: 'hidden' } },
+          { type: 'image', data: { media: { kind: 'url', value: 'https://x/y.png' } } },
+        ],
+      },
+      { message: stubMessage },
+    );
+    expect(result).toEqual([
+      { type: 'text', data: { text: 'visible' } },
+      { type: 'image', data: { media: { kind: 'url', value: 'https://x/y.png' } } },
+    ]);
+  });
+
+  it('appends extension segments', async () => {
+    const result = await resolveAiOutboundToMessageElements(
+      { text: 'hi', extensions: { 'test.ext': { foo: 1 } } },
+      {
+        message: stubMessage,
+        extensions: [{
+          key: 'test.ext',
+          schema: {},
+          examples: ['{}'],
+          toMessageElements: () => [{ type: 'text', data: { text: ' ext' } }],
+        }],
+      },
+    );
+    expect(result).toEqual([
+      { type: 'text', data: { text: 'hi' } },
+      { type: 'text', data: { text: ' ext' } },
+    ]);
   });
 });


### PR DESCRIPTION
## Summary
- `ZhinAiOutboundPayload.segments` 使用 canonical `Segment[]`；`AiOutboundSegment` kind/mode 标为 deprecated
- `parseOutboundSegment` 支持 canonical + legacy kind 映射
- `resolveAiOutboundToMessageElements` 消费 segments、产出 `mention`、经 `segmentsForImDelivery` 过滤后再进 IM

## Test plan
- [x] `pnpm vitest run packages/im/core/tests/ai-outbound/ai-outbound.test.ts`
- [x] `pnpm check:ai-outbound`

Closes #555

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrates AI outbound JSON to canonical `Segment[]` and updates the resolver to emit `mention` segments and filter via `segmentsForImDelivery`. Implements #555 to align parsing and delivery with the segment contract.

- **New Features**
  - `ZhinAiOutboundPayload.segments` now uses canonical `Segment[]`.
  - `parseOutboundSegment` validates canonical segments and maps legacy `kind` → `type`.
  - `resolveAiOutboundToMessageElements` consumes `segments`, emits `mention`, and filters with `segmentsForImDelivery`.

- **Migration**
  - Prefer `type` over legacy `kind`; remove `mode`.
  - `AiOutboundSegment` is deprecated in favor of `Segment`.
  - Use `mention` with `{ target }` instead of legacy `at` with `{ id/qq }` when producing mentions.

<sup>Written for commit 3b5951b9de19d2522abe12595be0ccd404185a93. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zhinjs/zhin/pull/564?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

