### PR TITLE
fix(sandbox): avoid blocking websocket readiness probe

### DIFF
--- a/.changeset/async-sandbox-readiness.md
+++ b/.changeset/async-sandbox-readiness.md
@@ -1,0 +1,5 @@
+---
+"@zhin.js/adapter-sandbox": patch
+---
+
+Probe Docker readiness asynchronously so Sandbox WebSocket permissions and messages are never blocked by the informational ready frame.

--- a/plugins/adapters/sandbox/src/endpoint.ts
+++ b/plugins/adapters/sandbox/src/endpoint.ts
@@ -2,7 +2,7 @@
  * SandboxWsEndpoint — WebSocket lifecycle and MessageGateway bridge for /sandbox.
  */
 import { randomUUID } from 'node:crypto';
-import { spawnSync } from 'node:child_process';
+import { execFile } from 'node:child_process';
 import type { EndpointInstance, EndpointSendRequest } from 'zhin.js/adapter';
 import type { MessageGateway, SideEventGateway } from '@zhin.js/core/runtime';
 import type { HttpHost, WsConnection } from '@zhin.js/host-http';
@@ -66,6 +66,12 @@ interface SandboxConnection {
   /** true = 占位连接（尚无真实 WS 客户端），send 命中时按 miss 处理。 */
   readonly placeholder?: boolean;
 }
+
+type ShellIsolationStatus = Readonly<{
+  available: boolean;
+  provider: 'docker';
+  message: string;
+}>;
 
 export interface SandboxEndpointOptions {
   readonly id: CapabilityId;
@@ -282,26 +288,30 @@ export class SandboxWsEndpoint implements EndpointInstance {
     });
     this.#connections.set(target, { target, owner, socket, release });
     this.#logger.debug(formatCompact({ op: 'sandbox_ws_connected', target, owner }));
-    const readyPayload = JSON.stringify({
-      type: 'ready',
-      id: owner,
-      endpoint: target,
-      workingDirectory: process.cwd(),
-      canExecute,
-      shellIsolation: probeShellIsolation(),
-      content: [{
-        type: 'text',
-        data: {
-          text: [
-            `已连接 Sandbox「${target}」`,
-            `与 Node Host 控制台沙盒协议一致（${this.#wsPath}）`,
-            'Agent 试验台会话已启用持久化运行配置。',
-          ].join('\n'),
-        },
-      }],
-      timestamp: Date.now(),
+    void probeShellIsolation().then((shellIsolation) => {
+      const current = this.#connections.get(target);
+      if (!current || current.socket !== socket) return;
+      const readyPayload = JSON.stringify({
+        type: 'ready',
+        id: owner,
+        endpoint: target,
+        workingDirectory: process.cwd(),
+        canExecute,
+        shellIsolation,
+        content: [{
+          type: 'text',
+          data: {
+            text: [
+              `已连接 Sandbox「${target}」`,
+              `与 Node Host 控制台沙盒协议一致（${this.#wsPath}）`,
+              'Agent 试验台会话已启用持久化运行配置。',
+            ].join('\n'),
+          },
+        }],
+        timestamp: Date.now(),
+      });
+      whenWsOpen(socket, () => socket.send(readyPayload));
     });
-    whenWsOpen(socket, () => socket.send(readyPayload));
   }
 
   #ensurePlaceholder(name: string, owner: string): void {
@@ -316,29 +326,34 @@ export class SandboxWsEndpoint implements EndpointInstance {
   }
 }
 
-function probeShellIsolation(): Readonly<{ available: boolean; provider: 'docker'; message: string }> {
-  try {
-    const result = spawnSync('docker', ['info', '--format', '{{.ServerVersion}}'], {
+function probeShellIsolation(): Promise<ShellIsolationStatus> {
+  return new Promise<ShellIsolationStatus>((resolve) => {
+    execFile('docker', ['info', '--format', '{{.ServerVersion}}'], {
       encoding: 'utf8',
-      stdio: ['ignore', 'pipe', 'pipe'],
       timeout: 500,
-    });
-    if (result.status === 0) {
-      const version = result.stdout.trim();
-      return Object.freeze({
-        available: true,
+    }, (error, stdout) => {
+      if (!error) {
+        const version = stdout.trim();
+        resolve(Object.freeze({
+          available: true,
+          provider: 'docker',
+          message: version ? `Docker ${version}` : 'Docker ready',
+        }));
+        return;
+      }
+      resolve(Object.freeze({
+        available: false,
         provider: 'docker',
-        message: version ? `Docker ${version}` : 'Docker ready',
-      });
-    }
-    return Object.freeze({ available: false, provider: 'docker', message: 'Docker daemon is unavailable' });
-  } catch (error) {
-    return Object.freeze({
-      available: false,
-      provider: 'docker',
-      message: error instanceof Error && error.name === 'ETIMEDOUT'
-        ? 'Docker readiness check timed out'
-        : 'Docker is unavailable',
+        message: error.killed || error.code === 'ETIMEDOUT'
+          ? 'Docker readiness check timed out'
+          : 'Docker daemon is unavailable',
+      }));
     });
-  }
+  }).catch((error: unknown) => Object.freeze({
+    available: false,
+    provider: 'docker' as const,
+    message: error instanceof Error && error.name === 'ETIMEDOUT'
+      ? 'Docker readiness check timed out'
+      : 'Docker is unavailable',
+  }));
 }

--- a/plugins/adapters/sandbox/src/endpoint.ts
+++ b/plugins/adapters/sandbox/src/endpoint.ts
@@ -73,6 +73,33 @@ type ShellIsolationStatus = Readonly<{
   message: string;
 }>;
 
+type ShellIsolationProbe = () => Promise<ShellIsolationStatus>;
+
+/**
+ * Share an in-flight readiness probe across reconnects while still allowing a
+ * later connection to refresh the informational status after it settles.
+ * Kept internal to this module's package surface; tests import it directly.
+ */
+export function createSandboxReadinessGate(probe: ShellIsolationProbe): Readonly<{
+  afterProbe: (deliver: (status: ShellIsolationStatus) => void) => void;
+}> {
+  let inFlight: Promise<ShellIsolationStatus> | undefined;
+  const acquire = (): Promise<ShellIsolationStatus> => {
+    if (inFlight) return inFlight;
+    const pending = probe();
+    const shared = pending.finally(() => {
+      if (inFlight === shared) inFlight = undefined;
+    });
+    inFlight = shared;
+    return shared;
+  };
+  return Object.freeze({
+    afterProbe: (deliver) => {
+      void acquire().then(deliver);
+    },
+  });
+}
+
 export interface SandboxEndpointOptions {
   readonly id: CapabilityId;
   readonly gateway: MessageGateway;
@@ -90,6 +117,7 @@ export class SandboxWsEndpoint implements EndpointInstance {
 
   readonly #options: SandboxEndpointOptions;
   readonly #connections = new Map<string, SandboxConnection>();
+  readonly #readiness = createSandboxReadinessGate(probeShellIsolation);
   #wsHandleRelease?: () => void;
   #wsPathRelease?: () => void;
   #wsPath = '/sandbox';
@@ -288,7 +316,7 @@ export class SandboxWsEndpoint implements EndpointInstance {
     });
     this.#connections.set(target, { target, owner, socket, release });
     this.#logger.debug(formatCompact({ op: 'sandbox_ws_connected', target, owner }));
-    void probeShellIsolation().then((shellIsolation) => {
+    this.#readiness.afterProbe((shellIsolation) => {
       const current = this.#connections.get(target);
       if (!current || current.socket !== socket) return;
       const readyPayload = JSON.stringify({
@@ -349,11 +377,9 @@ function probeShellIsolation(): Promise<ShellIsolationStatus> {
           : 'Docker daemon is unavailable',
       }));
     });
-  }).catch((error: unknown) => Object.freeze({
+  }).catch(() => Object.freeze({
     available: false,
     provider: 'docker' as const,
-    message: error instanceof Error && error.name === 'ETIMEDOUT'
-      ? 'Docker readiness check timed out'
-      : 'Docker is unavailable',
+    message: 'Docker is unavailable',
   }));
 }

--- a/plugins/adapters/sandbox/tests/sandbox-runtime.test.ts
+++ b/plugins/adapters/sandbox/tests/sandbox-runtime.test.ts
@@ -7,7 +7,7 @@ import { capabilityId, featureId, rootPluginId } from 'zhin.js';
 import { createHttpHost } from '@zhin.js/host-http';
 import type { MessageGateway } from '@zhin.js/core/runtime';
 import type { ConversationRef } from '@zhin.js/im-contract';
-import { SandboxWsEndpoint } from '../src/endpoint.js';
+import { createSandboxReadinessGate, SandboxWsEndpoint } from '../src/endpoint.js';
 import {
   formatSandboxOutbound,
   parseSandboxWsPayload,
@@ -31,6 +31,40 @@ afterEach(async () => {
 });
 
 describe('sandbox plugin runtime adapter', () => {
+  it('shares a delayed readiness probe and lets callers suppress stale delivery', async () => {
+    let resolveProbe: ((status: {
+      available: boolean;
+      provider: 'docker';
+      message: string;
+    }) => void) | undefined;
+    const probe = vi.fn(() => new Promise<{
+      available: boolean;
+      provider: 'docker';
+      message: string;
+    }>((resolve) => {
+      resolveProbe = resolve;
+    }));
+    const gate = createSandboxReadinessGate(probe);
+    const staleDelivery = vi.fn();
+    const currentDelivery = vi.fn();
+    let firstConnectionIsCurrent = true;
+
+    gate.afterProbe(() => undefined);
+    gate.afterProbe((status) => {
+      if (firstConnectionIsCurrent) staleDelivery(status);
+    });
+    gate.afterProbe(currentDelivery);
+
+    expect(probe).toHaveBeenCalledTimes(1);
+    firstConnectionIsCurrent = false;
+    resolveProbe?.({ available: true, provider: 'docker', message: 'Docker test' });
+    await vi.waitFor(() => expect(currentDelivery).toHaveBeenCalledTimes(1));
+    expect(staleDelivery).not.toHaveBeenCalled();
+
+    gate.afterProbe(() => undefined);
+    expect(probe).toHaveBeenCalledTimes(2);
+  });
+
   it('routes websocket messages through MessageGateway', async () => {
     const http = createHttpHost({ host: '127.0.0.1', port: 0 });
     hosts.push(http);


### PR DESCRIPTION
## Summary
- run the Docker readiness probe asynchronously after registering the WebSocket
- keep permission checks and inbound/outbound messages responsive while the informational ready frame is prepared
- discard a delayed ready frame when the connection has already been replaced

## Validation
- pnpm check:all
- pnpm --filter @zhin.js/adapter-sandbox test
- pnpm --filter @zhin.js/adapter-sandbox build
- targeted ESLint and git diff --check

## Release
- patch changeset for @zhin.js/adapter-sandbox

## Sourcery 总结

通过异步执行 Docker 隔离检查，并在发送 ready 帧之前验证连接，使 Sandbox WebSocket 就绪检查不再阻塞。

错误修复：
- 防止 Docker 就绪检查阻塞 Sandbox WebSocket 就绪、权限检查或消息处理。
- 当关联的 WebSocket 连接已被替换时，丢弃延迟的 ready 帧。

增强功能：
- 异步运行 Docker 就绪探测，并在状态可用时报告该状态。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

通过使 Docker 就绪状态报告异步化并关联连接，保持 Sandbox WebSocket 连接的响应能力。

错误修复：
- 防止 Docker 就绪检查阻塞 Sandbox WebSocket 注册、权限检查和消息处理。
- 当关联的 WebSocket 连接已被替换时，丢弃延迟的就绪帧。

增强功能：
- 在重新连接期间共享正在进行的就绪探测，同时允许后续连接刷新就绪状态。

测试：
- 增加对共享异步就绪探测和抑制过期传递的测试覆盖。

维护：
- 为 @zhin.js/adapter-sandbox 添加补丁变更集。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Keep Sandbox WebSocket connections responsive by making Docker readiness reporting asynchronous and connection-aware.

Bug Fixes:
- Prevent Docker readiness checks from blocking Sandbox WebSocket registration, permission checks, and message handling.
- Discard delayed ready frames when the associated WebSocket connection has been replaced.

Enhancements:
- Share in-flight readiness probes across reconnects while allowing subsequent connections to refresh readiness status.

Tests:
- Add coverage for shared asynchronous readiness probes and suppression of stale deliveries.

Chores:
- Add a patch changeset for @zhin.js/adapter-sandbox.

</details>

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes Sandbox WebSocket readiness non-blocking and deduplicates Docker probes across reconnects. Previously the synchronous probe stalled permissions and messages; now the connection stays responsive and only the current socket receives the ready frame.

- Executes the Docker readiness check with execFile('docker', ...) under a 500ms timeout; reports “Docker readiness check timed out” or “Docker daemon is unavailable”.
- Shares an in-flight readiness probe across reconnects and sends the ready frame only if the same socket is still current, dropping stale deliveries.
- Ready frame timing may be slightly delayed; payload shape is unchanged. Patch release for `@zhin.js/adapter-sandbox`.

<sup>Written for commit 7c61a87203f4ccdfcb9775c22f64ccb0367cc20d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zhinjs/zhin/pull/623?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

