### PR TITLE
fix(agent): await effect projector shutdown

### DIFF
--- a/packages/im/agent/src/plugin-runtime/workroom-acceptance-production-composition.ts
+++ b/packages/im/agent/src/plugin-runtime/workroom-acceptance-production-composition.ts
@@ -594,7 +594,12 @@ export class WorkroomEffectAuthorizationProjectionRuntime {
   async dispose(): Promise<void> {
     if (this.#timer) clearInterval(this.#timer);
     this.#timer = undefined;
-    await this.#draining;
+    try {
+      await this.#draining;
+    } catch {
+      // The scheduled drain owns error reporting. Disposal is a lifecycle
+      // barrier and must still settle when generation retirement aborts it.
+    }
   }
 
   async #drainProjects(): Promise<number> {

--- a/packages/im/agent/src/plugin-runtime/workroom-acceptance-production-composition.ts
+++ b/packages/im/agent/src/plugin-runtime/workroom-acceptance-production-composition.ts
@@ -591,9 +591,10 @@ export class WorkroomEffectAuthorizationProjectionRuntime {
     }
   }
 
-  dispose(): void {
+  async dispose(): Promise<void> {
     if (this.#timer) clearInterval(this.#timer);
     this.#timer = undefined;
+    await this.#draining;
   }
 
   async #drainProjects(): Promise<number> {

--- a/packages/im/agent/tests/plugin-runtime/workroom-acceptance-production-composition.test.ts
+++ b/packages/im/agent/tests/plugin-runtime/workroom-acceptance-production-composition.test.ts
@@ -361,13 +361,18 @@ describe('P7 standard Acceptance production composition', () => {
     const effects = new MemoryWorkroomEffectJournal();
     const intent = createWorkroomEffectIntent(effectIntent());
     await new WorkroomEffectLedger(effects).recordIntent('project-1', intent);
-    const authorize = vi.fn(async input => ({
-      approved: true as const,
-      policy: input.acceptancePolicy,
-      expiresAt: 10_000,
-      policyDecisionRef: 'effect-policy-decision:restart',
-      policyDecisionDigest: SHA('9'),
-    }));
+    let releaseAuthorization!: () => void;
+    const authorizationGate = new Promise<void>(resolve => { releaseAuthorization = resolve; });
+    const authorize = vi.fn(async input => {
+      await authorizationGate;
+      return {
+        approved: true as const,
+        policy: input.acceptancePolicy,
+        expiresAt: 10_000,
+        policyDecisionRef: 'effect-policy-decision:restart',
+        policyDecisionDigest: SHA('9'),
+      };
+    });
     const sponsorAuthority = { authorize: async (input: { digest: string }) => ({
       authorized: true as const, authorizedBy: 'catalog:revision-1:project-digest',
       catalogRevision: 'c'.repeat(64), projectDigest: SHA('c'),
@@ -398,7 +403,10 @@ describe('P7 standard Acceptance production composition', () => {
     });
     first.start();
     await vi.waitFor(() => expect(authorize).toHaveBeenCalledTimes(1));
-    first.dispose();
+    const firstDisposal = first.dispose();
+    releaseAuthorization();
+    expect(firstDisposal).toBeInstanceOf(Promise);
+    await firstDisposal;
 
     const restartedProjector = new SponsorDecisionWorkroomEffectAuthorizationProjector({
       directory, effectJournal: effects, sponsorAuthority, policy: { authorize },
@@ -411,7 +419,7 @@ describe('P7 standard Acceptance production composition', () => {
     });
     restarted.start();
     await new Promise(resolve => setTimeout(resolve, 20));
-    restarted.dispose();
+    await restarted.dispose();
     expect(authorize).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/im/agent/tests/plugin-runtime/workroom-acceptance-production-composition.test.ts
+++ b/packages/im/agent/tests/plugin-runtime/workroom-acceptance-production-composition.test.ts
@@ -403,10 +403,13 @@ describe('P7 standard Acceptance production composition', () => {
     });
     first.start();
     await vi.waitFor(() => expect(authorize).toHaveBeenCalledTimes(1));
-    const firstDisposal = first.dispose();
+    let disposalCompleted = false;
+    const firstDisposal = first.dispose().then(() => { disposalCompleted = true; });
+    await Promise.resolve();
+    expect(disposalCompleted).toBe(false);
     releaseAuthorization();
-    expect(firstDisposal).toBeInstanceOf(Promise);
     await firstDisposal;
+    expect(disposalCompleted).toBe(true);
 
     const restartedProjector = new SponsorDecisionWorkroomEffectAuthorizationProjector({
       directory, effectJournal: effects, sponsorAuthority, policy: { authorize },
@@ -421,6 +424,40 @@ describe('P7 standard Acceptance production composition', () => {
     await restarted.drain();
     await restarted.dispose();
     expect(authorize).toHaveBeenCalledTimes(1);
+  });
+
+  it('settles disposal when generation retirement aborts an in-flight Project scan', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'zhin-effect-projector-abort-'));
+    let releaseScan!: () => void;
+    const scanGate = new Promise<void>(resolve => { releaseScan = resolve; });
+    const listProjectIds = vi.fn(async () => {
+      await scanGate;
+      return ['project-1'];
+    });
+    const controller = new AbortController();
+    const runtime = new WorkroomEffectAuthorizationProjectionRuntime({
+      signal: controller.signal,
+      projects: { listProjectIds },
+      projector: new SponsorDecisionWorkroomEffectAuthorizationProjector({
+        directory: join(root, 'facts'),
+        effectJournal: new MemoryWorkroomEffectJournal(),
+        sponsorAuthority: {
+          authorize: async input => ({
+            authorized: false as const,
+            requestDigest: input.digest,
+            reason: 'not reached',
+          }),
+        },
+        policy: { authorize: async () => null },
+      }),
+      intervalMs: 5,
+    });
+    runtime.start();
+    await vi.waitFor(() => expect(listProjectIds).toHaveBeenCalledTimes(1));
+    controller.abort();
+    const disposal = runtime.dispose();
+    releaseScan();
+    await expect(disposal).resolves.toBeUndefined();
   });
 });
 

--- a/packages/im/agent/tests/plugin-runtime/workroom-acceptance-production-composition.test.ts
+++ b/packages/im/agent/tests/plugin-runtime/workroom-acceptance-production-composition.test.ts
@@ -418,7 +418,7 @@ describe('P7 standard Acceptance production composition', () => {
       intervalMs: 5,
     });
     restarted.start();
-    await new Promise(resolve => setTimeout(resolve, 20));
+    await restarted.drain();
     await restarted.dispose();
     expect(authorize).toHaveBeenCalledTimes(1);
   });


### PR DESCRIPTION
## Summary
- make Effect authorization projector disposal await the in-flight drain
- prevent a restarted generation from authorizing the same pending Effect before the prior generation publishes its durable fact
- add a deterministic gated regression for the restart race

## Validation
- pnpm check:all (40/40 harness checks)
- pnpm check:workroom-ssot repeated 3x (22 files / 151 tests each)
- focused Acceptance composition suite (7/7)
- @zhin.js/agent build
- targeted ESLint and git diff --check

Fixes the Build and Publish failure in run 32579499652.

## Sourcery 总结

确保 Effect 授权投影器在允许新一代启动之前，完成对进行中工作的处理并完成释放。

错误修复：
- 等待 Effect 授权投影器关闭，以便在重启的一代处理同一个待处理 Effect 之前，完成进行中的授权处理。

测试：
- 添加确定性的门控回归测试，覆盖投影器重启竞态，并验证待处理的 Effect 只被授权一次。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

等待 Effect 授权投影器完成释放，以确保持久化的授权事实在重启前发布。

Bug 修复：
- 确保 Effect 授权投影器关闭时等待正在进行的授权工作完成，然后才允许新一代投影器启动，从而防止对待处理 Effect 重复授权。

测试：
- 添加确定性回归测试，覆盖投影器重启竞态，并验证待处理的 Effect 只被授权一次。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

等待 Effect 授权投影器关闭，以便在重启期间保留持久化的授权状态，并防止重复授权。

错误修复：
- 确保 Effect 授权投影器的释放操作等待正在进行的授权工作完成后，新一代实例才能重启，从而防止对待处理 Effect 进行重复授权。
- 确保当代际退出中止正在进行的扫描时，投影器的释放操作能够正常完成。

测试：
- 添加针对重启竞态以及中止正在进行的扫描时的释放操作的确定性回归测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Await Effect authorization projector shutdown to preserve durable authorization state across restarts and prevent duplicate authorization.

Bug Fixes:
- Ensure Effect authorization projector disposal waits for in-flight authorization work to finish before a new generation can restart, preventing duplicate authorization of pending Effects.
- Ensure projector disposal settles cleanly when generation retirement aborts an in-flight scan.

Tests:
- Add deterministic regression coverage for the restart race and aborted in-flight scan disposal.

</details>

</details>

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Await effect authorization projector shutdown to drain in-flight work and settle cleanly, preventing duplicate authorization on restart. Previously, dispose() returned immediately; now dispose() is async, awaits the scheduled drain, and still resolves when generation retirement aborts an in-flight scan.

- Review/Migration: dispose() now returns a Promise—update callers to await it.

<sup>Written for commit d93c8f4f3f33774322d4f3e5e1b7b339ad0cfab5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zhinjs/zhin/pull/619?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

