### PR TITLE
test(sandbox): stabilize demo permission gate

### DIFF
--- a/.changeset/stable-sandbox-demo-gate.md
+++ b/.changeset/stable-sandbox-demo-gate.md
@@ -1,0 +1,5 @@
+---
+"@zhin.js/adapter-sandbox": patch
+---
+
+Stabilize the demo-scope WebSocket permission regression test by verifying the gate independently from the informational ready frame.

--- a/.changeset/stable-sandbox-demo-gate.md
+++ b/.changeset/stable-sandbox-demo-gate.md
@@ -2,4 +2,4 @@
 "@zhin.js/adapter-sandbox": patch
 ---
 
-Stabilize the demo-scope WebSocket permission regression test by verifying the gate independently from the informational ready frame.
+Stabilize Sandbox WebSocket regressions by waiting for the server-side connection registration and verifying the demo-scope gate independently from the informational ready frame.

--- a/plugins/adapters/sandbox/tests/sandbox-runtime.test.ts
+++ b/plugins/adapters/sandbox/tests/sandbox-runtime.test.ts
@@ -120,8 +120,21 @@ describe('sandbox plugin runtime adapter', () => {
     const payload = await new Promise<string>((resolve, reject) => {
       const client = new WebSocket(`ws://127.0.0.1:${port}/sandbox`);
       const timer = setTimeout(() => reject(new Error('timeout waiting for websocket reply')), 3000);
+      let retry: ReturnType<typeof setTimeout> | undefined;
       client.once('open', () => {
-        endpoint.send({ conversation: sandboxConversation('sandbox-user'), payload: 'pong' });
+        const sendWhenAccepted = () => {
+          try {
+            endpoint.send({ conversation: sandboxConversation('sandbox-user'), payload: 'pong' });
+          } catch (error) {
+            if (!(error instanceof Error) || error.message !== 'Sandbox Endpoint has no live connection') {
+              clearTimeout(timer);
+              reject(error);
+              return;
+            }
+            retry = setTimeout(sendWhenAccepted, 10);
+          }
+        };
+        sendWhenAccepted();
       });
       client.on('message', (data) => {
         const parsed = JSON.parse(String(data)) as {
@@ -130,10 +143,15 @@ describe('sandbox plugin runtime adapter', () => {
         const text = parsed.content?.[0]?.data?.text;
         if (text !== 'pong') return;
         clearTimeout(timer);
+        if (retry) clearTimeout(retry);
         client.close();
         resolve(String(data));
       });
-      client.once('error', reject);
+      client.once('error', (error) => {
+        clearTimeout(timer);
+        if (retry) clearTimeout(retry);
+        reject(error);
+      });
     });
 
     expect(JSON.parse(payload).content).toEqual([

--- a/plugins/adapters/sandbox/tests/sandbox-runtime.test.ts
+++ b/plugins/adapters/sandbox/tests/sandbox-runtime.test.ts
@@ -194,19 +194,23 @@ describe('sandbox plugin runtime adapter', () => {
     const errorText = await new Promise<string>((resolve, reject) => {
       const client = new WebSocket(`ws://127.0.0.1:${port}/sandbox?token=demo-token`);
       const timer = setTimeout(() => reject(new Error('timeout waiting for read-only error')), 3000);
+      // The permission gate is independent of the informational `ready` frame,
+      // whose shell-isolation probe may be delayed on a loaded CI runner.
+      client.once('open', () => {
+        client.send(JSON.stringify({ text: 'run outside workspace' }));
+      });
       client.on('message', (raw) => {
         const payload = JSON.parse(String(raw)) as { type?: string; content?: Array<{ data?: { text?: string } }> };
-        if (payload.type === 'ready') {
-          client.send(JSON.stringify({ text: 'run outside workspace' }));
-          return;
-        }
         if (payload.type === 'error') {
           clearTimeout(timer);
           client.close();
           resolve(payload.content?.[0]?.data?.text ?? '');
         }
       });
-      client.once('error', reject);
+      client.once('error', (error) => {
+        clearTimeout(timer);
+        reject(error);
+      });
     });
 
     expect(errorText).toContain('只读演示权限');


### PR DESCRIPTION
## Summary
- send the demo-scope request as soon as the WebSocket opens
- keep the permission assertion independent from the informational `ready` frame and its Docker probe
- clear the timeout on WebSocket errors

## Validation
- target suite repeated 10 times
- `pnpm --filter @zhin.js/adapter-sandbox test` (4 files / 25 tests)
- `pnpm check:all` (40/40 harness checks)

## Sourcery 摘要

通过将断言与延迟的就绪信号解耦，并妥善处理连接失败，提升沙箱权限门控测试的稳定性。

错误修复：
- WebSocket 打开后立即提交 demo-scope 请求，而不是等待信息性就绪帧，从而提升沙箱权限门控测试的稳定性。
- 确保 WebSocket 错误处理会清除测试超时。

增强功能：
- 使权限验证独立于就绪帧中的 shell 隔离探测，以减少 CI 负载下的测试不稳定性。

测试：
- 提升沙箱运行时测试中只读权限断言的可靠性。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

在 CI 负载较高的情况下，稳定沙盒演示权限门控回归测试。

增强：
- 通过独立于延迟的信息性就绪帧来验证权限门控，稳定沙盒演示作用域权限回归测试。

测试：
- 通过在连接发生错误时清除超时，改进 WebSocket 测试的失败处理。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

通过将请求与实时连接同步，并独立验证权限门控与信息性就绪帧，稳定沙箱 WebSocket 回归测试。

Bug 修复：
- 通过处理连接注册竞态，并将权限检查与延迟的就绪探测解耦，稳定沙箱 WebSocket 权限和运行时回归测试。

增强功能：
- 通过在连接出错或完成时清除待处理的计时器和重试，改进 WebSocket 测试失败处理。

测试：
- 确保沙箱运行时测试在 CI 负载下可靠地验证正常消息处理和只读演示权限。

杂项：
- 为沙箱适配器测试稳定性改进添加补丁变更集。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Stabilize sandbox WebSocket regression tests by synchronizing requests with live connections and validating permission gates independently of informational readiness frames.

Bug Fixes:
- Stabilize sandbox WebSocket permission and runtime regression tests by handling connection registration races and decoupling permission checks from delayed readiness probes.

Enhancements:
- Improve WebSocket test failure handling by clearing pending timers and retries when connections error or complete.

Tests:
- Make sandbox runtime tests reliably verify normal message handling and read-only demo permissions under CI load.

Chores:
- Add a patch changeset for the sandbox adapter test stabilization.

</details>

</details>

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes sandbox WebSocket tests in `@zhin.js/adapter-sandbox` by waiting for server-side connection registration and asserting the demo-scope gate on the `error` frame, independent of the informational `ready` frame. This removes CI flakiness from delayed shell-isolation probes and not-yet-registered endpoints.

- Old: waited for `ready` then sent; New: send on `open`, retry until the endpoint registers, and assert on `error`. Test-only; no runtime behavior change.
- Clear timers on WebSocket `error`, and add a patch changeset for `@zhin.js/adapter-sandbox`.

<sup>Written for commit e6ef74db84e82322f9ce882ef9e40931b3766dae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zhinjs/zhin/pull/621?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

