### PR TITLE
test(cli): stabilize release L4 gate

### DIFF
--- a/basic/cli/tests/agent-legacy-payloads.test.ts
+++ b/basic/cli/tests/agent-legacy-payloads.test.ts
@@ -24,7 +24,7 @@ describe('zhin agent legacy-payloads', () => {
     await expect(executeLegacyPayloadsOfflineCommand({
       input, output, storage: 'file', sourceKind: 'projection',
     })).rejects.toThrow();
-  });
+  }, 30_000);
 
   it('reads only a versioned explicit DB export and stdout remains content-free', async () => {
     const root = await mkdtemp(join(tmpdir(), 'zhin-legacy-payload-db-cli-'));

--- a/basic/cli/tests/agent-legacy-runs.test.ts
+++ b/basic/cli/tests/agent-legacy-runs.test.ts
@@ -29,7 +29,7 @@ describe('zhin agent legacy-runs', () => {
     });
     expect(persisted).toEqual(value);
     expect(await readdir(root)).toEqual(['audit.json', 'legacy.json']);
-  });
+  }, 30_000);
 
   it('emits only an explicit proposal record for active Run replan', async () => {
     const root = await workspace();


### PR DESCRIPTION
## Summary
- give the two cold-start legacy CLI integration tests an explicit 30 second budget
- keep the global unit-test timeout unchanged

## Validation
- pnpm check:workroom-ssot (22 files, 151 tests)
- pnpm check:all (40/40 harness checks)
- targeted ESLint
- git diff --check

This fixes the release harness failure observed when L4-CI and the full unit suite load @zhin.js/agent concurrently.

## Sourcery 摘要

增加冷启动旧版 CLI 集成测试的超时预算，以稳定并发执行发布测试和单元测试。

Bug 修复：
- 允许两个冷启动旧版 CLI 集成测试最多运行 30 秒完成，避免发布测试工具失败。

测试：
- 在不更改全局单元测试超时设置的情况下，稳定旧版 CLI 集成测试的执行时间。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Increase the timeout budget for cold-start legacy CLI integration tests to stabilize concurrent release and unit-test execution.

Bug Fixes:
- Prevent release harness failures by allowing the two cold-start legacy CLI integration tests up to 30 seconds to complete.

Tests:
- Stabilize legacy CLI integration test timing without changing the global unit-test timeout.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes the L4 release gate by giving two cold-start legacy CLI tests explicit 30s timeouts. Previously these tests used the global default and could fail under concurrent `@zhin.js/agent` loads; they now allow cold imports without changing the global test timeout.

- Only change: add a 30_000 ms timeout to the first test in `basic/cli/tests/agent-legacy-payloads.test.ts` and `basic/cli/tests/agent-legacy-runs.test.ts`.
- No runtime or package changes; tests only.
- Keeps the global unit-test timeout unchanged while reducing flakiness in the L4 release gate.

<sup>Written for commit 69c961e465110e2e83802af96e2936aaf0ec45ad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zhinjs/zhin/pull/618?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

