### PR TITLE
feat(segment): intl adapters segment-mapper + clear pending (#557)

### DIFF
--- a/plugins/adapters/common/generic-segment-mapper.ts
+++ b/plugins/adapters/common/generic-segment-mapper.ts
@@ -1,0 +1,151 @@
+import type { MessageElement, MessageSegment, Segment } from 'zhin.js';
+import {
+  createImageSegment,
+  isMediaRef,
+  mediaRefFromLegacyData,
+  mediaRefToLegacyFields,
+} from 'zhin.js';
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function readMentionTarget(data: Record<string, unknown>): string {
+  const raw = data.target ?? data.user_id ?? data.qq ?? data.id;
+  if (raw === 'all') return 'all';
+  return raw != null ? String(raw) : '';
+}
+
+function normalizeMention(seg: MessageSegment): Segment {
+  const data = seg.data as Record<string, unknown>;
+  const target = readMentionTarget(data);
+  const name = typeof data.name === 'string' && data.name ? data.name : undefined;
+  return {
+    type: 'mention',
+    data: name ? { target, name } : { target },
+    ...(seg.platform ? { platform: seg.platform } : {}),
+  };
+}
+
+function normalizeImage(seg: MessageSegment): Segment {
+  const data = seg.data as Record<string, unknown>;
+  if (isMediaRef(data.media)) {
+    return {
+      type: 'image',
+      data: {
+        media: data.media,
+        ...(typeof data.alt === 'string' ? { alt: data.alt } : {}),
+      },
+      ...(seg.platform ? { platform: seg.platform } : {}),
+    };
+  }
+  const media = mediaRefFromLegacyData(data);
+  if (media) {
+    const platform: Record<string, unknown> = { ...(seg.platform ?? {}) };
+    for (const key of ['url', 'file', 'src', 'file_id'] as const) {
+      if (typeof data[key] === 'string' && data[key]) platform[key] = data[key];
+    }
+    return createImageSegment(media, {
+      alt: typeof data.alt === 'string' ? data.alt : undefined,
+      platform: Object.keys(platform).length ? platform : undefined,
+    });
+  }
+  return seg as Segment;
+}
+
+function normalizeReply(seg: MessageSegment): Segment {
+  const data = seg.data as Record<string, unknown>;
+  const messageId = String(data.message_id ?? data.id ?? '').trim();
+  if (!messageId) return seg as Segment;
+  return { type: 'reply', data: { message_id: messageId } };
+}
+
+function normalizeLink(seg: MessageSegment): Segment {
+  const data = seg.data as Record<string, unknown>;
+  const url = String(data.url ?? data.href ?? '').trim();
+  if (!url) return seg as Segment;
+  const text = typeof data.text === 'string' && data.text ? data.text : undefined;
+  return {
+    type: 'link',
+    data: text ? { url, text } : { url },
+    ...(seg.platform ? { platform: seg.platform } : {}),
+  };
+}
+
+function normalizeMarkdown(seg: MessageSegment): Segment {
+  const data = seg.data as Record<string, unknown>;
+  const content = typeof data.content === 'string'
+    ? data.content
+    : typeof data.text === 'string'
+      ? data.text
+      : '';
+  return { type: 'markdown', data: { content } };
+}
+
+function normalizeSegment(seg: MessageSegment): Segment {
+  if (seg.type === 'at' || seg.type === 'mention') return normalizeMention(seg);
+  if (seg.type === 'image') return normalizeImage(seg);
+  if (seg.type === 'reply') return normalizeReply(seg);
+  if (seg.type === 'link') return normalizeLink(seg);
+  if (seg.type === 'markdown') return normalizeMarkdown(seg);
+  return seg as Segment;
+}
+
+function asMessageSegments(content: readonly unknown[]): MessageSegment[] {
+  return content.map((item) => {
+    if (typeof item === 'string') return { type: 'text', data: { text: item } };
+    return item as MessageSegment;
+  });
+}
+
+/** 通用 IM adapter：legacy wire → canonical Segment[] */
+export function toCanonicalSegments(content: readonly MessageElement[] | readonly unknown[]): Segment[] {
+  return asMessageSegments(content).map((seg) => normalizeSegment(seg));
+}
+
+/** canonical → wire（mention→at；image MediaRef→legacy 字段） */
+export function fromCanonicalSegments(segments: readonly Segment[]): MessageElement[] {
+  return segments.map((seg) => {
+    if (seg.type === 'image' && isRecord(seg.data) && seg.data.media) {
+      const media = seg.data.media as import('zhin.js').MediaRef;
+      const legacy = mediaRefToLegacyFields(media);
+      return {
+        type: 'image',
+        data: {
+          ...legacy,
+          media,
+          ...(typeof seg.data.alt === 'string' ? { alt: seg.data.alt } : {}),
+        },
+        ...(seg.platform ? { platform: seg.platform } : {}),
+      };
+    }
+    if (seg.type === 'mention') {
+      const data = seg.data as { target: string; name?: string };
+      return {
+        type: 'at',
+        data: {
+          id: data.target,
+          ...(data.name ? { name: data.name } : {}),
+        },
+        ...(seg.platform ? { platform: seg.platform } : {}),
+      };
+    }
+    if (seg.type === 'reply') {
+      const messageId = String((seg.data as { message_id: string }).message_id);
+      return {
+        type: 'reply',
+        data: { id: messageId, message_id: messageId },
+        ...(seg.platform ? { platform: seg.platform } : {}),
+      };
+    }
+    if (seg.type === 'link') {
+      const data = seg.data as { url: string; text?: string };
+      return {
+        type: 'link',
+        data: { url: data.url, ...(data.text ? { text: data.text } : {}) },
+        ...(seg.platform ? { platform: seg.platform } : {}),
+      };
+    }
+    return seg as MessageElement;
+  });
+}

--- a/plugins/adapters/dingtalk/src/endpoint.ts
+++ b/plugins/adapters/dingtalk/src/endpoint.ts
@@ -1,7 +1,7 @@
 /**
  * 钉钉 Endpoint 实现
  */
-import { formatCompact, Endpoint, Message, MessageSegment, segment, SendContent, SendOptions,} from 'zhin.js';
+import { formatCompact, Endpoint, Message, MessageSegment, segment, SendContent, SendOptions, expandInteractiveSegmentsInContent,} from 'zhin.js';
 import { registerFetchRoute, type Router, type RouterContext } from "@zhin.js/host-router/router";
 import { createHmac } from "crypto";
 import type {
@@ -12,6 +12,7 @@ import type {
 } from "./types.js";
 import type { DingTalkAdapter } from "./adapter.js";
 import { normalizeDingtalkSenderForPermit } from "./platform-permit.js";
+import { fromCanonicalSegments, toCanonicalSegments } from './segment-mapper.js';
 
 export class DingTalkEndpoint implements Endpoint<DingTalkEndpointConfig, DingTalkMessage> {
   $connected: boolean;
@@ -169,7 +170,8 @@ export class DingTalkEndpoint implements Endpoint<DingTalkEndpointConfig, DingTa
   }
 
   $formatMessage(msg: DingTalkMessage): Message<DingTalkMessage> {
-    const content = this.parseMessageContent(msg);
+    const wire = this.parseMessageContent(msg);
+    const content = toCanonicalSegments(wire);
     const chatType = msg.conversationType === "2" ? "group" : "private";
     const permit = normalizeDingtalkSenderForPermit({ isAdmin: msg.isAdmin === true });
     return Message.from(msg, {
@@ -306,7 +308,9 @@ export class DingTalkEndpoint implements Endpoint<DingTalkEndpointConfig, DingTa
 
   async $sendMessage(options: SendOptions): Promise<string> {
     const conversationId = options.id;
-    const content = this.formatSendContent(options.content);
+    const canonical = expandInteractiveSegmentsInContent(options.content);
+    const wire = fromCanonicalSegments(canonical);
+    const content = this.formatSendContent(wire);
     try {
       const sessionWebhook = this.sessionWebhooks.get(conversationId);
       if (sessionWebhook) {

--- a/plugins/adapters/dingtalk/src/segment-mapper.ts
+++ b/plugins/adapters/dingtalk/src/segment-mapper.ts
@@ -1,0 +1,1 @@
+export { toCanonicalSegments, fromCanonicalSegments } from '../../common/generic-segment-mapper.js';

--- a/plugins/adapters/dingtalk/tests/segment-contract.test.ts
+++ b/plugins/adapters/dingtalk/tests/segment-contract.test.ts
@@ -1,0 +1,23 @@
+import { describe, it } from 'vitest';
+import { fromCanonicalSegments, toCanonicalSegments } from '../src/segment-mapper.js';
+import { assertSegmentRoundTrip } from '../../../../packages/im/core/tests/helpers/segment-adapter-contract.js';
+
+const mapper = { toCanonicalSegments, fromCanonicalSegments };
+
+describe('dingtalk segment contract', () => {
+  it('round-trips text and mention', () => {
+    assertSegmentRoundTrip(
+      mapper,
+      [{ type: 'at', data: { id: 'u1', name: 'Bot' } }, { type: 'text', data: { text: ' hi' } }],
+      [{ type: 'mention', data: { target: 'u1', name: 'Bot' } }, { type: 'text', data: { text: ' hi' } }],
+    );
+  });
+
+  it('normalizes link url/text', () => {
+    assertSegmentRoundTrip(
+      mapper,
+      [{ type: 'link', data: { url: 'https://example.com', text: 'Example' } }],
+      [{ type: 'link', data: { url: 'https://example.com', text: 'Example' } }],
+    );
+  });
+});

--- a/plugins/adapters/discord/src/endpoint.ts
+++ b/plugins/adapters/discord/src/endpoint.ts
@@ -34,6 +34,7 @@ import {
   SendContent,
   MessageSegment,
   segment,
+  expandInteractiveSegmentsInContent,
   type EditMessageOptions,
 } from 'zhin.js';
 import type { DiscordGatewayConfig, DiscordChannelMessage } from "./types.js";
@@ -41,6 +42,7 @@ import type { DiscordAdapter } from "./adapter.js";
 import { createReadStream } from "fs";
 import { promises as fs } from "fs";
 import path from "path";
+import { fromCanonicalSegments, toCanonicalSegments } from './segment-mapper.js';
 
 export class DiscordEndpoint
   extends Client
@@ -253,7 +255,8 @@ export class DiscordEndpoint
     }
 
     // 转换消息内容为 segment 格式
-    const content = this.parseMessageContent(msg);
+    const wire = this.parseMessageContent(msg);
+    const content = toCanonicalSegments(wire);
 
     const sender = (() => {
       const base = {
@@ -599,9 +602,11 @@ export class DiscordEndpoint
         throw new Error(`Channel ${options.id} is not a text channel`);
       }
 
+      const canonical = expandInteractiveSegmentsInContent(options.content);
+      const wire = fromCanonicalSegments(canonical);
       const result = await this.sendContentToChannel(
         channel as any,
-        options.content
+        wire
       );
       this.messageChannelMap.set(result.id, options.id);
       this.pluginLogger.debug(

--- a/plugins/adapters/discord/src/segment-mapper.ts
+++ b/plugins/adapters/discord/src/segment-mapper.ts
@@ -1,0 +1,1 @@
+export { toCanonicalSegments, fromCanonicalSegments } from '../../common/generic-segment-mapper.js';

--- a/plugins/adapters/discord/tests/segment-contract.test.ts
+++ b/plugins/adapters/discord/tests/segment-contract.test.ts
@@ -1,0 +1,23 @@
+import { describe, it } from 'vitest';
+import { fromCanonicalSegments, toCanonicalSegments } from '../src/segment-mapper.js';
+import { assertSegmentRoundTrip } from '../../../../packages/im/core/tests/helpers/segment-adapter-contract.js';
+
+const mapper = { toCanonicalSegments, fromCanonicalSegments };
+
+describe('discord segment contract', () => {
+  it('round-trips text and mention', () => {
+    assertSegmentRoundTrip(
+      mapper,
+      [{ type: 'at', data: { id: 'u1', name: 'Bot' } }, { type: 'text', data: { text: ' hi' } }],
+      [{ type: 'mention', data: { target: 'u1', name: 'Bot' } }, { type: 'text', data: { text: ' hi' } }],
+    );
+  });
+
+  it('normalizes link url/text', () => {
+    assertSegmentRoundTrip(
+      mapper,
+      [{ type: 'link', data: { url: 'https://example.com', text: 'Example' } }],
+      [{ type: 'link', data: { url: 'https://example.com', text: 'Example' } }],
+    );
+  });
+});

--- a/plugins/adapters/email/src/endpoint.ts
+++ b/plugins/adapters/email/src/endpoint.ts
@@ -4,13 +4,14 @@
 import nodemailer from "nodemailer";
 import Imap from "imap";
 import { simpleParser, type ParsedMail, type Attachment } from "mailparser";
-import { formatCompact, Endpoint, Message, MessageSegment, segment, SendContent, SendOptions, htmlToPlainTextWithBlockBreaks,
+import { formatCompact, Endpoint, Message, MessageSegment, segment, SendContent, SendOptions, htmlToPlainTextWithBlockBreaks, expandInteractiveSegmentsInContent,
 } from 'zhin.js';
 import { EventEmitter } from "events";
 import { createWriteStream, promises as fs } from "fs";
 import path from "path";
 import type { EmailEndpointConfig, EmailMessage } from "./types.js";
 import type { EmailAdapter } from "./adapter.js";
+import { fromCanonicalSegments, toCanonicalSegments } from './segment-mapper.js';
 
 export class EmailEndpoint extends EventEmitter implements Endpoint<EmailEndpointConfig, EmailMessage> {
     $config: EmailEndpointConfig;
@@ -231,7 +232,8 @@ export class EmailEndpoint extends EventEmitter implements Endpoint<EmailEndpoin
         const channelId = emailMsg.from;
 
         // 解析邮件内容
-        const content = EmailEndpoint.parseEmailContent(emailMsg);
+        const wire = EmailEndpoint.parseEmailContent(emailMsg);
+        const content = toCanonicalSegments(wire);
 
         const result = Message.from(emailMsg, {
             $id: emailMsg.messageId,
@@ -312,7 +314,9 @@ export class EmailEndpoint extends EventEmitter implements Endpoint<EmailEndpoin
         }
 
         try {
-            const mailOptions = await this.formatSendContent(options);
+            const canonical = expandInteractiveSegmentsInContent(options.content);
+            const wire = fromCanonicalSegments(canonical);
+            const mailOptions = await this.formatSendContent({ ...options, content: wire });
             const info = await this.smtpTransporter.sendMail(mailOptions);
             this.logger.debug('Email sent:', info.messageId);
             return info.messageId || '';

--- a/plugins/adapters/email/src/segment-mapper.ts
+++ b/plugins/adapters/email/src/segment-mapper.ts
@@ -1,0 +1,1 @@
+export { toCanonicalSegments, fromCanonicalSegments } from '../../common/generic-segment-mapper.js';

--- a/plugins/adapters/email/tests/segment-contract.test.ts
+++ b/plugins/adapters/email/tests/segment-contract.test.ts
@@ -1,0 +1,23 @@
+import { describe, it } from 'vitest';
+import { fromCanonicalSegments, toCanonicalSegments } from '../src/segment-mapper.js';
+import { assertSegmentRoundTrip } from '../../../../packages/im/core/tests/helpers/segment-adapter-contract.js';
+
+const mapper = { toCanonicalSegments, fromCanonicalSegments };
+
+describe('email segment contract', () => {
+  it('round-trips text and mention', () => {
+    assertSegmentRoundTrip(
+      mapper,
+      [{ type: 'at', data: { id: 'u1', name: 'Bot' } }, { type: 'text', data: { text: ' hi' } }],
+      [{ type: 'mention', data: { target: 'u1', name: 'Bot' } }, { type: 'text', data: { text: ' hi' } }],
+    );
+  });
+
+  it('normalizes link url/text', () => {
+    assertSegmentRoundTrip(
+      mapper,
+      [{ type: 'link', data: { url: 'https://example.com', text: 'Example' } }],
+      [{ type: 'link', data: { url: 'https://example.com', text: 'Example' } }],
+    );
+  });
+});

--- a/plugins/adapters/github/src/endpoint.ts
+++ b/plugins/adapters/github/src/endpoint.ts
@@ -3,6 +3,7 @@
  */
 import { formatCompact, Endpoint, Message, segment, SendContent, SendOptions, type MessageSegment,
   coerceQrcodeSegmentsToText,
+  expandInteractiveSegmentsInContent,
 } from 'zhin.js';
 import type {
   GitHubEndpointConfig,
@@ -13,6 +14,7 @@ import type {
 import { buildChannelId, parseChannelId } from './types.js';
 import type { GitHubAdapter } from './adapter.js';
 import { GhClient } from './gh-client.js';
+import { fromCanonicalSegments, toCanonicalSegments } from './segment-mapper.js';
 
 export function parseMarkdown(md: string): MessageSegment[] {
   const segments: MessageSegment[] = [];
@@ -34,6 +36,7 @@ export function toMarkdown(content: SendContent): string {
     if (typeof seg === 'string') return seg;
     switch (seg.type) {
       case 'text': return seg.data.text || '';
+      case 'mention': return `@${seg.data.name || seg.data.target}`;
       case 'at': return `@${seg.data.name || seg.data.id}`;
       case 'image': return seg.data.url ? `![image](${seg.data.url})` : '[image]';
       case 'link': return `[${seg.data.text || seg.data.url}](${seg.data.url})`;
@@ -85,7 +88,7 @@ export class GitHubEndpoint implements Endpoint<GitHubEndpointConfig, IssueComme
       $endpoint: this.$config.name,
       $sender: { id: payload.sender.login, name: payload.sender.login },
       $channel: { id: channelId, type: 'group' },
-      $content: parseMarkdown(payload.comment.body),
+      $content: toCanonicalSegments(parseMarkdown(payload.comment.body)),
       $raw: payload.comment.body,
       $timestamp: new Date(payload.comment.created_at).getTime(),
       $recall: async () => { await gh.deleteIssueComment(repo, payload.comment.id); },
@@ -115,7 +118,7 @@ export class GitHubEndpoint implements Endpoint<GitHubEndpointConfig, IssueComme
       $endpoint: this.$config.name,
       $sender: { id: payload.sender.login, name: payload.sender.login },
       $channel: { id: channelId, type: 'group' },
-      $content: parseMarkdown(body),
+      $content: toCanonicalSegments(parseMarkdown(body)),
       $raw: body,
       $timestamp: new Date(payload.comment.created_at).getTime(),
       $recall: async () => { await gh.deletePRReviewComment(repo, payload.comment.id); },
@@ -145,7 +148,7 @@ export class GitHubEndpoint implements Endpoint<GitHubEndpointConfig, IssueComme
       $endpoint: this.$config.name,
       $sender: { id: payload.sender.login, name: payload.sender.login },
       $channel: { id: channelId, type: 'group' },
-      $content: parseMarkdown(body),
+      $content: toCanonicalSegments(parseMarkdown(body)),
       $raw: body,
       $timestamp: new Date(payload.review.submitted_at).getTime(),
       $recall: async () => {},
@@ -160,7 +163,10 @@ export class GitHubEndpoint implements Endpoint<GitHubEndpointConfig, IssueComme
     const parsed = parseChannelId(options.id);
     if (!parsed) throw new Error(`无效的 GitHub channel ID: ${options.id}`);
 
-    const text = toMarkdown(coerceQrcodeSegmentsToText(options.content ?? ''));
+    const expanded = expandInteractiveSegmentsInContent(coerceQrcodeSegmentsToText(options.content ?? ''));
+    const arr = Array.isArray(expanded) ? expanded : [expanded];
+    const canonical = arr.map((s) => (typeof s === 'string' ? { type: 'text' as const, data: { text: s } } : s));
+    const text = toMarkdown(fromCanonicalSegments(canonical));
     const r = parsed.type === 'issue'
       ? await this.gh.createIssueComment(parsed.repo, parsed.number, text)
       : await this.gh.createPRComment(parsed.repo, parsed.number, text);

--- a/plugins/adapters/github/src/segment-mapper.ts
+++ b/plugins/adapters/github/src/segment-mapper.ts
@@ -1,0 +1,1 @@
+export { toCanonicalSegments, fromCanonicalSegments } from '../../common/generic-segment-mapper.js';

--- a/plugins/adapters/github/tests/segment-contract.test.ts
+++ b/plugins/adapters/github/tests/segment-contract.test.ts
@@ -1,0 +1,23 @@
+import { describe, it } from 'vitest';
+import { fromCanonicalSegments, toCanonicalSegments } from '../src/segment-mapper.js';
+import { assertSegmentRoundTrip } from '../../../../packages/im/core/tests/helpers/segment-adapter-contract.js';
+
+const mapper = { toCanonicalSegments, fromCanonicalSegments };
+
+describe('github segment contract', () => {
+  it('round-trips text and mention', () => {
+    assertSegmentRoundTrip(
+      mapper,
+      [{ type: 'at', data: { id: 'u1', name: 'Bot' } }, { type: 'text', data: { text: ' hi' } }],
+      [{ type: 'mention', data: { target: 'u1', name: 'Bot' } }, { type: 'text', data: { text: ' hi' } }],
+    );
+  });
+
+  it('normalizes link url/text', () => {
+    assertSegmentRoundTrip(
+      mapper,
+      [{ type: 'link', data: { url: 'https://example.com', text: 'Example' } }],
+      [{ type: 'link', data: { url: 'https://example.com', text: 'Example' } }],
+    );
+  });
+});

--- a/plugins/adapters/kook/src/endpoint.ts
+++ b/plugins/adapters/kook/src/endpoint.ts
@@ -57,6 +57,7 @@ import {
 import { materializeOutboundMedia } from "./outbound-media.js";
 import { uploadKookAsset } from "./kook-asset-upload.js";
 import { convertToKookSendable } from "./outbound-sendable.js";
+import { fromCanonicalSegments, toCanonicalSegments } from './segment-mapper.js';
 
 export class KookEndpoint extends Client implements Endpoint<KookEndpointConfig, KookRawMessage> {
   $connected: boolean = false;
@@ -235,7 +236,7 @@ export class KookEndpoint extends Client implements Endpoint<KookEndpointConfig,
         ...(guildId ? { guild_id: guildId } : {}),
       },
       
-      $content: this.parseMessageContent(msg.message),
+      $content: toCanonicalSegments(this.parseMessageContent(msg.message)),
       $raw: msg.raw_message,
       $timestamp: msg.timestamp,
       
@@ -721,7 +722,9 @@ export class KookEndpoint extends Client implements Endpoint<KookEndpointConfig,
     try {
       const { id, type, content } = options;
 
-      const elements = await materializeOutboundMedia(this, expandInteractiveSegmentsInContent(content));
+      const canonical = expandInteractiveSegmentsInContent(content);
+      const wire = fromCanonicalSegments(canonical);
+      const elements = await materializeOutboundMedia(this, wire);
       const kookContent = convertToKookSendable(
         elements,
         (els) => this.convertToKookFormat(els),

--- a/plugins/adapters/kook/src/segment-mapper.ts
+++ b/plugins/adapters/kook/src/segment-mapper.ts
@@ -1,0 +1,1 @@
+export { toCanonicalSegments, fromCanonicalSegments } from '../../common/generic-segment-mapper.js';

--- a/plugins/adapters/kook/tests/segment-contract.test.ts
+++ b/plugins/adapters/kook/tests/segment-contract.test.ts
@@ -1,0 +1,23 @@
+import { describe, it } from 'vitest';
+import { fromCanonicalSegments, toCanonicalSegments } from '../src/segment-mapper.js';
+import { assertSegmentRoundTrip } from '../../../../packages/im/core/tests/helpers/segment-adapter-contract.js';
+
+const mapper = { toCanonicalSegments, fromCanonicalSegments };
+
+describe('kook segment contract', () => {
+  it('round-trips text and mention', () => {
+    assertSegmentRoundTrip(
+      mapper,
+      [{ type: 'at', data: { id: 'u1', name: 'Bot' } }, { type: 'text', data: { text: ' hi' } }],
+      [{ type: 'mention', data: { target: 'u1', name: 'Bot' } }, { type: 'text', data: { text: ' hi' } }],
+    );
+  });
+
+  it('normalizes link url/text', () => {
+    assertSegmentRoundTrip(
+      mapper,
+      [{ type: 'link', data: { url: 'https://example.com', text: 'Example' } }],
+      [{ type: 'link', data: { url: 'https://example.com', text: 'Example' } }],
+    );
+  });
+});

--- a/plugins/adapters/lark/src/endpoint.ts
+++ b/plugins/adapters/lark/src/endpoint.ts
@@ -4,10 +4,11 @@
 import { registerFetchRoute, type Router, type RouterContext } from "@zhin.js/host-router/router";
 import axios, { type AxiosInstance } from "axios";
 import { createHash } from "crypto";
-import { formatCompact, Endpoint, Message, MessageSegment, segment, SendContent, SendOptions,} from 'zhin.js';
+import { formatCompact, Endpoint, Message, MessageSegment, segment, SendContent, SendOptions, expandInteractiveSegmentsInContent,} from 'zhin.js';
 import type { LarkEndpointConfig, LarkMessage, LarkEvent, AccessToken } from "./types.js";
 import type { LarkAdapter } from "./adapter.js";
 import { normalizeLarkSenderForPermit } from "./platform-permit.js";
+import { fromCanonicalSegments, toCanonicalSegments } from './segment-mapper.js';
 
 export class LarkEndpoint implements Endpoint<LarkEndpointConfig, LarkMessage> {
     $connected: boolean
@@ -221,7 +222,8 @@ export class LarkEndpoint implements Endpoint<LarkEndpointConfig, LarkMessage> {
     // ================================================================================================
 
     $formatMessage(msg: LarkMessage, event?: any): Message<LarkMessage> {
-        const content = this.parseMessageContent(msg);
+        const wire = this.parseMessageContent(msg);
+        const content = toCanonicalSegments(wire);
         
         // 确定聊天类型
         const chatType = msg.chat_id?.startsWith('oc_') ? 'group' : 'private';
@@ -373,7 +375,9 @@ export class LarkEndpoint implements Endpoint<LarkEndpointConfig, LarkMessage> {
 
     async $sendMessage(options: SendOptions): Promise<string> {
         const chatId = options.id;
-        const content = this.formatSendContent(options.content);
+        const canonical = expandInteractiveSegmentsInContent(options.content);
+        const wire = fromCanonicalSegments(canonical);
+        const content = this.formatSendContent(wire);
         
         try {
             const response = await this.axiosInstance.post('/im/v1/messages', {

--- a/plugins/adapters/lark/src/segment-mapper.ts
+++ b/plugins/adapters/lark/src/segment-mapper.ts
@@ -1,0 +1,1 @@
+export { toCanonicalSegments, fromCanonicalSegments } from '../../common/generic-segment-mapper.js';

--- a/plugins/adapters/lark/tests/segment-contract.test.ts
+++ b/plugins/adapters/lark/tests/segment-contract.test.ts
@@ -1,0 +1,23 @@
+import { describe, it } from 'vitest';
+import { fromCanonicalSegments, toCanonicalSegments } from '../src/segment-mapper.js';
+import { assertSegmentRoundTrip } from '../../../../packages/im/core/tests/helpers/segment-adapter-contract.js';
+
+const mapper = { toCanonicalSegments, fromCanonicalSegments };
+
+describe('lark segment contract', () => {
+  it('round-trips text and mention', () => {
+    assertSegmentRoundTrip(
+      mapper,
+      [{ type: 'at', data: { id: 'u1', name: 'Bot' } }, { type: 'text', data: { text: ' hi' } }],
+      [{ type: 'mention', data: { target: 'u1', name: 'Bot' } }, { type: 'text', data: { text: ' hi' } }],
+    );
+  });
+
+  it('normalizes link url/text', () => {
+    assertSegmentRoundTrip(
+      mapper,
+      [{ type: 'link', data: { url: 'https://example.com', text: 'Example' } }],
+      [{ type: 'link', data: { url: 'https://example.com', text: 'Example' } }],
+    );
+  });
+});

--- a/plugins/adapters/line/src/endpoint.ts
+++ b/plugins/adapters/line/src/endpoint.ts
@@ -13,6 +13,7 @@ import {
   MessageSegment,
   segment,
   formatCompact,
+  expandInteractiveSegmentsInContent,
   type QuotedMessagePayload,} from 'zhin.js';
 import { registerFetchRoute, type Router, type RouterContext } from "@zhin.js/host-router/router";
 import type {
@@ -30,6 +31,7 @@ import type {
   LineApiResponse,
 } from "./types.js";
 import type { LineAdapter } from "./adapter.js";
+import { fromCanonicalSegments, toCanonicalSegments } from './segment-mapper.js';
 
 /** Type guard: narrows a LineEvent to a message event */
 function isMessageEvent(e: LineEvent): e is LineMessageEvent {
@@ -248,9 +250,10 @@ export class LineEndpoint implements Endpoint<LineEndpointConfig, LineEvent> {
 
   $formatMessage(event: LineEvent): Message<LineEvent> {
     const { channelType, channelId } = this.resolveChannel(event.source);
-    const content = this.parseMessageContent(event);
-    const quoteId = Message.quoteIdFromContent(content);
-    Message.alignReplySegments(content, quoteId);
+    const wire = this.parseMessageContent(event);
+    const quoteId = Message.quoteIdFromContent(wire);
+    Message.alignReplySegments(wire, quoteId);
+    const content = toCanonicalSegments(wire);
 
     const userId = event.source.userId || "";
     const timestamp = event.timestamp || Date.now();
@@ -421,7 +424,9 @@ export class LineEndpoint implements Endpoint<LineEndpointConfig, LineEvent> {
 
   async $sendMessage(options: SendOptions): Promise<string> {
     try {
-      const messages = this.buildLineMessages(options.content);
+      const canonical = expandInteractiveSegmentsInContent(options.content);
+      const wire = fromCanonicalSegments(canonical);
+      const messages = this.buildLineMessages(wire);
       if (messages.length === 0) {
         throw new Error("No valid LINE messages to send");
       }

--- a/plugins/adapters/line/src/segment-mapper.ts
+++ b/plugins/adapters/line/src/segment-mapper.ts
@@ -1,0 +1,1 @@
+export { toCanonicalSegments, fromCanonicalSegments } from '../../common/generic-segment-mapper.js';

--- a/plugins/adapters/line/tests/segment-contract.test.ts
+++ b/plugins/adapters/line/tests/segment-contract.test.ts
@@ -1,0 +1,23 @@
+import { describe, it } from 'vitest';
+import { fromCanonicalSegments, toCanonicalSegments } from '../src/segment-mapper.js';
+import { assertSegmentRoundTrip } from '../../../../packages/im/core/tests/helpers/segment-adapter-contract.js';
+
+const mapper = { toCanonicalSegments, fromCanonicalSegments };
+
+describe('line segment contract', () => {
+  it('round-trips text and mention', () => {
+    assertSegmentRoundTrip(
+      mapper,
+      [{ type: 'at', data: { id: 'u1', name: 'Bot' } }, { type: 'text', data: { text: ' hi' } }],
+      [{ type: 'mention', data: { target: 'u1', name: 'Bot' } }, { type: 'text', data: { text: ' hi' } }],
+    );
+  });
+
+  it('normalizes link url/text', () => {
+    assertSegmentRoundTrip(
+      mapper,
+      [{ type: 'link', data: { url: 'https://example.com', text: 'Example' } }],
+      [{ type: 'link', data: { url: 'https://example.com', text: 'Example' } }],
+    );
+  });
+});

--- a/plugins/adapters/milky/src/endpoint-sse.ts
+++ b/plugins/adapters/milky/src/endpoint-sse.ts
@@ -3,7 +3,7 @@
  */
 import EventSource from 'eventsource';
 import { EventEmitter } from 'events';
-import { formatCompact, Endpoint, Message, segment, SendOptions,} from 'zhin.js';
+import { formatCompact, Endpoint, Message, segment, SendOptions, expandInteractiveSegmentsInContent,} from 'zhin.js';
 import { callApi } from './api.js';
 import type { MilkySseConfig, MilkyEvent } from './types.js';
 import type { MilkyAdapter } from './adapter.js';
@@ -13,6 +13,7 @@ import {
   toMilkyOutgoingSegments,
   parseMilkyMessageId,
 } from './utils.js';
+import { fromCanonicalSegments } from './segment-mapper.js';
 
 export class MilkySseClient extends EventEmitter implements Endpoint<MilkySseConfig, MilkyEvent> {
   $connected: boolean;
@@ -121,11 +122,12 @@ export class MilkySseClient extends EventEmitter implements Endpoint<MilkySseCon
   }
 
   async $sendMessage(options: SendOptions): Promise<string> {
-    const content = Array.isArray(options.content) ? options.content : [options.content];
-    const segments = content.map((c) =>
-      typeof c === 'string' ? { type: 'text' as const, data: { text: c } } : (c as { type: string; data?: Record<string, unknown> }),
+    const expanded = expandInteractiveSegmentsInContent(options.content);
+    const arr = Array.isArray(expanded) ? expanded : [expanded];
+    const wire = fromCanonicalSegments(
+      arr.map((c) => (typeof c === 'string' ? { type: 'text' as const, data: { text: c } } : c)),
     );
-    const message = toMilkyOutgoingSegments(segments);
+    const message = toMilkyOutgoingSegments(wire);
     if (options.type === 'group') {
       const result = await callApi(this.apiOptions(), 'send_group_message', {
         group_id: parseInt(options.id, 10),

--- a/plugins/adapters/milky/src/endpoint-webhook.ts
+++ b/plugins/adapters/milky/src/endpoint-webhook.ts
@@ -2,7 +2,7 @@
  * Milky Webhook Bot：无长连接，在 router.post(path) 接收 POST 事件，鉴权后转 Message
  */
 import { EventEmitter } from 'events';
-import { formatCompact, Endpoint, Message, segment, SendOptions,} from 'zhin.js';
+import { formatCompact, Endpoint, Message, segment, SendOptions, expandInteractiveSegmentsInContent,} from 'zhin.js';
 import { firstHeader, firstQuery, registerFetchRoute, type Router, type RouterContext } from '@zhin.js/host-router/router';
 import { callApi } from './api.js';
 import type { MilkyWebhookConfig, MilkyEvent } from './types.js';
@@ -13,6 +13,7 @@ import {
   toMilkyOutgoingSegments,
   parseMilkyMessageId,
 } from './utils.js';
+import { fromCanonicalSegments } from './segment-mapper.js';
 
 function getAccessTokenFromRequest(ctx: RouterContext): string | undefined {
   const auth = firstHeader(ctx, 'authorization');
@@ -116,11 +117,12 @@ export class MilkyWebhookEndpoint extends EventEmitter implements Endpoint<Milky
   }
 
   async $sendMessage(options: SendOptions): Promise<string> {
-    const content = Array.isArray(options.content) ? options.content : [options.content];
-    const segments = content.map((c) =>
-      typeof c === 'string' ? { type: 'text' as const, data: { text: c } } : (c as { type: string; data?: Record<string, unknown> }),
+    const expanded = expandInteractiveSegmentsInContent(options.content);
+    const arr = Array.isArray(expanded) ? expanded : [expanded];
+    const wire = fromCanonicalSegments(
+      arr.map((c) => (typeof c === 'string' ? { type: 'text' as const, data: { text: c } } : c)),
     );
-    const message = toMilkyOutgoingSegments(segments);
+    const message = toMilkyOutgoingSegments(wire);
     if (options.type === 'group') {
       const result = await callApi(this.apiOptions(), 'send_group_message', {
         group_id: parseInt(options.id, 10),

--- a/plugins/adapters/milky/src/endpoint-ws.ts
+++ b/plugins/adapters/milky/src/endpoint-ws.ts
@@ -4,7 +4,7 @@
 import WebSocket from 'ws';
 import { EventEmitter } from 'events';
 import { clearInterval } from 'node:timers';
-import { formatCompact, Endpoint, Message, segment, SendOptions,} from 'zhin.js';
+import { formatCompact, Endpoint, Message, segment, SendOptions, expandInteractiveSegmentsInContent,} from 'zhin.js';
 import { callApi } from './api.js';
 import type { MilkyWsConfig, MilkyEvent } from './types.js';
 import type { MilkyAdapter } from './adapter.js';
@@ -14,6 +14,7 @@ import {
   toMilkyOutgoingSegments,
   parseMilkyMessageId,
 } from './utils.js';
+import { fromCanonicalSegments } from './segment-mapper.js';
 
 export class MilkyWsClient extends EventEmitter implements Endpoint<MilkyWsConfig, MilkyEvent> {
   $connected: boolean;
@@ -162,11 +163,12 @@ export class MilkyWsClient extends EventEmitter implements Endpoint<MilkyWsConfi
   }
 
   async $sendMessage(options: SendOptions): Promise<string> {
-    const content = Array.isArray(options.content) ? options.content : [options.content];
-    const segments = content.map((c) =>
-      typeof c === 'string' ? { type: 'text' as const, data: { text: c } } : (c as { type: string; data?: Record<string, unknown> }),
+    const expanded = expandInteractiveSegmentsInContent(options.content);
+    const arr = Array.isArray(expanded) ? expanded : [expanded];
+    const wire = fromCanonicalSegments(
+      arr.map((c) => (typeof c === 'string' ? { type: 'text' as const, data: { text: c } } : c)),
     );
-    const message = toMilkyOutgoingSegments(segments);
+    const message = toMilkyOutgoingSegments(wire);
     if (options.type === 'group') {
       const result = await callApi(this.apiOptions(), 'send_group_message', {
         group_id: parseInt(options.id, 10),

--- a/plugins/adapters/milky/src/endpoint-wss.ts
+++ b/plugins/adapters/milky/src/endpoint-wss.ts
@@ -5,7 +5,7 @@ import { IncomingMessage } from 'http';
 import WebSocket, { WebSocketServer } from 'ws';
 import { EventEmitter } from 'events';
 import { clearInterval } from 'node:timers';
-import { formatCompact, Endpoint, Message, segment, SendOptions,} from 'zhin.js';
+import { formatCompact, Endpoint, Message, segment, SendOptions, expandInteractiveSegmentsInContent,} from 'zhin.js';
 import type { Router } from '@zhin.js/host-router';
 import { callApi } from './api.js';
 import type { MilkyWssConfig, MilkyEvent } from './types.js';
@@ -16,6 +16,7 @@ import {
   toMilkyOutgoingSegments,
   parseMilkyMessageId,
 } from './utils.js';
+import { fromCanonicalSegments } from './segment-mapper.js';
 
 function getAccessTokenFromWsRequest(req: IncomingMessage): string | undefined {
   const auth = req.headers['authorization'];
@@ -154,11 +155,12 @@ export class MilkyWssServer extends EventEmitter implements Endpoint<MilkyWssCon
   }
 
   async $sendMessage(options: SendOptions): Promise<string> {
-    const content = Array.isArray(options.content) ? options.content : [options.content];
-    const segments = content.map((c) =>
-      typeof c === 'string' ? { type: 'text' as const, data: { text: c } } : (c as { type: string; data?: Record<string, unknown> }),
+    const expanded = expandInteractiveSegmentsInContent(options.content);
+    const arr = Array.isArray(expanded) ? expanded : [expanded];
+    const wire = fromCanonicalSegments(
+      arr.map((c) => (typeof c === 'string' ? { type: 'text' as const, data: { text: c } } : c)),
     );
-    const message = toMilkyOutgoingSegments(segments);
+    const message = toMilkyOutgoingSegments(wire);
     if (options.type === 'group') {
       const result = await callApi(this.apiOptions(), 'send_group_message', {
         group_id: parseInt(options.id, 10),

--- a/plugins/adapters/milky/src/segment-mapper.ts
+++ b/plugins/adapters/milky/src/segment-mapper.ts
@@ -1,0 +1,193 @@
+import type { MessageSegment, Segment } from 'zhin.js';
+import {
+  createImageSegment,
+  isMediaRef,
+  mediaRefFromLegacyData,
+  mediaRefToLegacyFields,
+} from 'zhin.js';
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function readMentionTarget(data: Record<string, unknown>): string {
+  const raw = data.target ?? data.user_id ?? data.qq ?? data.id;
+  if (raw === 'all') return 'all';
+  return raw != null ? String(raw) : '';
+}
+
+function normalizeMention(seg: MessageSegment): Segment {
+  const data = seg.data as Record<string, unknown>;
+  const target = readMentionTarget(data);
+  const name = typeof data.name === 'string' && data.name ? data.name : undefined;
+  return {
+    type: 'mention',
+    data: name ? { target, name } : { target },
+    ...(seg.platform ? { platform: seg.platform } : {}),
+  };
+}
+
+function normalizeImage(seg: MessageSegment): Segment {
+  const data = seg.data as Record<string, unknown>;
+  if (isMediaRef(data.media)) {
+    return {
+      type: 'image',
+      data: {
+        media: data.media,
+        ...(typeof data.alt === 'string' ? { alt: data.alt } : {}),
+      },
+      ...(seg.platform ? { platform: seg.platform } : {}),
+    };
+  }
+  const media = mediaRefFromLegacyData(data);
+  if (!media) return seg as Segment;
+
+  const platform: Record<string, unknown> = { ...(seg.platform ?? {}) };
+  for (const key of ['url', 'file', 'src'] as const) {
+    if (typeof data[key] === 'string' && data[key]) platform[key] = data[key];
+  }
+
+  return createImageSegment(media, {
+    alt: typeof data.alt === 'string' ? data.alt : undefined,
+    platform: Object.keys(platform).length ? platform : undefined,
+  });
+}
+
+function normalizeReply(seg: MessageSegment): Segment {
+  const data = seg.data as Record<string, unknown>;
+  const messageId = String(data.message_id ?? data.id ?? '').trim();
+  if (!messageId) return seg as Segment;
+  return { type: 'reply', data: { message_id: messageId } };
+}
+
+function normalizeForward(seg: MessageSegment): Segment {
+  const data = seg.data as Record<string, unknown>;
+  const forwardId = String(
+    data.forward_id ?? data.id ?? data.resid ?? data.res_id ?? '',
+  ).trim();
+  if (!forwardId) return seg as Segment;
+
+  const platform: Record<string, unknown> = { ...(seg.platform ?? {}) };
+  for (const key of ['resid', 'res_id'] as const) {
+    if (typeof data[key] === 'string' && data[key]) platform[key] = data[key];
+  }
+
+  return {
+    type: 'forward',
+    data: {
+      forward_id: forwardId,
+      ...(typeof data.title === 'string' && data.title ? { title: data.title } : {}),
+      ...(Array.isArray(data.messages) ? { messages: data.messages as Segment[][] } : {}),
+    },
+    ...(Object.keys(platform).length ? { platform } : {}),
+  };
+}
+
+function normalizeFace(seg: MessageSegment): Segment {
+  const data = seg.data as Record<string, unknown>;
+  const id = data.id ?? data.face_id;
+  if (id == null || id === '') return seg as Segment;
+  const name =
+    typeof data.name === 'string' && data.name
+      ? data.name
+      : typeof data.text === 'string' && data.text
+        ? data.text
+        : undefined;
+  return {
+    type: 'face',
+    data: {
+      id: typeof id === 'number' ? id : String(id),
+      ...(name ? { name } : {}),
+    },
+    ...(seg.platform ? { platform: seg.platform } : {}),
+  };
+}
+
+function normalizeGame(seg: MessageSegment, type: 'dice' | 'rps'): Segment {
+  const data = seg.data as Record<string, unknown>;
+  const result = typeof data.result === 'number' ? data.result : undefined;
+  return {
+    type,
+    data: result != null ? { result } : {},
+    ...(seg.platform ? { platform: seg.platform } : {}),
+  };
+}
+
+function normalizeSegment(seg: MessageSegment): Segment {
+  if (seg.type === 'at' || seg.type === 'mention') return normalizeMention(seg);
+  if (seg.type === 'image') return normalizeImage(seg);
+  if (seg.type === 'reply') return normalizeReply(seg);
+  if (seg.type === 'forward') return normalizeForward(seg);
+  if (seg.type === 'face' || seg.type === 'sticker' || seg.type === 'emoji') {
+    return normalizeFace(seg);
+  }
+  if (seg.type === 'dice' || seg.type === 'rps') return normalizeGame(seg, seg.type);
+  return seg as Segment;
+}
+
+/** 入站 legacy / CQ 段 → canonical Segment[] */
+export function toCanonicalSegments(content: readonly MessageSegment[]): Segment[] {
+  return content.map((seg) => {
+    if (typeof seg === 'string') return { type: 'text', data: { text: seg } };
+    return normalizeSegment(seg);
+  });
+}
+
+/** 出站：canonical → OneBot11 wire（CQ 构建仍读 url/file + media） */
+export function fromCanonicalSegments(segments: readonly Segment[]): MessageSegment[] {
+  return segments.map((seg) => {
+    if (seg.type === 'image' && isRecord(seg.data) && seg.data.media) {
+      const media = seg.data.media as import('zhin.js').MediaRef;
+      const legacy = mediaRefToLegacyFields(media);
+      return {
+        type: 'image',
+        data: {
+          ...legacy,
+          media,
+          ...(typeof seg.data.alt === 'string' ? { alt: seg.data.alt } : {}),
+        },
+        ...(seg.platform ? { platform: seg.platform } : {}),
+      };
+    }
+    if (seg.type === 'mention') {
+      const data = seg.data as { target: string; name?: string };
+      return {
+        type: 'at',
+        data: {
+          qq: data.target,
+          ...(data.name ? { name: data.name } : {}),
+        },
+        ...(seg.platform ? { platform: seg.platform } : {}),
+      };
+    }
+    if (seg.type === 'reply') {
+      const messageId = String((seg.data as { message_id: string }).message_id);
+      return {
+        type: 'reply',
+        data: { id: messageId, message_id: messageId },
+        ...(seg.platform ? { platform: seg.platform } : {}),
+      };
+    }
+    if (seg.type === 'forward') {
+      const data = seg.data as {
+        forward_id: string;
+        title?: string;
+        messages?: unknown;
+      };
+      const platform = { ...(seg.platform ?? {}) };
+      const resid = platform.resid ?? data.forward_id;
+      return {
+        type: 'forward',
+        data: {
+          id: data.forward_id,
+          forward_id: data.forward_id,
+          resid,
+          ...(data.title ? { title: data.title } : {}),
+          ...(data.messages ? { messages: data.messages } : {}),
+        },
+        platform: { ...platform, resid },
+      };
+    }
+    return seg as MessageSegment;
+  });
+}

--- a/plugins/adapters/milky/src/utils.ts
+++ b/plugins/adapters/milky/src/utils.ts
@@ -4,6 +4,7 @@
 import type { MessageBase, SendContent } from 'zhin.js';
 import { Message, applyQqSenderRoleToMessageSender } from 'zhin.js';
 import type { MilkyEvent, MilkyIncomingMessage, MilkyIncomingSegment } from './types.js';
+import { toCanonicalSegments } from './segment-mapper.js';
 
 /** 将 Milky 接收消息段转为 zhin 的 $content（MessageSegment[]） */
 export function formatMilkySegments(segments: MilkyIncomingSegment[]): Array<{ type: string; data: Record<string, unknown> }> {
@@ -76,7 +77,7 @@ export function formatMilkyMessagePayload(
   const senderId = data.sender_id.toString();
   const senderName =
     (isGroup ? data.group_member?.card ?? data.group_member?.nickname : data.friend?.nickname) ?? senderId;
-  const content = formatMilkySegments(data.segments);
+  const content = toCanonicalSegments(formatMilkySegments(data.segments));
   const raw = content.map((c) => (c.type === 'text' ? (c.data as { text?: string }).text : '')).join('');
 
   return {

--- a/plugins/adapters/milky/tests/segment-contract.test.ts
+++ b/plugins/adapters/milky/tests/segment-contract.test.ts
@@ -1,0 +1,43 @@
+/**
+ * milky segment contract — OneBot11 wire round-trip
+ */
+import { describe, it } from 'vitest';
+import { fromCanonicalSegments, toCanonicalSegments } from '../src/segment-mapper.js';
+import { assertSegmentRoundTrip } from '../../../../packages/im/core/tests/helpers/segment-adapter-contract.js';
+
+const mapper = { toCanonicalSegments, fromCanonicalSegments };
+
+describe('milky segment contract', () => {
+  it('normalizes legacy image url to MediaRef', () => {
+    assertSegmentRoundTrip(
+      mapper,
+      [{ type: 'image', data: { url: 'https://cdn.example/cat.jpg', file: 'https://cdn.example/cat.jpg' } }],
+      [{
+        type: 'image',
+        data: { media: { kind: 'url', value: 'https://cdn.example/cat.jpg' } },
+        platform: { url: 'https://cdn.example/cat.jpg', file: 'https://cdn.example/cat.jpg' },
+      }],
+    );
+  });
+
+  it('round-trips mention via at wire', () => {
+    assertSegmentRoundTrip(
+      mapper,
+      [{ type: 'at', data: { qq: '10001', name: 'Alice' } }],
+      [{ type: 'mention', data: { target: '10001', name: 'Alice' } }],
+    );
+  });
+
+  it('normalizes legacy reply id to message_id', () => {
+    assertSegmentRoundTrip(
+      mapper,
+      [{ type: 'reply', data: { id: 'q-1' } }],
+      [{ type: 'reply', data: { message_id: 'q-1' } }],
+    );
+  });
+
+  it('round-trips dice and rps', () => {
+    assertSegmentRoundTrip(mapper, [{ type: 'dice', data: {} }], [{ type: 'dice', data: {} }]);
+    assertSegmentRoundTrip(mapper, [{ type: 'rps', data: { result: 1 } }], [{ type: 'rps', data: { result: 1 } }]);
+  });
+});

--- a/plugins/adapters/onebot12/src/endpoint-webhook.ts
+++ b/plugins/adapters/onebot12/src/endpoint-webhook.ts
@@ -2,12 +2,13 @@
  * OneBot 12 HTTP Webhook Bot：OneBot 实现 POST 事件到应用 path，可选 api_url 用于发消息
  */
 import { EventEmitter } from 'events';
-import { formatCompact, Endpoint, Message, segment, SendOptions,} from 'zhin.js';
+import { formatCompact, Endpoint, Message, segment, SendOptions, expandInteractiveSegmentsInContent,} from 'zhin.js';
 import { registerFetchRoute, type Router, type RouterContext } from '@zhin.js/host-router/router';
 import { callOneBot12Action } from './api.js';
 import type { OneBot12WebhookConfig, OneBot12Event } from './types.js';
 import type { OneBot12Adapter } from './adapter.js';
 import { formatOneBot12MessagePayload, isMessageEvent, contentToOb12Segments } from './utils.js';
+import { fromCanonicalSegments } from './segment-mapper.js';
 
 export class OneBot12WebhookEndpoint extends EventEmitter implements Endpoint<OneBot12WebhookConfig, OneBot12Event> {
   $connected: boolean = true;
@@ -103,7 +104,12 @@ export class OneBot12WebhookEndpoint extends EventEmitter implements Endpoint<On
     if (!apiUrl) {
       throw new Error('OneBot12 Webhook 发消息需要配置 api_url（OneBot 实现的 HTTP 端点）');
     }
-    const message = contentToOb12Segments(options.content);
+    const expanded = expandInteractiveSegmentsInContent(options.content);
+    const arr = Array.isArray(expanded) ? expanded : [expanded];
+    const wire = fromCanonicalSegments(
+      arr.map((c) => (typeof c === 'string' ? { type: 'text' as const, data: { text: c } } : c)),
+    );
+    const message = contentToOb12Segments(wire);
     const params: Record<string, unknown> = { message };
     if (options.type === 'private') {
       params.detail_type = 'private';

--- a/plugins/adapters/onebot12/src/endpoint-ws.ts
+++ b/plugins/adapters/onebot12/src/endpoint-ws.ts
@@ -4,10 +4,11 @@
 import WebSocket from 'ws';
 import { EventEmitter } from 'events';
 import { clearInterval, clearTimeout } from 'node:timers';
-import { formatCompact, Endpoint, Message, segment, SendOptions,} from 'zhin.js';
+import { formatCompact, Endpoint, Message, segment, SendOptions, expandInteractiveSegmentsInContent,} from 'zhin.js';
 import type { OneBot12WsConfig, OneBot12Event, OneBot12ActionRequest, OneBot12ActionResponse } from './types.js';
 import type { OneBot12Adapter } from './adapter.js';
 import { formatOneBot12MessagePayload, isMessageEvent, contentToOb12Segments } from './utils.js';
+import { fromCanonicalSegments } from './segment-mapper.js';
 
 export class OneBot12WsClient extends EventEmitter implements Endpoint<OneBot12WsConfig, OneBot12Event> {
   $connected: boolean;
@@ -196,7 +197,12 @@ export class OneBot12WsClient extends EventEmitter implements Endpoint<OneBot12W
   }
 
   async $sendMessage(options: SendOptions): Promise<string> {
-    const message = contentToOb12Segments(options.content);
+    const expanded = expandInteractiveSegmentsInContent(options.content);
+    const arr = Array.isArray(expanded) ? expanded : [expanded];
+    const wire = fromCanonicalSegments(
+      arr.map((c) => (typeof c === 'string' ? { type: 'text' as const, data: { text: c } } : c)),
+    );
+    const message = contentToOb12Segments(wire);
     const params: Record<string, unknown> = { message };
     if (options.type === 'private') {
       params.detail_type = 'private';

--- a/plugins/adapters/onebot12/src/endpoint-wss.ts
+++ b/plugins/adapters/onebot12/src/endpoint-wss.ts
@@ -5,11 +5,12 @@ import WebSocket, { WebSocketServer } from 'ws';
 import { EventEmitter } from 'events';
 import { clearInterval, clearTimeout } from 'node:timers';
 import { IncomingMessage } from 'http';
-import { formatCompact, Endpoint, Message, segment, SendOptions,} from 'zhin.js';
+import { formatCompact, Endpoint, Message, segment, SendOptions, expandInteractiveSegmentsInContent,} from 'zhin.js';
 import type { Router } from '@zhin.js/host-router';
 import type { OneBot12WssConfig, OneBot12Event, OneBot12ActionRequest, OneBot12ActionResponse } from './types.js';
 import type { OneBot12Adapter } from './adapter.js';
 import { formatOneBot12MessagePayload, isMessageEvent, contentToOb12Segments } from './utils.js';
+import { fromCanonicalSegments } from './segment-mapper.js';
 
 export class OneBot12WssServer extends EventEmitter implements Endpoint<OneBot12WssConfig, OneBot12Event> {
   $connected: boolean = false;
@@ -178,7 +179,12 @@ export class OneBot12WssServer extends EventEmitter implements Endpoint<OneBot12
   }
 
   async $sendMessage(options: SendOptions): Promise<string> {
-    const message = contentToOb12Segments(options.content);
+    const expanded = expandInteractiveSegmentsInContent(options.content);
+    const arr = Array.isArray(expanded) ? expanded : [expanded];
+    const wire = fromCanonicalSegments(
+      arr.map((c) => (typeof c === 'string' ? { type: 'text' as const, data: { text: c } } : c)),
+    );
+    const message = contentToOb12Segments(wire);
     const params: Record<string, unknown> = { message };
     if (options.type === 'private') {
       params.detail_type = 'private';

--- a/plugins/adapters/onebot12/src/segment-mapper.ts
+++ b/plugins/adapters/onebot12/src/segment-mapper.ts
@@ -1,0 +1,193 @@
+import type { MessageSegment, Segment } from 'zhin.js';
+import {
+  createImageSegment,
+  isMediaRef,
+  mediaRefFromLegacyData,
+  mediaRefToLegacyFields,
+} from 'zhin.js';
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function readMentionTarget(data: Record<string, unknown>): string {
+  const raw = data.target ?? data.user_id ?? data.qq ?? data.id;
+  if (raw === 'all') return 'all';
+  return raw != null ? String(raw) : '';
+}
+
+function normalizeMention(seg: MessageSegment): Segment {
+  const data = seg.data as Record<string, unknown>;
+  const target = readMentionTarget(data);
+  const name = typeof data.name === 'string' && data.name ? data.name : undefined;
+  return {
+    type: 'mention',
+    data: name ? { target, name } : { target },
+    ...(seg.platform ? { platform: seg.platform } : {}),
+  };
+}
+
+function normalizeImage(seg: MessageSegment): Segment {
+  const data = seg.data as Record<string, unknown>;
+  if (isMediaRef(data.media)) {
+    return {
+      type: 'image',
+      data: {
+        media: data.media,
+        ...(typeof data.alt === 'string' ? { alt: data.alt } : {}),
+      },
+      ...(seg.platform ? { platform: seg.platform } : {}),
+    };
+  }
+  const media = mediaRefFromLegacyData(data);
+  if (!media) return seg as Segment;
+
+  const platform: Record<string, unknown> = { ...(seg.platform ?? {}) };
+  for (const key of ['url', 'file', 'src'] as const) {
+    if (typeof data[key] === 'string' && data[key]) platform[key] = data[key];
+  }
+
+  return createImageSegment(media, {
+    alt: typeof data.alt === 'string' ? data.alt : undefined,
+    platform: Object.keys(platform).length ? platform : undefined,
+  });
+}
+
+function normalizeReply(seg: MessageSegment): Segment {
+  const data = seg.data as Record<string, unknown>;
+  const messageId = String(data.message_id ?? data.id ?? '').trim();
+  if (!messageId) return seg as Segment;
+  return { type: 'reply', data: { message_id: messageId } };
+}
+
+function normalizeForward(seg: MessageSegment): Segment {
+  const data = seg.data as Record<string, unknown>;
+  const forwardId = String(
+    data.forward_id ?? data.id ?? data.resid ?? data.res_id ?? '',
+  ).trim();
+  if (!forwardId) return seg as Segment;
+
+  const platform: Record<string, unknown> = { ...(seg.platform ?? {}) };
+  for (const key of ['resid', 'res_id'] as const) {
+    if (typeof data[key] === 'string' && data[key]) platform[key] = data[key];
+  }
+
+  return {
+    type: 'forward',
+    data: {
+      forward_id: forwardId,
+      ...(typeof data.title === 'string' && data.title ? { title: data.title } : {}),
+      ...(Array.isArray(data.messages) ? { messages: data.messages as Segment[][] } : {}),
+    },
+    ...(Object.keys(platform).length ? { platform } : {}),
+  };
+}
+
+function normalizeFace(seg: MessageSegment): Segment {
+  const data = seg.data as Record<string, unknown>;
+  const id = data.id ?? data.face_id;
+  if (id == null || id === '') return seg as Segment;
+  const name =
+    typeof data.name === 'string' && data.name
+      ? data.name
+      : typeof data.text === 'string' && data.text
+        ? data.text
+        : undefined;
+  return {
+    type: 'face',
+    data: {
+      id: typeof id === 'number' ? id : String(id),
+      ...(name ? { name } : {}),
+    },
+    ...(seg.platform ? { platform: seg.platform } : {}),
+  };
+}
+
+function normalizeGame(seg: MessageSegment, type: 'dice' | 'rps'): Segment {
+  const data = seg.data as Record<string, unknown>;
+  const result = typeof data.result === 'number' ? data.result : undefined;
+  return {
+    type,
+    data: result != null ? { result } : {},
+    ...(seg.platform ? { platform: seg.platform } : {}),
+  };
+}
+
+function normalizeSegment(seg: MessageSegment): Segment {
+  if (seg.type === 'at' || seg.type === 'mention') return normalizeMention(seg);
+  if (seg.type === 'image') return normalizeImage(seg);
+  if (seg.type === 'reply') return normalizeReply(seg);
+  if (seg.type === 'forward') return normalizeForward(seg);
+  if (seg.type === 'face' || seg.type === 'sticker' || seg.type === 'emoji') {
+    return normalizeFace(seg);
+  }
+  if (seg.type === 'dice' || seg.type === 'rps') return normalizeGame(seg, seg.type);
+  return seg as Segment;
+}
+
+/** 入站 legacy / CQ 段 → canonical Segment[] */
+export function toCanonicalSegments(content: readonly MessageSegment[]): Segment[] {
+  return content.map((seg) => {
+    if (typeof seg === 'string') return { type: 'text', data: { text: seg } };
+    return normalizeSegment(seg);
+  });
+}
+
+/** 出站：canonical → OneBot11 wire（CQ 构建仍读 url/file + media） */
+export function fromCanonicalSegments(segments: readonly Segment[]): MessageSegment[] {
+  return segments.map((seg) => {
+    if (seg.type === 'image' && isRecord(seg.data) && seg.data.media) {
+      const media = seg.data.media as import('zhin.js').MediaRef;
+      const legacy = mediaRefToLegacyFields(media);
+      return {
+        type: 'image',
+        data: {
+          ...legacy,
+          media,
+          ...(typeof seg.data.alt === 'string' ? { alt: seg.data.alt } : {}),
+        },
+        ...(seg.platform ? { platform: seg.platform } : {}),
+      };
+    }
+    if (seg.type === 'mention') {
+      const data = seg.data as { target: string; name?: string };
+      return {
+        type: 'at',
+        data: {
+          qq: data.target,
+          ...(data.name ? { name: data.name } : {}),
+        },
+        ...(seg.platform ? { platform: seg.platform } : {}),
+      };
+    }
+    if (seg.type === 'reply') {
+      const messageId = String((seg.data as { message_id: string }).message_id);
+      return {
+        type: 'reply',
+        data: { id: messageId, message_id: messageId },
+        ...(seg.platform ? { platform: seg.platform } : {}),
+      };
+    }
+    if (seg.type === 'forward') {
+      const data = seg.data as {
+        forward_id: string;
+        title?: string;
+        messages?: unknown;
+      };
+      const platform = { ...(seg.platform ?? {}) };
+      const resid = platform.resid ?? data.forward_id;
+      return {
+        type: 'forward',
+        data: {
+          id: data.forward_id,
+          forward_id: data.forward_id,
+          resid,
+          ...(data.title ? { title: data.title } : {}),
+          ...(data.messages ? { messages: data.messages } : {}),
+        },
+        platform: { ...platform, resid },
+      };
+    }
+    return seg as MessageSegment;
+  });
+}

--- a/plugins/adapters/onebot12/src/utils.ts
+++ b/plugins/adapters/onebot12/src/utils.ts
@@ -3,6 +3,7 @@
  */
 import type { SendContent } from 'zhin.js';
 import type { OneBot12Event, OneBot12Segment } from './types.js';
+import { toCanonicalSegments } from './segment-mapper.js';
 
 /** 判断是否为消息事件（type=message） */
 export function isMessageEvent(ev: OneBot12Event): ev is OneBot12Event & { message_id: string; message?: OneBot12Segment[] } {
@@ -46,9 +47,10 @@ export function formatOneBot12MessagePayload(
   const channelId = getChannelId(ev);
   const channelType = getChannelType(ev);
   const raw = ev.alt_message ?? (Array.isArray(ev.message) ? ev.message.map((s) => (s.type === 'text' ? (s.data?.text as string) ?? '' : '')).join('') : '');
-  const content = Array.isArray(ev.message)
+  const wire = Array.isArray(ev.message)
     ? ev.message.map((s) => ({ type: s.type, data: (s.data ?? {}) as Record<string, unknown> }))
     : [{ type: 'text', data: { text: raw } }];
+  const content = toCanonicalSegments(wire);
   const senderId = ev.user_id ?? '';
   const senderName = (ev as Record<string, unknown>)['user.name'] as string | undefined ?? (ev as Record<string, unknown>)['qq.nickname'] as string | undefined ?? senderId;
 

--- a/plugins/adapters/onebot12/tests/segment-contract.test.ts
+++ b/plugins/adapters/onebot12/tests/segment-contract.test.ts
@@ -1,0 +1,43 @@
+/**
+ * onebot12 segment contract — OneBot11 wire round-trip
+ */
+import { describe, it } from 'vitest';
+import { fromCanonicalSegments, toCanonicalSegments } from '../src/segment-mapper.js';
+import { assertSegmentRoundTrip } from '../../../../packages/im/core/tests/helpers/segment-adapter-contract.js';
+
+const mapper = { toCanonicalSegments, fromCanonicalSegments };
+
+describe('onebot12 segment contract', () => {
+  it('normalizes legacy image url to MediaRef', () => {
+    assertSegmentRoundTrip(
+      mapper,
+      [{ type: 'image', data: { url: 'https://cdn.example/cat.jpg', file: 'https://cdn.example/cat.jpg' } }],
+      [{
+        type: 'image',
+        data: { media: { kind: 'url', value: 'https://cdn.example/cat.jpg' } },
+        platform: { url: 'https://cdn.example/cat.jpg', file: 'https://cdn.example/cat.jpg' },
+      }],
+    );
+  });
+
+  it('round-trips mention via at wire', () => {
+    assertSegmentRoundTrip(
+      mapper,
+      [{ type: 'at', data: { qq: '10001', name: 'Alice' } }],
+      [{ type: 'mention', data: { target: '10001', name: 'Alice' } }],
+    );
+  });
+
+  it('normalizes legacy reply id to message_id', () => {
+    assertSegmentRoundTrip(
+      mapper,
+      [{ type: 'reply', data: { id: 'q-1' } }],
+      [{ type: 'reply', data: { message_id: 'q-1' } }],
+    );
+  });
+
+  it('round-trips dice and rps', () => {
+    assertSegmentRoundTrip(mapper, [{ type: 'dice', data: {} }], [{ type: 'dice', data: {} }]);
+    assertSegmentRoundTrip(mapper, [{ type: 'rps', data: { result: 1 } }], [{ type: 'rps', data: { result: 1 } }]);
+  });
+});

--- a/plugins/adapters/satori/src/segment-mapper.ts
+++ b/plugins/adapters/satori/src/segment-mapper.ts
@@ -1,0 +1,1 @@
+export { toCanonicalSegments, fromCanonicalSegments } from '../../common/generic-segment-mapper.js';

--- a/plugins/adapters/satori/src/utils.ts
+++ b/plugins/adapters/satori/src/utils.ts
@@ -4,6 +4,7 @@
 import type { SendContent } from 'zhin.js';
 import { Message } from 'zhin.js';
 import type { SatoriEventBody, SatoriMessage, SatoriChannel } from './types.js';
+import { toCanonicalSegments } from './segment-mapper.js';
 
 /** Satori Channel.type: 0=TEXT, 1=DIRECT, 2=CATEGORY, 3=VOICE */
 export function isPrivateChannel(channel?: SatoriChannel): boolean {
@@ -45,7 +46,7 @@ export function formatSatoriMessagePayload(
     $endpoint: endpointName,
     $channel: { id: channelId, type: isPrivate ? 'private' : 'group' },
     $sender: { id: senderId, name: senderName },
-    $content: [{ type: 'text', data: { text: raw } }],
+    $content: toCanonicalSegments([{ type: 'text', data: { text: raw } }]),
     $raw: raw,
     $timestamp: body.timestamp ?? msg.created_at ?? Math.floor(Date.now() / 1000),
     $recall: () => recallFn(`${channelId}:${msg.id}`),

--- a/plugins/adapters/satori/tests/segment-contract.test.ts
+++ b/plugins/adapters/satori/tests/segment-contract.test.ts
@@ -1,0 +1,23 @@
+import { describe, it } from 'vitest';
+import { fromCanonicalSegments, toCanonicalSegments } from '../src/segment-mapper.js';
+import { assertSegmentRoundTrip } from '../../../../packages/im/core/tests/helpers/segment-adapter-contract.js';
+
+const mapper = { toCanonicalSegments, fromCanonicalSegments };
+
+describe('satori segment contract', () => {
+  it('round-trips text and mention', () => {
+    assertSegmentRoundTrip(
+      mapper,
+      [{ type: 'at', data: { id: 'u1', name: 'Bot' } }, { type: 'text', data: { text: ' hi' } }],
+      [{ type: 'mention', data: { target: 'u1', name: 'Bot' } }, { type: 'text', data: { text: ' hi' } }],
+    );
+  });
+
+  it('normalizes link url/text', () => {
+    assertSegmentRoundTrip(
+      mapper,
+      [{ type: 'link', data: { url: 'https://example.com', text: 'Example' } }],
+      [{ type: 'link', data: { url: 'https://example.com', text: 'Example' } }],
+    );
+  });
+});

--- a/plugins/adapters/slack/src/endpoint.ts
+++ b/plugins/adapters/slack/src/endpoint.ts
@@ -3,10 +3,11 @@
  */
 import { App as SlackApp, LogLevel } from "@slack/bolt";
 import { WebClient, type ChatPostMessageArguments } from "@slack/web-api";
-import { formatCompact, Endpoint, Message, MessageSegment, segment, SendContent, SendOptions,} from 'zhin.js';
+import { formatCompact, Endpoint, Message, MessageSegment, segment, SendContent, SendOptions, expandInteractiveSegmentsInContent,} from 'zhin.js';
 import type { SlackEndpointConfig, SlackMessageEvent } from "./types.js";
 import type { SlackAdapter } from "./adapter.js";
 import { normalizeSlackSenderForPermit } from "./platform-permit.js";
+import { fromCanonicalSegments, toCanonicalSegments } from './segment-mapper.js';
 
 
 export class SlackEndpoint implements Endpoint<SlackEndpointConfig, SlackMessageEvent> {
@@ -165,7 +166,8 @@ export class SlackEndpoint implements Endpoint<SlackEndpointConfig, SlackMessage
     const channelId = msg.channel;
 
     // Parse message content
-    const content = this.parseMessageContent(msg);
+    const wire = this.parseMessageContent(msg);
+    const content = toCanonicalSegments(wire);
 
     // Extract user info safely
     const userId = ("user" in msg ? msg.user : "") || "";
@@ -405,9 +407,11 @@ export class SlackEndpoint implements Endpoint<SlackEndpointConfig, SlackMessage
 
   async $sendMessage(options: SendOptions): Promise<string> {
     try {
+      const canonical = expandInteractiveSegmentsInContent(options.content);
+      const wire = fromCanonicalSegments(canonical);
       const result = await this.sendContentToChannel(
         options.id,
-        options.content
+        wire
       );
       this.logger.debug(
         `${this.$config.name} send ${options.type}(${options.id}): ${segment.raw(options.content)}`

--- a/plugins/adapters/slack/src/segment-mapper.ts
+++ b/plugins/adapters/slack/src/segment-mapper.ts
@@ -1,0 +1,1 @@
+export { toCanonicalSegments, fromCanonicalSegments } from '../../common/generic-segment-mapper.js';

--- a/plugins/adapters/slack/tests/segment-contract.test.ts
+++ b/plugins/adapters/slack/tests/segment-contract.test.ts
@@ -1,0 +1,23 @@
+import { describe, it } from 'vitest';
+import { fromCanonicalSegments, toCanonicalSegments } from '../src/segment-mapper.js';
+import { assertSegmentRoundTrip } from '../../../../packages/im/core/tests/helpers/segment-adapter-contract.js';
+
+const mapper = { toCanonicalSegments, fromCanonicalSegments };
+
+describe('slack segment contract', () => {
+  it('round-trips text and mention', () => {
+    assertSegmentRoundTrip(
+      mapper,
+      [{ type: 'at', data: { id: 'u1', name: 'Bot' } }, { type: 'text', data: { text: ' hi' } }],
+      [{ type: 'mention', data: { target: 'u1', name: 'Bot' } }, { type: 'text', data: { text: ' hi' } }],
+    );
+  });
+
+  it('normalizes link url/text', () => {
+    assertSegmentRoundTrip(
+      mapper,
+      [{ type: 'link', data: { url: 'https://example.com', text: 'Example' } }],
+      [{ type: 'link', data: { url: 'https://example.com', text: 'Example' } }],
+    );
+  });
+});

--- a/plugins/adapters/telegram/src/endpoint.ts
+++ b/plugins/adapters/telegram/src/endpoint.ts
@@ -10,10 +10,12 @@ import {
   SendContent,
   MessageSegment,
   segment,
+  expandInteractiveSegmentsInContent,
   type QuotedMessagePayload,} from 'zhin.js';
 import type { TelegramEndpointConfig, TelegramSenderInfo } from "./types.js";
 import type { TelegramAdapter } from "./adapter.js";
 import { normalizeTelegramChatMember } from "./platform-permit.js";
+import { fromCanonicalSegments, toCanonicalSegments } from './segment-mapper.js';
 
 export class TelegramEndpoint extends Telegraf implements Endpoint<TelegramEndpointConfig, TelegramMessage> {
   $connected: boolean = false;
@@ -173,9 +175,10 @@ export class TelegramEndpoint extends Telegraf implements Endpoint<TelegramEndpo
     const channelId = msg.chat.id.toString();
 
     // Parse message content
-    const content = this.parseMessageContent(msg);
-    const quoteId = Message.quoteIdFromContent(content);
-    Message.alignReplySegments(content, quoteId);
+    const wire = this.parseMessageContent(msg);
+    const quoteId = Message.quoteIdFromContent(wire);
+    Message.alignReplySegments(wire, quoteId);
+    const content = toCanonicalSegments(wire);
 
     const result = Message.from(msg, {
       $id: msg.message_id.toString(),
@@ -519,7 +522,9 @@ export class TelegramEndpoint extends Telegraf implements Endpoint<TelegramEndpo
   async $sendMessage(options: SendOptions): Promise<string> {
     try {
       const chatId = parseInt(options.id);
-      const result = await this.sendContentToChat(chatId, options.content);
+      const canonical = expandInteractiveSegmentsInContent(options.content);
+      const wire = fromCanonicalSegments(canonical);
+      const result = await this.sendContentToChat(chatId, wire);
       this.messageChatMap.set(result.message_id.toString(), options.id);
       this.pluginLogger.debug(
         `${this.$config.name} send ${options.type}(${options.id}): ${segment.raw(options.content)}`

--- a/plugins/adapters/telegram/src/segment-mapper.ts
+++ b/plugins/adapters/telegram/src/segment-mapper.ts
@@ -1,0 +1,1 @@
+export { toCanonicalSegments, fromCanonicalSegments } from '../../common/generic-segment-mapper.js';

--- a/plugins/adapters/telegram/tests/segment-contract.test.ts
+++ b/plugins/adapters/telegram/tests/segment-contract.test.ts
@@ -1,0 +1,23 @@
+import { describe, it } from 'vitest';
+import { fromCanonicalSegments, toCanonicalSegments } from '../src/segment-mapper.js';
+import { assertSegmentRoundTrip } from '../../../../packages/im/core/tests/helpers/segment-adapter-contract.js';
+
+const mapper = { toCanonicalSegments, fromCanonicalSegments };
+
+describe('telegram segment contract', () => {
+  it('round-trips text and mention', () => {
+    assertSegmentRoundTrip(
+      mapper,
+      [{ type: 'at', data: { id: 'u1', name: 'Bot' } }, { type: 'text', data: { text: ' hi' } }],
+      [{ type: 'mention', data: { target: 'u1', name: 'Bot' } }, { type: 'text', data: { text: ' hi' } }],
+    );
+  });
+
+  it('normalizes link url/text', () => {
+    assertSegmentRoundTrip(
+      mapper,
+      [{ type: 'link', data: { url: 'https://example.com', text: 'Example' } }],
+      [{ type: 'link', data: { url: 'https://example.com', text: 'Example' } }],
+    );
+  });
+});

--- a/plugins/adapters/wechat-mp/src/endpoint.ts
+++ b/plugins/adapters/wechat-mp/src/endpoint.ts
@@ -17,6 +17,7 @@ import {
     hasOutbound,
     runInboundMessage,
     truncatePreview,
+    expandInteractiveSegmentsInContent,
     type MessageBase,} from 'zhin.js';
 import { registerFetchRoute, type Router, type RouterContext } from "@zhin.js/host-router/router";
 import type { WeChatMPConfig, WeChatMessage, WeChatAPIResponse, TokenResponse } from "./types.js";
@@ -26,6 +27,7 @@ import {
     recordPassiveReplyText,
     runWithPassiveReplyCapture,
 } from "./passive-reply.js";
+import { fromCanonicalSegments, toCanonicalSegments } from './segment-mapper.js';
 
 function queryParam(value: unknown): string {
     if (typeof value === "string") return value;
@@ -342,7 +344,8 @@ export class WeChatMPEndpoint extends EventEmitter implements Endpoint<WeChatMPC
         const channelId = wechatMsg.FromUserName;
         
         // 解析消息内容
-        const content = WeChatMPEndpoint.parseMessageContent(wechatMsg);
+        const wire = WeChatMPEndpoint.parseMessageContent(wechatMsg);
+        const content = toCanonicalSegments(wire);
         
         const base: MessageBase = {
             $id: wechatMsg.MsgId || `${wechatMsg.CreateTime}`,
@@ -444,15 +447,22 @@ export class WeChatMPEndpoint extends EventEmitter implements Endpoint<WeChatMPC
     }
 
     async $sendMessage(options: SendOptions): Promise<string> {
+        const canonical = expandInteractiveSegmentsInContent(options.content);
+        const wire = fromCanonicalSegments(
+            (Array.isArray(canonical) ? canonical : [canonical]).map((s) =>
+                typeof s === 'string' ? { type: 'text' as const, data: { text: s } } : s,
+            ),
+        );
+        const outbound = { ...options, content: wire };
         if (getPassiveReplyCapture()) {
-            const text = this.extractSendText(options);
+            const text = this.extractSendText(outbound);
             recordPassiveReplyText(text);
             return `passive_${Date.now()}`;
         }
 
         if (!this.usesPassiveReply()) {
             try {
-                return await this.sendCustomerServiceMessage(options);
+                return await this.sendCustomerServiceMessage(outbound);
             } catch (error) {
                 this.logger.error("Failed to send WeChat message:", error);
                 throw error;

--- a/plugins/adapters/wechat-mp/src/segment-mapper.ts
+++ b/plugins/adapters/wechat-mp/src/segment-mapper.ts
@@ -1,0 +1,1 @@
+export { toCanonicalSegments, fromCanonicalSegments } from '../../common/generic-segment-mapper.js';

--- a/plugins/adapters/wechat-mp/tests/segment-contract.test.ts
+++ b/plugins/adapters/wechat-mp/tests/segment-contract.test.ts
@@ -1,0 +1,23 @@
+import { describe, it } from 'vitest';
+import { fromCanonicalSegments, toCanonicalSegments } from '../src/segment-mapper.js';
+import { assertSegmentRoundTrip } from '../../../../packages/im/core/tests/helpers/segment-adapter-contract.js';
+
+const mapper = { toCanonicalSegments, fromCanonicalSegments };
+
+describe('wechat-mp segment contract', () => {
+  it('round-trips text and mention', () => {
+    assertSegmentRoundTrip(
+      mapper,
+      [{ type: 'at', data: { id: 'u1', name: 'Bot' } }, { type: 'text', data: { text: ' hi' } }],
+      [{ type: 'mention', data: { target: 'u1', name: 'Bot' } }, { type: 'text', data: { text: ' hi' } }],
+    );
+  });
+
+  it('normalizes link url/text', () => {
+    assertSegmentRoundTrip(
+      mapper,
+      [{ type: 'link', data: { url: 'https://example.com', text: 'Example' } }],
+      [{ type: 'link', data: { url: 'https://example.com', text: 'Example' } }],
+    );
+  });
+});

--- a/plugins/adapters/wecom/src/endpoint.ts
+++ b/plugins/adapters/wecom/src/endpoint.ts
@@ -1,7 +1,7 @@
 /**
  * 企业微信 Endpoint 实现
  */
-import { formatCompact, Endpoint, Message, MessageSegment, segment, type SendContent, type SendOptions,} from 'zhin.js';
+import { formatCompact, Endpoint, Message, MessageSegment, segment, type SendContent, type SendOptions, expandInteractiveSegmentsInContent,} from 'zhin.js';
 import { registerFetchRoute, type Router, type RouterContext } from '@zhin.js/host-router/router';
 import { createHash, createDecipheriv } from 'node:crypto';
 import type {
@@ -12,6 +12,7 @@ import type {
 } from './types.js';
 import type { WecomAdapter } from './adapter.js';
 import { normalizeWecomSenderForPermit } from './platform-permit.js';
+import { fromCanonicalSegments, toCanonicalSegments } from './segment-mapper.js';
 
 export class WecomEndpoint implements Endpoint<WecomEndpointConfig, WecomMessage> {
   $connected: boolean;
@@ -336,7 +337,8 @@ export class WecomEndpoint implements Endpoint<WecomEndpointConfig, WecomMessage
   // ── $formatMessage ──
 
   $formatMessage(msg: WecomMessage): Message<WecomMessage> {
-    const content = this.parseMessageContent(msg);
+    const wire = this.parseMessageContent(msg);
+    const content = toCanonicalSegments(wire);
     // 企业微信中群消息与私聊消息的判断:
     // 群消息 FromUserName 以 @chatroom 结尾
     const chatType = msg.FromUserName.endsWith('@chatroom') ? 'group' : 'private';
@@ -446,7 +448,9 @@ export class WecomEndpoint implements Endpoint<WecomEndpointConfig, WecomMessage
 
   async $sendMessage(options: SendOptions): Promise<string> {
     const targetId = options.id;
-    const content = this.formatSendContent(options.content);
+    const canonical = expandInteractiveSegmentsInContent(options.content);
+    const wire = fromCanonicalSegments(canonical);
+    const content = this.formatSendContent(wire);
     try {
       const body: Record<string, unknown> = {
         touser: targetId,

--- a/plugins/adapters/wecom/src/segment-mapper.ts
+++ b/plugins/adapters/wecom/src/segment-mapper.ts
@@ -1,0 +1,1 @@
+export { toCanonicalSegments, fromCanonicalSegments } from '../../common/generic-segment-mapper.js';

--- a/plugins/adapters/wecom/tests/segment-contract.test.ts
+++ b/plugins/adapters/wecom/tests/segment-contract.test.ts
@@ -1,0 +1,23 @@
+import { describe, it } from 'vitest';
+import { fromCanonicalSegments, toCanonicalSegments } from '../src/segment-mapper.js';
+import { assertSegmentRoundTrip } from '../../../../packages/im/core/tests/helpers/segment-adapter-contract.js';
+
+const mapper = { toCanonicalSegments, fromCanonicalSegments };
+
+describe('wecom segment contract', () => {
+  it('round-trips text and mention', () => {
+    assertSegmentRoundTrip(
+      mapper,
+      [{ type: 'at', data: { id: 'u1', name: 'Bot' } }, { type: 'text', data: { text: ' hi' } }],
+      [{ type: 'mention', data: { target: 'u1', name: 'Bot' } }, { type: 'text', data: { text: ' hi' } }],
+    );
+  });
+
+  it('normalizes link url/text', () => {
+    assertSegmentRoundTrip(
+      mapper,
+      [{ type: 'link', data: { url: 'https://example.com', text: 'Example' } }],
+      [{ type: 'link', data: { url: 'https://example.com', text: 'Example' } }],
+    );
+  });
+});

--- a/plugins/adapters/weixin-ilink/src/endpoint.ts
+++ b/plugins/adapters/weixin-ilink/src/endpoint.ts
@@ -10,8 +10,10 @@ import {
   type MessageSegment,
   type SendContent,
   type SendOptions,
-  segment,} from 'zhin.js';
+  segment,
+  expandInteractiveSegmentsInContent,} from 'zhin.js';
 import { getUpdates, notifyStart, notifyStop, sendTyping } from "./ilink-api.js";
+import { fromCanonicalSegments, toCanonicalSegments } from './segment-mapper.js';
 import {
   configureIlinkMeta,
   DEFAULT_API_BASE_URL,
@@ -194,9 +196,10 @@ export class WeixinIlinkEndpoint implements Endpoint<WeixinIlinkEndpointConfig, 
 
   $formatMessage(msg: WeixinMessageWithMedia): Message<WeixinMessage> {
     const userId = msg.from_user_id ?? "";
-    const content = this.buildInboundContent(msg);
-    const quoteId = Message.quoteIdFromContent(content);
-    Message.alignReplySegments(content, quoteId);
+    const wire = this.buildInboundContent(msg);
+    const quoteId = Message.quoteIdFromContent(wire);
+    Message.alignReplySegments(wire, quoteId);
+    const content = toCanonicalSegments(wire);
     const msgId = String(msg.message_id ?? msg.client_id ?? msg.seq ?? Date.now());
 
     return Message.from(msg, {
@@ -271,7 +274,13 @@ export class WeixinIlinkEndpoint implements Endpoint<WeixinIlinkEndpointConfig, 
     };
 
     const outboundDir = path.join(resolveStateDir(), "media", "outbound");
-    const materialized = await materializeOutboundMedia(options.content, outboundDir);
+    const canonical = expandInteractiveSegmentsInContent(options.content);
+    const wire = fromCanonicalSegments(
+      (Array.isArray(canonical) ? canonical : [canonical]).map((s) =>
+        typeof s === 'string' ? { type: 'text' as const, data: { text: s } } : s,
+      ),
+    );
+    const materialized = await materializeOutboundMedia(wire, outboundDir);
     const segments = Array.isArray(materialized) ? materialized : [materialized];
     let lastId = "";
     let pendingText = "";

--- a/plugins/adapters/weixin-ilink/src/segment-mapper.ts
+++ b/plugins/adapters/weixin-ilink/src/segment-mapper.ts
@@ -1,0 +1,1 @@
+export { toCanonicalSegments, fromCanonicalSegments } from '../../common/generic-segment-mapper.js';

--- a/plugins/adapters/weixin-ilink/tests/segment-contract.test.ts
+++ b/plugins/adapters/weixin-ilink/tests/segment-contract.test.ts
@@ -1,0 +1,23 @@
+import { describe, it } from 'vitest';
+import { fromCanonicalSegments, toCanonicalSegments } from '../src/segment-mapper.js';
+import { assertSegmentRoundTrip } from '../../../../packages/im/core/tests/helpers/segment-adapter-contract.js';
+
+const mapper = { toCanonicalSegments, fromCanonicalSegments };
+
+describe('weixin-ilink segment contract', () => {
+  it('round-trips text and mention', () => {
+    assertSegmentRoundTrip(
+      mapper,
+      [{ type: 'at', data: { id: 'u1', name: 'Bot' } }, { type: 'text', data: { text: ' hi' } }],
+      [{ type: 'mention', data: { target: 'u1', name: 'Bot' } }, { type: 'text', data: { text: ' hi' } }],
+    );
+  });
+
+  it('normalizes link url/text', () => {
+    assertSegmentRoundTrip(
+      mapper,
+      [{ type: 'link', data: { url: 'https://example.com', text: 'Example' } }],
+      [{ type: 'link', data: { url: 'https://example.com', text: 'Example' } }],
+    );
+  });
+});

--- a/scripts/check-segment-adapters.mjs
+++ b/scripts/check-segment-adapters.mjs
@@ -11,27 +11,14 @@ const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..'
 const adaptersDir = path.join(repoRoot, 'plugins/adapters');
 
 /** 必须含 segment-mapper + segment-contract.test.ts */
-const REQUIRED_ADAPTERS = new Set(['sandbox', 'icqq', 'napcat', 'onebot11', 'qq']);
+const REQUIRED_ADAPTERS = new Set([
+  'sandbox', 'icqq', 'napcat', 'onebot11', 'qq',
+  'dingtalk', 'discord', 'email', 'github', 'kook', 'lark', 'line', 'milky',
+  'onebot12', 'process', 'satori', 'slack', 'telegram', 'wechat-mp', 'wecom', 'weixin-ilink',
+]);
 
 /** 尚未迁移 segment-mapper 的 adapter（不报错） */
-const PENDING_ADAPTERS = new Set([
-  'dingtalk',
-  'discord',
-  'email',
-  'github',
-  'kook',
-  'lark',
-  'line',
-  'milky',
-  'onebot12',
-  'process',
-  'satori',
-  'slack',
-  'telegram',
-  'wechat-mp',
-  'wecom',
-  'weixin-ilink',
-]);
+const PENDING_ADAPTERS = new Set([]);
 
 const entries = fs.readdirSync(adaptersDir, { withFileTypes: true })
   .filter((d) => d.isDirectory())


### PR DESCRIPTION
## Summary
- 新增 `common/generic-segment-mapper`（text/mention/image/reply/link/markdown）
- 16 个剩余 IM adapter 补齐 `segment-mapper` + `segment-contract.test.ts` 并接入 endpoint
- `check:segments` pending 白名单清空，全部 adapter 纳入 required

## Test plan
- [x] `pnpm vitest run plugins/adapters/*/tests/segment-contract.test.ts` (55 tests)
- [x] `pnpm check:segments` (pending: 0)

Closes #557

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a generic segment mapper and wires it into all international IM adapters to normalize inbound/outbound segments (text, mention, image, reply, link, markdown). Removes the pending whitelist so `check:segments` now requires every adapter to implement the contract.

- New Features
  - Added `plugins/adapters/common/generic-segment-mapper` with `toCanonicalSegments`/`fromCanonicalSegments` for mention aliasing, image `MediaRef`, reply id normalization, link/markdown; QQ-style adapters also cover forward/face/dice/rps.
  - Integrated the mapper into DingTalk, Discord, Email, GitHub, Kook, Lark, Line, Milky, OneBot12, Satori, Slack, Telegram, WeChat MP, WeCom, and Weixin iLink: parse inbound to canonical; expand interactive segments and convert from canonical before sending. GitHub markdown now renders `mention` as `@user`.
  - Added segment contract tests for each adapter to ensure round-trip behavior.

- Migration
  - `scripts/check-segment-adapters.mjs` now requires all adapters; pending whitelist cleared. Run `pnpm check:segments` (expected pending: 0).
  - If you maintain a custom adapter, add a `segment-mapper.ts` exporting `toCanonicalSegments`/`fromCanonicalSegments` (you can re-export from `common/generic-segment-mapper`).

<sup>Written for commit 353a7b417d54cc7a30b8477617200c264231a115. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zhinjs/zhin/pull/566?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

