### PR TITLE
feat(segment): OneBot adapters segment-mapper (#556)

### DIFF
--- a/plugins/adapters/napcat/src/endpoint-base.ts
+++ b/plugins/adapters/napcat/src/endpoint-base.ts
@@ -17,6 +17,7 @@ import { parseOneBotGetMsgResponse } from './onebot-get-msg.js';
 import type { NapCatEndpointConfig, NapCatMessageEvent, MessageSegment, ApiResponse } from './types.js';
 import type { NapCatAdapter } from './adapter.js';
 import { InboundMessageDeduper, isSelfMessage, normalizeMessage, resolveSideEventDedupeKey } from './napcat-inbound.js';
+import { fromCanonicalSegments, toCanonicalSegments } from './segment-mapper.js';
 
 export abstract class NapCatEndpointBase extends EventEmitter implements Endpoint<NapCatEndpointConfig, NapCatMessageEvent> {
   $connected = false;
@@ -37,10 +38,18 @@ export abstract class NapCatEndpointBase extends EventEmitter implements Endpoin
   // 消息格式化
   // ══════════════════════════════════════════════════════════════════
 
+  private toWireSendContent(content: SendContent): MessageSegment[] {
+    const items = (Array.isArray(content) ? content : [content]).map((item) =>
+      typeof item === 'string' ? { type: 'text', data: { text: item } } : item as MessageSegment,
+    );
+    return fromCanonicalSegments(toCanonicalSegments(items));
+  }
+
   $formatMessage(ev: NapCatMessageEvent): Message<NapCatMessageEvent> {
-    const content = normalizeMessage(ev.message);
-    const quoteId = Message.quoteIdFromContent(content);
-    Message.alignReplySegments(content, quoteId);
+    const wire = normalizeMessage(ev.message);
+    const quoteId = Message.quoteIdFromContent(wire);
+    Message.alignReplySegments(wire, quoteId);
+    const content = toCanonicalSegments(wire);
 
     const message = Message.from(ev, {
       $id: ev.message_id.toString(),
@@ -76,7 +85,7 @@ export abstract class NapCatEndpointBase extends EventEmitter implements Endpoin
   }
 
   async $sendMessage(options: SendOptions): Promise<string> {
-    const content = expandInteractiveSegmentsInContent(options.content);
+    const content = this.toWireSendContent(expandInteractiveSegmentsInContent(options.content));
     const msg: any = { message: content };
     if (options.type === 'group') {
       const result = await this.callApi<{ message_id: number }>('send_group_msg', { group_id: parseInt(options.id), ...msg });

--- a/plugins/adapters/napcat/src/segment-mapper.ts
+++ b/plugins/adapters/napcat/src/segment-mapper.ts
@@ -1,0 +1,193 @@
+import type { MessageSegment, Segment } from 'zhin.js';
+import {
+  createImageSegment,
+  isMediaRef,
+  mediaRefFromLegacyData,
+  mediaRefToLegacyFields,
+} from 'zhin.js';
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function readMentionTarget(data: Record<string, unknown>): string {
+  const raw = data.target ?? data.user_id ?? data.qq ?? data.id;
+  if (raw === 'all') return 'all';
+  return raw != null ? String(raw) : '';
+}
+
+function normalizeMention(seg: MessageSegment): Segment {
+  const data = seg.data as Record<string, unknown>;
+  const target = readMentionTarget(data);
+  const name = typeof data.name === 'string' && data.name ? data.name : undefined;
+  return {
+    type: 'mention',
+    data: name ? { target, name } : { target },
+    ...(seg.platform ? { platform: seg.platform } : {}),
+  };
+}
+
+function normalizeImage(seg: MessageSegment): Segment {
+  const data = seg.data as Record<string, unknown>;
+  if (isMediaRef(data.media)) {
+    return {
+      type: 'image',
+      data: {
+        media: data.media,
+        ...(typeof data.alt === 'string' ? { alt: data.alt } : {}),
+      },
+      ...(seg.platform ? { platform: seg.platform } : {}),
+    };
+  }
+  const media = mediaRefFromLegacyData(data);
+  if (!media) return seg as Segment;
+
+  const platform: Record<string, unknown> = { ...(seg.platform ?? {}) };
+  for (const key of ['url', 'file', 'src'] as const) {
+    if (typeof data[key] === 'string' && data[key]) platform[key] = data[key];
+  }
+
+  return createImageSegment(media, {
+    alt: typeof data.alt === 'string' ? data.alt : undefined,
+    platform: Object.keys(platform).length ? platform : undefined,
+  });
+}
+
+function normalizeReply(seg: MessageSegment): Segment {
+  const data = seg.data as Record<string, unknown>;
+  const messageId = String(data.message_id ?? data.id ?? '').trim();
+  if (!messageId) return seg as Segment;
+  return { type: 'reply', data: { message_id: messageId } };
+}
+
+function normalizeForward(seg: MessageSegment): Segment {
+  const data = seg.data as Record<string, unknown>;
+  const forwardId = String(
+    data.forward_id ?? data.id ?? data.resid ?? data.res_id ?? '',
+  ).trim();
+  if (!forwardId) return seg as Segment;
+
+  const platform: Record<string, unknown> = { ...(seg.platform ?? {}) };
+  for (const key of ['resid', 'res_id'] as const) {
+    if (typeof data[key] === 'string' && data[key]) platform[key] = data[key];
+  }
+
+  return {
+    type: 'forward',
+    data: {
+      forward_id: forwardId,
+      ...(typeof data.title === 'string' && data.title ? { title: data.title } : {}),
+      ...(Array.isArray(data.messages) ? { messages: data.messages as Segment[][] } : {}),
+    },
+    ...(Object.keys(platform).length ? { platform } : {}),
+  };
+}
+
+function normalizeFace(seg: MessageSegment): Segment {
+  const data = seg.data as Record<string, unknown>;
+  const id = data.id ?? data.face_id;
+  if (id == null || id === '') return seg as Segment;
+  const name =
+    typeof data.name === 'string' && data.name
+      ? data.name
+      : typeof data.text === 'string' && data.text
+        ? data.text
+        : undefined;
+  return {
+    type: 'face',
+    data: {
+      id: typeof id === 'number' ? id : String(id),
+      ...(name ? { name } : {}),
+    },
+    ...(seg.platform ? { platform: seg.platform } : {}),
+  };
+}
+
+function normalizeGame(seg: MessageSegment, type: 'dice' | 'rps'): Segment {
+  const data = seg.data as Record<string, unknown>;
+  const result = typeof data.result === 'number' ? data.result : undefined;
+  return {
+    type,
+    data: result != null ? { result } : {},
+    ...(seg.platform ? { platform: seg.platform } : {}),
+  };
+}
+
+function normalizeSegment(seg: MessageSegment): Segment {
+  if (seg.type === 'at' || seg.type === 'mention') return normalizeMention(seg);
+  if (seg.type === 'image') return normalizeImage(seg);
+  if (seg.type === 'reply') return normalizeReply(seg);
+  if (seg.type === 'forward') return normalizeForward(seg);
+  if (seg.type === 'face' || seg.type === 'sticker' || seg.type === 'emoji') {
+    return normalizeFace(seg);
+  }
+  if (seg.type === 'dice' || seg.type === 'rps') return normalizeGame(seg, seg.type);
+  return seg as Segment;
+}
+
+/** 入站 legacy / CQ 段 → canonical Segment[] */
+export function toCanonicalSegments(content: readonly MessageSegment[]): Segment[] {
+  return content.map((seg) => {
+    if (typeof seg === 'string') return { type: 'text', data: { text: seg } };
+    return normalizeSegment(seg);
+  });
+}
+
+/** 出站：canonical → OneBot11 wire（CQ 构建仍读 url/file + media） */
+export function fromCanonicalSegments(segments: readonly Segment[]): MessageSegment[] {
+  return segments.map((seg) => {
+    if (seg.type === 'image' && isRecord(seg.data) && seg.data.media) {
+      const media = seg.data.media as import('zhin.js').MediaRef;
+      const legacy = mediaRefToLegacyFields(media);
+      return {
+        type: 'image',
+        data: {
+          ...legacy,
+          media,
+          ...(typeof seg.data.alt === 'string' ? { alt: seg.data.alt } : {}),
+        },
+        ...(seg.platform ? { platform: seg.platform } : {}),
+      };
+    }
+    if (seg.type === 'mention') {
+      const data = seg.data as { target: string; name?: string };
+      return {
+        type: 'at',
+        data: {
+          qq: data.target,
+          ...(data.name ? { name: data.name } : {}),
+        },
+        ...(seg.platform ? { platform: seg.platform } : {}),
+      };
+    }
+    if (seg.type === 'reply') {
+      const messageId = String((seg.data as { message_id: string }).message_id);
+      return {
+        type: 'reply',
+        data: { id: messageId, message_id: messageId },
+        ...(seg.platform ? { platform: seg.platform } : {}),
+      };
+    }
+    if (seg.type === 'forward') {
+      const data = seg.data as {
+        forward_id: string;
+        title?: string;
+        messages?: unknown;
+      };
+      const platform = { ...(seg.platform ?? {}) };
+      const resid = platform.resid ?? data.forward_id;
+      return {
+        type: 'forward',
+        data: {
+          id: data.forward_id,
+          forward_id: data.forward_id,
+          resid,
+          ...(data.title ? { title: data.title } : {}),
+          ...(data.messages ? { messages: data.messages } : {}),
+        },
+        platform: { ...platform, resid },
+      };
+    }
+    return seg as MessageSegment;
+  });
+}

--- a/plugins/adapters/napcat/tests/segment-contract.test.ts
+++ b/plugins/adapters/napcat/tests/segment-contract.test.ts
@@ -1,0 +1,43 @@
+/**
+ * napcat segment contract — OneBot11 wire round-trip
+ */
+import { describe, it } from 'vitest';
+import { fromCanonicalSegments, toCanonicalSegments } from '../src/segment-mapper.js';
+import { assertSegmentRoundTrip } from '../../../../packages/im/core/tests/helpers/segment-adapter-contract.js';
+
+const mapper = { toCanonicalSegments, fromCanonicalSegments };
+
+describe('napcat segment contract', () => {
+  it('normalizes legacy image url to MediaRef', () => {
+    assertSegmentRoundTrip(
+      mapper,
+      [{ type: 'image', data: { url: 'https://cdn.example/cat.jpg', file: 'https://cdn.example/cat.jpg' } }],
+      [{
+        type: 'image',
+        data: { media: { kind: 'url', value: 'https://cdn.example/cat.jpg' } },
+        platform: { url: 'https://cdn.example/cat.jpg', file: 'https://cdn.example/cat.jpg' },
+      }],
+    );
+  });
+
+  it('round-trips mention via at wire', () => {
+    assertSegmentRoundTrip(
+      mapper,
+      [{ type: 'at', data: { qq: '10001', name: 'Alice' } }],
+      [{ type: 'mention', data: { target: '10001', name: 'Alice' } }],
+    );
+  });
+
+  it('normalizes legacy reply id to message_id', () => {
+    assertSegmentRoundTrip(
+      mapper,
+      [{ type: 'reply', data: { id: 'q-1' } }],
+      [{ type: 'reply', data: { message_id: 'q-1' } }],
+    );
+  });
+
+  it('round-trips dice and rps', () => {
+    assertSegmentRoundTrip(mapper, [{ type: 'dice', data: {} }], [{ type: 'dice', data: {} }]);
+    assertSegmentRoundTrip(mapper, [{ type: 'rps', data: { result: 1 } }], [{ type: 'rps', data: { result: 1 } }]);
+  });
+});

--- a/plugins/adapters/onebot11/src/endpoint-ws-client.ts
+++ b/plugins/adapters/onebot11/src/endpoint-ws-client.ts
@@ -4,8 +4,9 @@
 import WebSocket from 'ws';
 import { EventEmitter } from 'events';
 import { clearInterval } from 'node:timers';
-import { formatCompact, Endpoint, Message, Notice, Request, segment, SendContent, SendOptions, expandInteractiveSegmentsInContent, type QuotedMessagePayload, applyQqSenderRoleToMessageSender,} from 'zhin.js';
+import { formatCompact, Endpoint, Message, Notice, Request, segment, SendContent, SendOptions, expandInteractiveSegmentsInContent, type QuotedMessagePayload, applyQqSenderRoleToMessageSender, type MessageElement,} from 'zhin.js';
 import { parseOneBotGetMsgResponse } from './onebot-get-msg.js';
+import { fromCanonicalSegments, toCanonicalSegments } from './segment-mapper.js';
 import type {
   OneBot11WsClientConfig,
   OneBot11Message,
@@ -115,10 +116,18 @@ export class OneBot11WsClient extends EventEmitter implements Endpoint<OneBot11W
     }
   }
 
+  private toWireSendContent(content: SendContent): MessageElement[] {
+    const items = (Array.isArray(content) ? content : [content]).map((item) =>
+      typeof item === 'string' ? { type: 'text', data: { text: item } } : item as MessageElement,
+    );
+    return fromCanonicalSegments(toCanonicalSegments(items as never));
+  }
+
   $formatMessage(onebotMsg: OneBot11Message) {
-    const content = Array.isArray(onebotMsg.message) ? [...onebotMsg.message] : [];
-    const quoteId = Message.quoteIdFromContent(content);
-    Message.alignReplySegments(content, quoteId);
+    const wire = Array.isArray(onebotMsg.message) ? [...onebotMsg.message] : [];
+    const quoteId = Message.quoteIdFromContent(wire);
+    Message.alignReplySegments(wire, quoteId);
+    const content = toCanonicalSegments(wire as never);
 
     const message = Message.from(onebotMsg, {
       $id: onebotMsg.message_id.toString(),
@@ -158,7 +167,7 @@ export class OneBot11WsClient extends EventEmitter implements Endpoint<OneBot11W
   }
 
   async $sendMessage(options: SendOptions): Promise<string> {
-    const content = expandInteractiveSegmentsInContent(options.content);
+    const content = this.toWireSendContent(expandInteractiveSegmentsInContent(options.content));
     const messageData: any = { message: content };
     if (options.type === 'group') {
       const result = await this.callApi('send_group_msg', {

--- a/plugins/adapters/onebot11/src/endpoint-ws-server.ts
+++ b/plugins/adapters/onebot11/src/endpoint-ws-server.ts
@@ -5,8 +5,9 @@ import WebSocket, { WebSocketServer } from 'ws';
 import { EventEmitter } from 'events';
 import { clearInterval } from 'node:timers';
 import { IncomingMessage } from 'http';
-import { formatCompact, Endpoint, Message, Notice, Request, segment, SendOptions, expandInteractiveSegmentsInContent, type QuotedMessagePayload, applyQqSenderRoleToMessageSender,} from 'zhin.js';
+import { formatCompact, Endpoint, Message, Notice, Request, segment, SendContent, SendOptions, expandInteractiveSegmentsInContent, type QuotedMessagePayload, applyQqSenderRoleToMessageSender, type MessageElement,} from 'zhin.js';
 import { parseOneBotGetMsgResponse } from './onebot-get-msg.js';
+import { fromCanonicalSegments, toCanonicalSegments } from './segment-mapper.js';
 import type { Router } from '@zhin.js/host-router';
 import type {
   OneBot11WsServerConfig,
@@ -105,15 +106,23 @@ export class OneBot11WsServer extends EventEmitter implements Endpoint<OneBot11W
     }
   }
 
+  private toWireSendContent(content: SendContent): MessageElement[] {
+    const items = (Array.isArray(content) ? content : [content]).map((item) =>
+      typeof item === 'string' ? { type: 'text', data: { text: item } } : item as MessageElement,
+    );
+    return fromCanonicalSegments(toCanonicalSegments(items as never));
+  }
+
   $formatMessage(onebotMsg: OneBot11Message) {
     const msgId = [onebotMsg.self_id, onebotMsg.message_id].join(':');
     const channel = {
       id: [onebotMsg.self_id, (onebotMsg.group_id || onebotMsg.user_id)].join(':'),
       type: (onebotMsg.group_id ? 'group' : 'private') as 'group' | 'private',
     };
-    const content = Array.isArray(onebotMsg.message) ? [...onebotMsg.message] : [];
-    const quoteId = Message.quoteIdFromContent(content);
-    Message.alignReplySegments(content, quoteId);
+    const wire = Array.isArray(onebotMsg.message) ? [...onebotMsg.message] : [];
+    const quoteId = Message.quoteIdFromContent(wire);
+    Message.alignReplySegments(wire, quoteId);
+    const content = toCanonicalSegments(wire as never);
 
     const message = Message.from(onebotMsg, {
       $id: msgId,
@@ -148,7 +157,7 @@ export class OneBot11WsServer extends EventEmitter implements Endpoint<OneBot11W
   }
 
   async $sendMessage(options: SendOptions): Promise<string> {
-    const content = expandInteractiveSegmentsInContent(options.content);
+    const content = this.toWireSendContent(expandInteractiveSegmentsInContent(options.content));
     const messageData: any = { message: content };
     if (options.type === 'group') {
       const [self_id, id] = options.id.split(':');

--- a/plugins/adapters/onebot11/src/segment-mapper.ts
+++ b/plugins/adapters/onebot11/src/segment-mapper.ts
@@ -1,0 +1,193 @@
+import type { MessageSegment, Segment } from 'zhin.js';
+import {
+  createImageSegment,
+  isMediaRef,
+  mediaRefFromLegacyData,
+  mediaRefToLegacyFields,
+} from 'zhin.js';
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function readMentionTarget(data: Record<string, unknown>): string {
+  const raw = data.target ?? data.user_id ?? data.qq ?? data.id;
+  if (raw === 'all') return 'all';
+  return raw != null ? String(raw) : '';
+}
+
+function normalizeMention(seg: MessageSegment): Segment {
+  const data = seg.data as Record<string, unknown>;
+  const target = readMentionTarget(data);
+  const name = typeof data.name === 'string' && data.name ? data.name : undefined;
+  return {
+    type: 'mention',
+    data: name ? { target, name } : { target },
+    ...(seg.platform ? { platform: seg.platform } : {}),
+  };
+}
+
+function normalizeImage(seg: MessageSegment): Segment {
+  const data = seg.data as Record<string, unknown>;
+  if (isMediaRef(data.media)) {
+    return {
+      type: 'image',
+      data: {
+        media: data.media,
+        ...(typeof data.alt === 'string' ? { alt: data.alt } : {}),
+      },
+      ...(seg.platform ? { platform: seg.platform } : {}),
+    };
+  }
+  const media = mediaRefFromLegacyData(data);
+  if (!media) return seg as Segment;
+
+  const platform: Record<string, unknown> = { ...(seg.platform ?? {}) };
+  for (const key of ['url', 'file', 'src'] as const) {
+    if (typeof data[key] === 'string' && data[key]) platform[key] = data[key];
+  }
+
+  return createImageSegment(media, {
+    alt: typeof data.alt === 'string' ? data.alt : undefined,
+    platform: Object.keys(platform).length ? platform : undefined,
+  });
+}
+
+function normalizeReply(seg: MessageSegment): Segment {
+  const data = seg.data as Record<string, unknown>;
+  const messageId = String(data.message_id ?? data.id ?? '').trim();
+  if (!messageId) return seg as Segment;
+  return { type: 'reply', data: { message_id: messageId } };
+}
+
+function normalizeForward(seg: MessageSegment): Segment {
+  const data = seg.data as Record<string, unknown>;
+  const forwardId = String(
+    data.forward_id ?? data.id ?? data.resid ?? data.res_id ?? '',
+  ).trim();
+  if (!forwardId) return seg as Segment;
+
+  const platform: Record<string, unknown> = { ...(seg.platform ?? {}) };
+  for (const key of ['resid', 'res_id'] as const) {
+    if (typeof data[key] === 'string' && data[key]) platform[key] = data[key];
+  }
+
+  return {
+    type: 'forward',
+    data: {
+      forward_id: forwardId,
+      ...(typeof data.title === 'string' && data.title ? { title: data.title } : {}),
+      ...(Array.isArray(data.messages) ? { messages: data.messages as Segment[][] } : {}),
+    },
+    ...(Object.keys(platform).length ? { platform } : {}),
+  };
+}
+
+function normalizeFace(seg: MessageSegment): Segment {
+  const data = seg.data as Record<string, unknown>;
+  const id = data.id ?? data.face_id;
+  if (id == null || id === '') return seg as Segment;
+  const name =
+    typeof data.name === 'string' && data.name
+      ? data.name
+      : typeof data.text === 'string' && data.text
+        ? data.text
+        : undefined;
+  return {
+    type: 'face',
+    data: {
+      id: typeof id === 'number' ? id : String(id),
+      ...(name ? { name } : {}),
+    },
+    ...(seg.platform ? { platform: seg.platform } : {}),
+  };
+}
+
+function normalizeGame(seg: MessageSegment, type: 'dice' | 'rps'): Segment {
+  const data = seg.data as Record<string, unknown>;
+  const result = typeof data.result === 'number' ? data.result : undefined;
+  return {
+    type,
+    data: result != null ? { result } : {},
+    ...(seg.platform ? { platform: seg.platform } : {}),
+  };
+}
+
+function normalizeSegment(seg: MessageSegment): Segment {
+  if (seg.type === 'at' || seg.type === 'mention') return normalizeMention(seg);
+  if (seg.type === 'image') return normalizeImage(seg);
+  if (seg.type === 'reply') return normalizeReply(seg);
+  if (seg.type === 'forward') return normalizeForward(seg);
+  if (seg.type === 'face' || seg.type === 'sticker' || seg.type === 'emoji') {
+    return normalizeFace(seg);
+  }
+  if (seg.type === 'dice' || seg.type === 'rps') return normalizeGame(seg, seg.type);
+  return seg as Segment;
+}
+
+/** 入站 legacy / CQ 段 → canonical Segment[] */
+export function toCanonicalSegments(content: readonly MessageSegment[]): Segment[] {
+  return content.map((seg) => {
+    if (typeof seg === 'string') return { type: 'text', data: { text: seg } };
+    return normalizeSegment(seg);
+  });
+}
+
+/** 出站：canonical → OneBot11 wire（CQ 构建仍读 url/file + media） */
+export function fromCanonicalSegments(segments: readonly Segment[]): MessageSegment[] {
+  return segments.map((seg) => {
+    if (seg.type === 'image' && isRecord(seg.data) && seg.data.media) {
+      const media = seg.data.media as import('zhin.js').MediaRef;
+      const legacy = mediaRefToLegacyFields(media);
+      return {
+        type: 'image',
+        data: {
+          ...legacy,
+          media,
+          ...(typeof seg.data.alt === 'string' ? { alt: seg.data.alt } : {}),
+        },
+        ...(seg.platform ? { platform: seg.platform } : {}),
+      };
+    }
+    if (seg.type === 'mention') {
+      const data = seg.data as { target: string; name?: string };
+      return {
+        type: 'at',
+        data: {
+          qq: data.target,
+          ...(data.name ? { name: data.name } : {}),
+        },
+        ...(seg.platform ? { platform: seg.platform } : {}),
+      };
+    }
+    if (seg.type === 'reply') {
+      const messageId = String((seg.data as { message_id: string }).message_id);
+      return {
+        type: 'reply',
+        data: { id: messageId, message_id: messageId },
+        ...(seg.platform ? { platform: seg.platform } : {}),
+      };
+    }
+    if (seg.type === 'forward') {
+      const data = seg.data as {
+        forward_id: string;
+        title?: string;
+        messages?: unknown;
+      };
+      const platform = { ...(seg.platform ?? {}) };
+      const resid = platform.resid ?? data.forward_id;
+      return {
+        type: 'forward',
+        data: {
+          id: data.forward_id,
+          forward_id: data.forward_id,
+          resid,
+          ...(data.title ? { title: data.title } : {}),
+          ...(data.messages ? { messages: data.messages } : {}),
+        },
+        platform: { ...platform, resid },
+      };
+    }
+    return seg as MessageSegment;
+  });
+}

--- a/plugins/adapters/onebot11/tests/segment-contract.test.ts
+++ b/plugins/adapters/onebot11/tests/segment-contract.test.ts
@@ -1,0 +1,42 @@
+/**
+ * onebot11 segment contract — OneBot11 wire round-trip
+ */
+import { describe, it } from 'vitest';
+import { fromCanonicalSegments, toCanonicalSegments } from '../src/segment-mapper.js';
+import { assertSegmentRoundTrip } from '../../../../packages/im/core/tests/helpers/segment-adapter-contract.js';
+
+const mapper = { toCanonicalSegments, fromCanonicalSegments };
+
+describe('onebot11 segment contract', () => {
+  it('normalizes legacy image url to MediaRef', () => {
+    assertSegmentRoundTrip(
+      mapper,
+      [{ type: 'image', data: { url: 'https://cdn.example/cat.jpg' } }],
+      [{
+        type: 'image',
+        data: { media: { kind: 'url', value: 'https://cdn.example/cat.jpg' } },
+        platform: { url: 'https://cdn.example/cat.jpg' },
+      }],
+    );
+  });
+
+  it('round-trips mention via at wire', () => {
+    assertSegmentRoundTrip(
+      mapper,
+      [{ type: 'at', data: { qq: '10001' } }],
+      [{ type: 'mention', data: { target: '10001' } }],
+    );
+  });
+
+  it('normalizes legacy forward id/resid to forward_id', () => {
+    assertSegmentRoundTrip(
+      mapper,
+      [{ type: 'forward', data: { id: 'fwd-9', resid: 'fwd-9' } }],
+      [{
+        type: 'forward',
+        data: { forward_id: 'fwd-9' },
+        platform: { resid: 'fwd-9' },
+      }],
+    );
+  });
+});

--- a/plugins/adapters/qq/src/endpoint.ts
+++ b/plugins/adapters/qq/src/endpoint.ts
@@ -25,6 +25,7 @@ import { SDK_VERSION, SDK_VERSION_HEADER } from "./sdk-version.js";
 import { applyCustomAuthEndpoints } from "./gateway-config.js";
 import { normalizeOutboundMarkdown, asOutboundSegments, splitReplyPrefix } from "./outbound-markdown.js";
 import { normalizeOutboundMedia } from "./outbound-media.js";
+import { fromCanonicalSegments, toCanonicalSegments } from "./segment-mapper.js";
 import {
   buildMixedMediaMessagePayload,
   buildQqImageUploadPayload,
@@ -292,6 +293,13 @@ export class QQEndpoint<T extends ReceiverMode, M extends ApplicationPlatform = 
     }
   }
 
+  private toWireSendContent(content: SendContent): MessageElement[] {
+    const items = (Array.isArray(content) ? content : [content]).map((item) =>
+      typeof item === "string" ? { type: "text", data: { text: item } } : item as MessageElement,
+    );
+    return fromCanonicalSegments(toCanonicalSegments(items as never));
+  }
+
   $formatMessage(msg: PrivateMessageEvent | GroupMessageEvent) {
     const raw = msg as PrivateMessageEvent & GroupMessageEvent & {
       group_openid?: string;
@@ -320,6 +328,10 @@ export class QQEndpoint<T extends ReceiverMode, M extends ApplicationPlatform = 
         .filter((id): id is string => Boolean(id))
         .map(String);
       content = normalizeGroupAtPrefix(content, endpointAtIds, raw.__zhin_group_at === true);
+    }
+
+    if (Array.isArray(content)) {
+      content = toCanonicalSegments(content);
     }
 
     const result = Message.from(msg, {
@@ -356,7 +368,8 @@ export class QQEndpoint<T extends ReceiverMode, M extends ApplicationPlatform = 
 
   async $sendMessage(options: SendOptions): Promise<string> {
     const expanded = expandKeyboardSegmentsForQq(options.content);
-    const mediaNorm = normalizeOutboundMedia(expanded);
+    const canonicalized = this.toWireSendContent(expanded);
+    const mediaNorm = normalizeOutboundMedia(canonicalized);
     const markdownMode = this.$config.outboundMarkdown;
 
     if (

--- a/plugins/adapters/qq/src/segment-mapper.ts
+++ b/plugins/adapters/qq/src/segment-mapper.ts
@@ -1,0 +1,115 @@
+import type { MessageSegment, Segment } from 'zhin.js';
+import {
+  createImageSegment,
+  isMediaRef,
+  mediaRefFromLegacyData,
+  mediaRefToLegacyFields,
+} from 'zhin.js';
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function readMentionTarget(data: Record<string, unknown>): string {
+  const raw = data.target ?? data.user_id ?? data.qq ?? data.id;
+  return raw != null ? String(raw) : '';
+}
+
+function normalizeMention(seg: MessageSegment): Segment {
+  const data = seg.data as Record<string, unknown>;
+  const target = readMentionTarget(data);
+  const name = typeof data.name === 'string' && data.name ? data.name : undefined;
+  return {
+    type: 'mention',
+    data: name ? { target, name } : { target },
+    ...(seg.platform ? { platform: seg.platform } : {}),
+  };
+}
+
+function normalizeImage(seg: MessageSegment): Segment {
+  const data = seg.data as Record<string, unknown>;
+  if (isMediaRef(data.media)) {
+    return {
+      type: 'image',
+      data: {
+        media: data.media,
+        ...(typeof data.alt === 'string' ? { alt: data.alt } : {}),
+      },
+      ...(seg.platform ? { platform: seg.platform } : {}),
+    };
+  }
+  const media = mediaRefFromLegacyData(data);
+  if (!media) return seg as Segment;
+  return createImageSegment(media, {
+    alt: typeof data.alt === 'string' ? data.alt : undefined,
+    platform: seg.platform,
+  });
+}
+
+function normalizeReply(seg: MessageSegment): Segment {
+  const data = seg.data as Record<string, unknown>;
+  const messageId = String(data.message_id ?? data.id ?? '').trim();
+  if (!messageId) return seg as Segment;
+  return { type: 'reply', data: { message_id: messageId } };
+}
+
+function normalizeSegment(seg: MessageSegment): Segment {
+  if (seg.type === 'at' || seg.type === 'mention') return normalizeMention(seg);
+  if (seg.type === 'image') return normalizeImage(seg);
+  if (seg.type === 'reply') return normalizeReply(seg);
+  if (seg.type === 'face') return seg as Segment;
+  if (seg.type === 'markdown') {
+    const data = seg.data as Record<string, unknown>;
+    const content = typeof data.content === 'string' ? data.content : '';
+    return { type: 'markdown', data: { content } };
+  }
+  return seg as Segment;
+}
+
+/** QQ 官方入站段 → canonical Segment[] */
+export function toCanonicalSegments(content: readonly MessageSegment[]): Segment[] {
+  return content.map((seg) => {
+    if (typeof seg === 'string') return { type: 'text', data: { text: seg } };
+    return normalizeSegment(seg);
+  });
+}
+
+/** canonical → QQ 官方 wire */
+export function fromCanonicalSegments(segments: readonly Segment[]): MessageSegment[] {
+  return segments.map((seg) => {
+    if (seg.type === 'image' && isRecord(seg.data) && seg.data.media) {
+      const media = seg.data.media as import('zhin.js').MediaRef;
+      const legacy = mediaRefToLegacyFields(media);
+      return {
+        type: 'image',
+        data: {
+          ...legacy,
+          media,
+          ...(typeof seg.data.alt === 'string' ? { alt: seg.data.alt } : {}),
+        },
+        ...(seg.platform ? { platform: seg.platform } : {}),
+      };
+    }
+    if (seg.type === 'mention') {
+      const data = seg.data as { target: string; name?: string };
+      return {
+        type: 'at',
+        data: {
+          qq: data.target,
+          id: data.target,
+          ...(data.name ? { name: data.name } : {}),
+        },
+        ...(seg.platform ? { platform: seg.platform } : {}),
+      };
+    }
+    if (seg.type === 'reply') {
+      const messageId = String((seg.data as { message_id: string }).message_id);
+      return {
+        type: 'reply',
+        data: { id: messageId, message_id: messageId },
+        ...(seg.platform ? { platform: seg.platform } : {}),
+      };
+    }
+    return seg as MessageSegment;
+  });
+}

--- a/plugins/adapters/qq/tests/segment-contract.test.ts
+++ b/plugins/adapters/qq/tests/segment-contract.test.ts
@@ -1,0 +1,34 @@
+import { describe, it } from 'vitest';
+import { fromCanonicalSegments, toCanonicalSegments } from '../src/segment-mapper.js';
+import { assertSegmentRoundTrip } from '../../../../packages/im/core/tests/helpers/segment-adapter-contract.js';
+
+const mapper = { toCanonicalSegments, fromCanonicalSegments };
+
+describe('qq segment contract', () => {
+  it('normalizes legacy image url to MediaRef', () => {
+    assertSegmentRoundTrip(
+      mapper,
+      [{ type: 'image', data: { url: 'https://cdn.example/cat.jpg' } }],
+      [{
+        type: 'image',
+        data: { media: { kind: 'url', value: 'https://cdn.example/cat.jpg' } },
+      }],
+    );
+  });
+
+  it('round-trips mention via at wire', () => {
+    assertSegmentRoundTrip(
+      mapper,
+      [{ type: 'at', data: { qq: '10001', id: '10001' } }],
+      [{ type: 'mention', data: { target: '10001' } }],
+    );
+  });
+
+  it('normalizes legacy reply id to message_id', () => {
+    assertSegmentRoundTrip(
+      mapper,
+      [{ type: 'reply', data: { id: 'q-1' } }],
+      [{ type: 'reply', data: { message_id: 'q-1' } }],
+    );
+  });
+});

--- a/scripts/check-segment-adapters.mjs
+++ b/scripts/check-segment-adapters.mjs
@@ -11,7 +11,7 @@ const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..'
 const adaptersDir = path.join(repoRoot, 'plugins/adapters');
 
 /** 必须含 segment-mapper + segment-contract.test.ts */
-const REQUIRED_ADAPTERS = new Set(['sandbox', 'icqq']);
+const REQUIRED_ADAPTERS = new Set(['sandbox', 'icqq', 'napcat', 'onebot11', 'qq']);
 
 /** 尚未迁移 segment-mapper 的 adapter（不报错） */
 const PENDING_ADAPTERS = new Set([
@@ -23,11 +23,8 @@ const PENDING_ADAPTERS = new Set([
   'lark',
   'line',
   'milky',
-  'napcat',
-  'onebot11',
   'onebot12',
   'process',
-  'qq',
   'satori',
   'slack',
   'telegram',


### PR DESCRIPTION
## Summary
- napcat / onebot11 / qq 增加 `segment-mapper` + `segment-contract.test.ts`
- 入站 `toCanonicalSegments`、出站 `fromCanonicalSegments` 已接入 endpoint
- `check:segments` 将三者从 pending 提升为 required

## Test plan
- [x] `pnpm vitest run plugins/adapters/{napcat,onebot11,qq}/tests/segment-contract.test.ts`
- [x] `pnpm check:segments`

Closes #556

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add canonical segment mappers for `napcat`, `onebot11`, and `qq` to normalize inbound messages and rebuild outbound payloads, ensuring consistent segment handling across adapters. Segment checks are now required as part of the CI for these adapters, aligning with #556.

- **New Features**
  - Implemented `segment-mapper` for `napcat`, `onebot11`, `qq` (mention, image `MediaRef`, reply ID, forward ID/resid; plus face/dice/rps and QQ markdown).
  - Wired endpoints to use `toCanonicalSegments` (inbound) and `fromCanonicalSegments` (outbound) for send/format paths.
  - Added `segment-contract.test.ts` for each adapter to verify round-trip behavior.
  - Updated `check-segment-adapters.mjs` to require these adapters in `check:segments`.

<sup>Written for commit ed5e712b220e802738412f2e21681da482b5e2ea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zhinjs/zhin/pull/565?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

