### PR TITLE
feat(agent): add Workroom status and controls

### DIFF
--- a/.changeset/workroom-preview-cli.md
+++ b/.changeset/workroom-preview-cli.md
@@ -1,0 +1,5 @@
+---
+"@zhin.js/cli": patch
+---
+
+Add authenticated `zhin agent workroom runs` and `zhin agent workroom run` commands for content-free online Run, Task, and Assignment status inspection, with explicit missing-token and offline-Host diagnostics.

--- a/.changeset/workroom-readiness-controls.md
+++ b/.changeset/workroom-readiness-controls.md
@@ -1,0 +1,6 @@
+---
+"@zhin.js/agent": patch
+"@zhin.js/cli": patch
+---
+
+Add content-free Workroom readiness diagnostics and authenticated Sponsor controls for exact-sequence Run cancellation and durable replan requests.

--- a/basic/cli/README.md
+++ b/basic/cli/README.md
@@ -25,6 +25,8 @@ zhin config check [--fix] # 校验/修复 zhin.config.yml
 zhin doctor               # 环境诊断
 zhin send <scene_id> ...  # 向运行中的实例发消息
 zhin agent workroom runs --project <id> # 查看在线 Workroom Run 状态
+zhin agent workroom readiness <runId> --project <id> # 诊断 content-free Blocker
+zhin agent workroom request-replan <runId> --project <id> --expected-sequence <n> --reason-code requirements_changed
 zhin --help               # 全部命令
 ```
 

--- a/basic/cli/README.md
+++ b/basic/cli/README.md
@@ -24,6 +24,7 @@ zhin setup                # 交互式配置向导（适配器 / AI / 数据库�
 zhin config check [--fix] # 校验/修复 zhin.config.yml
 zhin doctor               # 环境诊断
 zhin send <scene_id> ...  # 向运行中的实例发消息
+zhin agent workroom runs --project <id> # 查看在线 Workroom Run 状态
 zhin --help               # 全部命令
 ```
 

--- a/basic/cli/src/commands/agent-workroom.ts
+++ b/basic/cli/src/commands/agent-workroom.ts
@@ -1,12 +1,19 @@
+import { randomUUID } from 'node:crypto';
 import { Command } from 'commander';
-import type {
-  WorkroomAssignmentState,
-  WorkroomAssignmentStatus,
-  WorkroomExecutionRole,
-  WorkroomRunStatus,
-  WorkroomTaskStatus,
+import {
+  isWorkroomRunCancelReasonCode,
+  isWorkroomRunReplanReasonCode,
+  type WorkroomAssignmentState,
+  type WorkroomAssignmentStatus,
+  type WorkroomBlockerKind,
+  type WorkroomExecutionRole,
+  type WorkroomReadinessState,
+  type WorkroomRunStatus,
+  type WorkroomRunCancelReasonCode,
+  type WorkroomRunReplanReasonCode,
+  type WorkroomTaskStatus,
 } from '@zhin.js/agent';
-import { hostGet, loadHostHttpConfig } from '../utils/host-http.js';
+import { hostGet, hostPost, loadHostHttpConfig } from '../utils/host-http.js';
 
 type WorkroomAssignmentOutcome = NonNullable<WorkroomAssignmentState['outcome']>;
 
@@ -17,6 +24,21 @@ export interface WorkroomRunsCommandOptions {
 
 export interface WorkroomRunCommandOptions extends WorkroomRunsCommandOptions {
   readonly runId: string;
+}
+
+export interface WorkroomReadinessCommandOptions extends WorkroomRunCommandOptions {}
+
+export interface WorkroomCancelCommandOptions extends WorkroomRunCommandOptions {
+  readonly expectedSequence: number;
+  readonly reasonCode: WorkroomRunCancelReasonCode;
+  readonly controlDeadline: number;
+  readonly operationId?: string;
+}
+
+export interface WorkroomRequestReplanCommandOptions extends WorkroomRunCommandOptions {
+  readonly expectedSequence: number;
+  readonly reasonCode: WorkroomRunReplanReasonCode;
+  readonly operationId?: string;
 }
 
 export interface WorkroomRunHeaderOutput {
@@ -71,6 +93,42 @@ export interface WorkroomRunOutput extends WorkroomRunHeaderOutput {
   readonly assignments: readonly WorkroomAssignmentHeaderOutput[];
 }
 
+export interface WorkroomReadinessBlockerOutput {
+  readonly version: 1;
+  readonly taskRef: string;
+  readonly blockerRef: string;
+  readonly kind: WorkroomBlockerKind | 'unknown';
+  readonly deadline?: number;
+  readonly allowedActions: readonly ('resolve' | 'replan' | 'cancel')[];
+  readonly digest: string;
+}
+
+export interface WorkroomReadinessOutput {
+  readonly version: 1;
+  readonly projectId: string;
+  readonly runId: string;
+  readonly sequence: number;
+  readonly state: WorkroomReadinessState;
+  readonly blockers: readonly WorkroomReadinessBlockerOutput[];
+  readonly recommendedActions: readonly ('resolve' | 'replan' | 'cancel')[];
+  readonly authorityDigest: string;
+  readonly digest: string;
+}
+
+export interface WorkroomControlOutput {
+  readonly status: 'committed' | 'duplicate';
+  readonly action: 'cancel' | 'request_replan';
+  readonly operationId: string;
+  readonly receiptRef: string;
+  readonly receiptDigest: string;
+  readonly run: Readonly<{
+    projectId: string;
+    runId: string;
+    status: WorkroomRunStatus;
+    sequence: number;
+  }>;
+}
+
 export async function executeWorkroomRunsCommand(
   options: WorkroomRunsCommandOptions,
   cwd = process.cwd(),
@@ -100,6 +158,51 @@ export async function executeWorkroomRunCommand(
   return output;
 }
 
+export async function executeWorkroomReadinessCommand(
+  options: WorkroomReadinessCommandOptions,
+  cwd = process.cwd(),
+): Promise<WorkroomReadinessOutput> {
+  const projectId = requireIdentifier(options.projectId, 'Project');
+  const runId = requirePathIdentifier(options.runId, 'Run');
+  const value = await readWorkroomHost(
+    `/agent/workroom/readiness?projectId=${encodeURIComponent(projectId)}&runId=${encodeURIComponent(runId)}`,
+    cwd,
+  );
+  const output = parseWorkroomReadinessOutput(value, projectId, runId);
+  console.log(options.json ? JSON.stringify(output, null, 2) : formatWorkroomReadiness(output));
+  return output;
+}
+
+export async function executeWorkroomCancelCommand(
+  options: WorkroomCancelCommandOptions,
+  cwd = process.cwd(),
+): Promise<WorkroomControlOutput> {
+  const common = normalizeControlOptions(options);
+  if (!isCancelReasonCode(options.reasonCode)) throw new Error('Cancellation reasonCode 无效');
+  const controlDeadline = requireNonNegativeInteger(options.controlDeadline, 'controlDeadline');
+  return executeWorkroomControl({
+    version: 1,
+    ...common,
+    action: 'cancel',
+    reasonCode: options.reasonCode,
+    controlDeadline,
+  }, options.json === true, cwd);
+}
+
+export async function executeWorkroomRequestReplanCommand(
+  options: WorkroomRequestReplanCommandOptions,
+  cwd = process.cwd(),
+): Promise<WorkroomControlOutput> {
+  const common = normalizeControlOptions(options);
+  if (!isReplanReasonCode(options.reasonCode)) throw new Error('Replan reasonCode 无效');
+  return executeWorkroomControl({
+    version: 1,
+    ...common,
+    action: 'request_replan',
+    reasonCode: options.reasonCode,
+  }, options.json === true, cwd);
+}
+
 export function registerWorkroomOnlineCommands(agentCommand: Command): void {
   const workroom = agentCommand
     .command('workroom')
@@ -126,6 +229,65 @@ export function registerWorkroomOnlineCommands(agentCommand: Command): void {
       runOnlineAction(() => executeWorkroomRunCommand({
         projectId: options.project,
         runId,
+        ...(options.json ? { json: true } : {}),
+      }));
+    });
+
+  workroom
+    .command('readiness <runId>')
+    .description('Diagnose content-free blockers and allowed actions for one Run')
+    .requiredOption('--project <projectId>', 'Exact Workroom Project id')
+    .option('--json', 'Output JSON')
+    .action((runId: string, options: Readonly<{ project: string; json?: boolean }>) => {
+      runOnlineAction(() => executeWorkroomReadinessCommand({
+        projectId: options.project,
+        runId,
+        ...(options.json ? { json: true } : {}),
+      }));
+    });
+
+  workroom
+    .command('cancel <runId>')
+    .description('Request an exact-sequence, Sponsor-authorized Run cancellation')
+    .requiredOption('--project <projectId>', 'Exact Workroom Project id')
+    .requiredOption('--expected-sequence <sequence>', 'Current Run sequence')
+    .requiredOption('--reason-code <code>', 'operator_request|no_longer_required|superseded|policy_change')
+    .requiredOption('--control-deadline <timestamp>', 'Kernel control deadline')
+    .option('--operation-id <operationId>', 'Stable idempotency key')
+    .option('--json', 'Output JSON')
+    .action((runId: string, options: Readonly<{
+      project: string; expectedSequence: string; reasonCode: WorkroomRunCancelReasonCode;
+      controlDeadline: string; operationId?: string; json?: boolean;
+    }>) => {
+      runOnlineAction(() => executeWorkroomCancelCommand({
+        projectId: options.project,
+        runId,
+        expectedSequence: parseIntegerOption(options.expectedSequence, 'expected-sequence'),
+        reasonCode: options.reasonCode,
+        controlDeadline: parseIntegerOption(options.controlDeadline, 'control-deadline'),
+        ...(options.operationId ? { operationId: options.operationId } : {}),
+        ...(options.json ? { json: true } : {}),
+      }));
+    });
+
+  workroom
+    .command('request-replan <runId>')
+    .description('Persist an exact-sequence, Sponsor-authorized replan request')
+    .requiredOption('--project <projectId>', 'Exact Workroom Project id')
+    .requiredOption('--expected-sequence <sequence>', 'Current Run sequence')
+    .requiredOption('--reason-code <code>', 'requirements_changed|blocker_recovery|policy_change|operator_request')
+    .option('--operation-id <operationId>', 'Stable idempotency key')
+    .option('--json', 'Output JSON')
+    .action((runId: string, options: Readonly<{
+      project: string; expectedSequence: string; reasonCode: WorkroomRunReplanReasonCode;
+      operationId?: string; json?: boolean;
+    }>) => {
+      runOnlineAction(() => executeWorkroomRequestReplanCommand({
+        projectId: options.project,
+        runId,
+        expectedSequence: parseIntegerOption(options.expectedSequence, 'expected-sequence'),
+        reasonCode: options.reasonCode,
+        ...(options.operationId ? { operationId: options.operationId } : {}),
         ...(options.json ? { json: true } : {}),
       }));
     });
@@ -232,6 +394,112 @@ function parseAssignmentHeader(value: unknown, index: number): WorkroomAssignmen
   });
 }
 
+function parseWorkroomReadinessOutput(
+  value: unknown,
+  projectId: string,
+  runId: string,
+): WorkroomReadinessOutput {
+  if (!isRecord(value) || value.version !== 1 || value.projectId !== projectId
+    || value.runId !== runId || !nonNegativeInteger(value.sequence)
+    || !isReadinessState(value.state) || !Array.isArray(value.blockers)
+    || !isBlockerActions(value.recommendedActions)
+    || !nonEmptyString(value.authorityDigest) || !nonEmptyString(value.digest)) {
+    throw new Error('Host 返回了无效的 Workroom readiness');
+  }
+  return Object.freeze({
+    version: 1,
+    projectId,
+    runId,
+    sequence: value.sequence,
+    state: value.state,
+    blockers: Object.freeze(value.blockers.map((blocker, index) =>
+      parseReadinessBlocker(blocker, index))),
+    recommendedActions: Object.freeze([...value.recommendedActions]),
+    authorityDigest: value.authorityDigest,
+    digest: value.digest,
+  });
+}
+
+function parseReadinessBlocker(value: unknown, index: number): WorkroomReadinessBlockerOutput {
+  if (!isRecord(value) || value.version !== 1 || !nonEmptyString(value.taskRef)
+    || !nonEmptyString(value.blockerRef) || value.kind !== 'unknown' && !isBlockerKind(value.kind)
+    || value.deadline !== undefined && !nonNegativeInteger(value.deadline)
+    || !isBlockerActions(value.allowedActions)
+    || !nonEmptyString(value.digest)) {
+    throw new Error(`Host 返回了无效的 Workroom Blocker header（索引 ${index}）`);
+  }
+  return Object.freeze({
+    version: 1,
+    taskRef: value.taskRef,
+    blockerRef: value.blockerRef,
+    kind: value.kind,
+    ...(value.deadline === undefined ? {} : { deadline: value.deadline }),
+    allowedActions: Object.freeze([...value.allowedActions]),
+    digest: value.digest,
+  });
+}
+
+function normalizeControlOptions(
+  options: WorkroomRunCommandOptions & Readonly<{ expectedSequence: number; operationId?: string }>,
+): Readonly<{
+  operationId: string;
+  projectId: string;
+  runId: string;
+  expectedSequence: number;
+}> {
+  return Object.freeze({
+    operationId: options.operationId
+      ? requireIdentifier(options.operationId, 'Operation')
+      : randomUUID(),
+    projectId: requireIdentifier(options.projectId, 'Project'),
+    runId: requirePathIdentifier(options.runId, 'Run'),
+    expectedSequence: requireNonNegativeInteger(options.expectedSequence, 'expectedSequence'),
+  });
+}
+
+async function executeWorkroomControl(
+  command: Readonly<Record<string, unknown>>,
+  json: boolean,
+  cwd: string,
+): Promise<WorkroomControlOutput> {
+  const http = await loadHostHttpConfig(cwd);
+  if (!http) throw new Error('未找到 zhin.config，无法确定 Host API 地址');
+  if (!http.token.trim()) {
+    throw new Error('Host API token 未配置；请配置绑定 principal 的 full scope token');
+  }
+  const response = await hostPost<unknown>(http, '/agent/workroom/control', command);
+  if (!response.ok) {
+    throw new Error(response.error ?? `控制 Workroom Run 失败（HTTP ${response.status}）`);
+  }
+  const output = parseWorkroomControlOutput(response.data);
+  console.log(json ? JSON.stringify(output, null, 2) : formatWorkroomControl(output));
+  return output;
+}
+
+function parseWorkroomControlOutput(value: unknown): WorkroomControlOutput {
+  if (!isRecord(value) || value.status !== 'committed' && value.status !== 'duplicate'
+    || value.action !== 'cancel' && value.action !== 'request_replan'
+    || !nonEmptyString(value.operationId) || !nonEmptyString(value.receiptRef)
+    || !nonEmptyString(value.receiptDigest) || !isRecord(value.run)
+    || !nonEmptyString(value.run.projectId) || !nonEmptyString(value.run.runId)
+    || !isRunStatus(value.run.status) || !nonNegativeInteger(value.run.sequence)) {
+    throw new Error('Host 返回了无效的 Workroom control receipt');
+  }
+  return Object.freeze({
+    status: value.status,
+    action: value.action,
+    operationId: value.operationId,
+    receiptRef: value.receiptRef,
+    receiptDigest: value.receiptDigest,
+    run: Object.freeze({
+      projectId: value.run.projectId,
+      runId: value.run.runId,
+      status: value.run.status,
+      sequence: value.run.sequence,
+    }),
+  });
+}
+
 function formatWorkroomRuns(output: WorkroomRunsOutput): string {
   if (output.runs.length === 0) return `Workroom runs · ${output.projectId}\n(none)`;
   const rows = output.runs.map(run => [
@@ -294,6 +562,32 @@ function formatWorkroomRun(output: WorkroomRunOutput): string {
   ].join('\n');
 }
 
+function formatWorkroomReadiness(output: WorkroomReadinessOutput): string {
+  const rows = output.blockers.map(blocker => [
+    blocker.taskRef,
+    blocker.blockerRef,
+    blocker.kind,
+    blocker.deadline === undefined ? '-' : String(blocker.deadline),
+    blocker.allowedActions.join(','),
+  ]);
+  return [
+    `Workroom readiness · ${output.projectId}/${output.runId} · ${output.state} · seq ${output.sequence}`,
+    rows.length === 0
+      ? '(no active blockers)'
+      : formatTable(['TASK', 'BLOCKER', 'KIND', 'DEADLINE', 'ACTIONS'], rows),
+    `Recommended: ${output.recommendedActions.length > 0
+      ? output.recommendedActions.join(', ')
+      : 'none'}`,
+  ].join('\n');
+}
+
+function formatWorkroomControl(output: WorkroomControlOutput): string {
+  return [
+    'Workroom control', output.action, output.status,
+    `${output.run.projectId}/${output.run.runId}`, output.run.status, `seq ${output.run.sequence}`,
+  ].join(' · ');
+}
+
 function formatTable(headers: readonly string[], rows: readonly (readonly string[])[]): string {
   const widths = headers.map((header, index) => Math.max(
     header.length,
@@ -314,6 +608,16 @@ function requirePathIdentifier(value: string, label: string): string {
   const normalized = requireIdentifier(value, label);
   if (/[/?#]/u.test(normalized)) throw new Error(`${label} id 无效`);
   return normalized;
+}
+
+function requireNonNegativeInteger(value: number, label: string): number {
+  if (!Number.isSafeInteger(value) || value < 0) throw new Error(`${label} 无效`);
+  return value;
+}
+
+function parseIntegerOption(value: string, label: string): number {
+  if (!/^\d+$/u.test(value)) throw new Error(`${label} 无效`);
+  return requireNonNegativeInteger(Number(value), label);
 }
 
 async function readWorkroomHost(apiPath: string, cwd: string): Promise<unknown> {
@@ -370,4 +674,29 @@ function isExecutionRole(value: unknown): value is WorkroomExecutionRole {
 
 function isAssignmentOutcome(value: unknown): value is WorkroomAssignmentOutcome {
   return value === 'interrupted' || value === 'committed' || value === 'outcome_unknown';
+}
+
+function isReadinessState(value: unknown): value is WorkroomReadinessState {
+  return value === 'ready' || value === 'blocked' || value === 'needs_replan'
+    || value === 'cancelling' || value === 'terminal';
+}
+
+function isBlockerKind(value: unknown): value is WorkroomBlockerKind {
+  return value === 'dependency' || value === 'approval' || value === 'capability'
+    || value === 'external' || value === 'human_input';
+}
+
+function isBlockerActions(
+  value: unknown,
+): value is readonly ('resolve' | 'replan' | 'cancel')[] {
+  return Array.isArray(value)
+    && value.every(action => action === 'resolve' || action === 'replan' || action === 'cancel');
+}
+
+function isCancelReasonCode(value: unknown): value is WorkroomRunCancelReasonCode {
+  return isWorkroomRunCancelReasonCode(value);
+}
+
+function isReplanReasonCode(value: unknown): value is WorkroomRunReplanReasonCode {
+  return isWorkroomRunReplanReasonCode(value);
 }

--- a/basic/cli/src/commands/agent-workroom.ts
+++ b/basic/cli/src/commands/agent-workroom.ts
@@ -1,0 +1,373 @@
+import { Command } from 'commander';
+import type {
+  WorkroomAssignmentState,
+  WorkroomAssignmentStatus,
+  WorkroomExecutionRole,
+  WorkroomRunStatus,
+  WorkroomTaskStatus,
+} from '@zhin.js/agent';
+import { hostGet, loadHostHttpConfig } from '../utils/host-http.js';
+
+type WorkroomAssignmentOutcome = NonNullable<WorkroomAssignmentState['outcome']>;
+
+export interface WorkroomRunsCommandOptions {
+  readonly projectId: string;
+  readonly json?: boolean;
+}
+
+export interface WorkroomRunCommandOptions extends WorkroomRunsCommandOptions {
+  readonly runId: string;
+}
+
+export interface WorkroomRunHeaderOutput {
+  readonly version: 1;
+  readonly projectId: string;
+  readonly runId: string;
+  readonly status: WorkroomRunStatus;
+  readonly sequence: number;
+  readonly cancelRequested: boolean;
+  readonly counts: Readonly<{
+    tasks: number;
+    assignments: number;
+    reviewerAssignments: number;
+    sponsorGates: number;
+  }>;
+  readonly authorityDigest: string;
+  readonly digest: string;
+}
+
+export interface WorkroomRunsOutput {
+  readonly projectId: string;
+  readonly runs: readonly WorkroomRunHeaderOutput[];
+}
+
+export interface WorkroomTaskHeaderOutput {
+  readonly version: 1;
+  readonly ref: string;
+  readonly status: WorkroomTaskStatus;
+  readonly revision: number;
+  readonly attempt: number;
+  readonly required: boolean;
+  readonly blockerCount: number;
+  readonly hasCurrentAssignment: boolean;
+  readonly digest: string;
+}
+
+export interface WorkroomAssignmentHeaderOutput {
+  readonly version: 1;
+  readonly ref: string;
+  readonly taskRef: string;
+  readonly status: WorkroomAssignmentStatus;
+  readonly role: WorkroomExecutionRole;
+  readonly revision: number;
+  readonly attempt: number;
+  readonly fence: number;
+  readonly outcome?: WorkroomAssignmentOutcome;
+  readonly digest: string;
+}
+
+export interface WorkroomRunOutput extends WorkroomRunHeaderOutput {
+  readonly tasks: readonly WorkroomTaskHeaderOutput[];
+  readonly assignments: readonly WorkroomAssignmentHeaderOutput[];
+}
+
+export async function executeWorkroomRunsCommand(
+  options: WorkroomRunsCommandOptions,
+  cwd = process.cwd(),
+): Promise<WorkroomRunsOutput> {
+  const projectId = requireIdentifier(options.projectId, 'Project');
+  const value = await readWorkroomHost(
+    `/agent/workroom/runs?projectId=${encodeURIComponent(projectId)}`,
+    cwd,
+  );
+  const output = parseWorkroomRunsOutput(value, projectId);
+  console.log(options.json ? JSON.stringify(output, null, 2) : formatWorkroomRuns(output));
+  return output;
+}
+
+export async function executeWorkroomRunCommand(
+  options: WorkroomRunCommandOptions,
+  cwd = process.cwd(),
+): Promise<WorkroomRunOutput> {
+  const projectId = requireIdentifier(options.projectId, 'Project');
+  const runId = requirePathIdentifier(options.runId, 'Run');
+  const value = await readWorkroomHost(
+    `/agent/workroom/runs/${encodeURIComponent(runId)}?projectId=${encodeURIComponent(projectId)}`,
+    cwd,
+  );
+  const output = parseWorkroomRunOutput(value, projectId, runId);
+  console.log(options.json ? JSON.stringify(output, null, 2) : formatWorkroomRun(output));
+  return output;
+}
+
+export function registerWorkroomOnlineCommands(agentCommand: Command): void {
+  const workroom = agentCommand
+    .command('workroom')
+    .description('Inspect the running Workroom through the authenticated Host API');
+
+  workroom
+    .command('runs')
+    .description('List content-free Run status for one Project')
+    .requiredOption('--project <projectId>', 'Exact Workroom Project id')
+    .option('--json', 'Output JSON')
+    .action((options: Readonly<{ project: string; json?: boolean }>) => {
+      runOnlineAction(() => executeWorkroomRunsCommand({
+        projectId: options.project,
+        ...(options.json ? { json: true } : {}),
+      }));
+    });
+
+  workroom
+    .command('run <runId>')
+    .description('Inspect content-free Task and Assignment status for one Run')
+    .requiredOption('--project <projectId>', 'Exact Workroom Project id')
+    .option('--json', 'Output JSON')
+    .action((runId: string, options: Readonly<{ project: string; json?: boolean }>) => {
+      runOnlineAction(() => executeWorkroomRunCommand({
+        projectId: options.project,
+        runId,
+        ...(options.json ? { json: true } : {}),
+      }));
+    });
+}
+
+function parseWorkroomRunsOutput(value: unknown, expectedProjectId: string): WorkroomRunsOutput {
+  if (!isRecord(value) || value.projectId !== expectedProjectId || !Array.isArray(value.runs)) {
+    throw new Error('Host 返回了无效的 Workroom Run 列表');
+  }
+  return Object.freeze({
+    projectId: expectedProjectId,
+    runs: Object.freeze(value.runs.map((run, index) => parseRunHeader(run, index, expectedProjectId))),
+  });
+}
+
+function parseRunHeader(value: unknown, index: number, projectId: string): WorkroomRunHeaderOutput {
+  if (!isRecord(value) || value.version !== 1 || value.projectId !== projectId
+    || !nonEmptyString(value.runId) || !isRunStatus(value.status)
+    || !nonNegativeInteger(value.sequence) || typeof value.cancelRequested !== 'boolean'
+    || !isRecord(value.counts) || !nonNegativeInteger(value.counts.tasks)
+    || !nonNegativeInteger(value.counts.assignments)
+    || !nonNegativeInteger(value.counts.reviewerAssignments)
+    || !nonNegativeInteger(value.counts.sponsorGates)
+    || !nonEmptyString(value.authorityDigest) || !nonEmptyString(value.digest)) {
+    throw new Error(`Host 返回了无效的 Workroom Run header（索引 ${index}）`);
+  }
+  return Object.freeze({
+    version: 1,
+    projectId,
+    runId: value.runId,
+    status: value.status,
+    sequence: value.sequence,
+    cancelRequested: value.cancelRequested,
+    counts: Object.freeze({
+      tasks: value.counts.tasks,
+      assignments: value.counts.assignments,
+      reviewerAssignments: value.counts.reviewerAssignments,
+      sponsorGates: value.counts.sponsorGates,
+    }),
+    authorityDigest: value.authorityDigest,
+    digest: value.digest,
+  });
+}
+
+function parseWorkroomRunOutput(
+  value: unknown,
+  projectId: string,
+  runId: string,
+): WorkroomRunOutput {
+  const header = parseRunHeader(value, 0, projectId);
+  if (header.runId !== runId || !isRecord(value)
+    || !Array.isArray(value.tasks) || !Array.isArray(value.assignments)) {
+    throw new Error('Host 返回了无效的 Workroom Run detail');
+  }
+  return Object.freeze({
+    ...header,
+    tasks: Object.freeze(value.tasks.map((task, index) => parseTaskHeader(task, index))),
+    assignments: Object.freeze(
+      value.assignments.map((assignment, index) => parseAssignmentHeader(assignment, index)),
+    ),
+  });
+}
+
+function parseTaskHeader(value: unknown, index: number): WorkroomTaskHeaderOutput {
+  if (!isRecord(value) || value.version !== 1 || !nonEmptyString(value.ref)
+    || !isTaskStatus(value.status) || !nonNegativeInteger(value.revision)
+    || !nonNegativeInteger(value.attempt) || typeof value.required !== 'boolean'
+    || !nonNegativeInteger(value.blockerCount) || typeof value.hasCurrentAssignment !== 'boolean'
+    || !nonEmptyString(value.digest)) {
+    throw new Error(`Host 返回了无效的 Workroom Task header（索引 ${index}）`);
+  }
+  return Object.freeze({
+    version: 1,
+    ref: value.ref,
+    status: value.status,
+    revision: value.revision,
+    attempt: value.attempt,
+    required: value.required,
+    blockerCount: value.blockerCount,
+    hasCurrentAssignment: value.hasCurrentAssignment,
+    digest: value.digest,
+  });
+}
+
+function parseAssignmentHeader(value: unknown, index: number): WorkroomAssignmentHeaderOutput {
+  if (!isRecord(value) || value.version !== 1 || !nonEmptyString(value.ref)
+    || !nonEmptyString(value.taskRef) || !isAssignmentStatus(value.status) || !isExecutionRole(value.role)
+    || !nonNegativeInteger(value.revision) || !nonNegativeInteger(value.attempt)
+    || !nonNegativeInteger(value.fence) || value.outcome !== undefined && !isAssignmentOutcome(value.outcome)
+    || !nonEmptyString(value.digest)) {
+    throw new Error(`Host 返回了无效的 Workroom Assignment header（索引 ${index}）`);
+  }
+  return Object.freeze({
+    version: 1,
+    ref: value.ref,
+    taskRef: value.taskRef,
+    status: value.status,
+    role: value.role,
+    revision: value.revision,
+    attempt: value.attempt,
+    fence: value.fence,
+    ...(value.outcome === undefined ? {} : { outcome: value.outcome }),
+    digest: value.digest,
+  });
+}
+
+function formatWorkroomRuns(output: WorkroomRunsOutput): string {
+  if (output.runs.length === 0) return `Workroom runs · ${output.projectId}\n(none)`;
+  const rows = output.runs.map(run => [
+    run.runId,
+    run.status,
+    String(run.sequence),
+    String(run.counts.tasks),
+    String(run.counts.assignments),
+    String(run.counts.reviewerAssignments),
+    String(run.counts.sponsorGates),
+    run.cancelRequested ? 'yes' : 'no',
+  ]);
+  return [
+    `Workroom runs · ${output.projectId}`,
+    formatTable(
+      ['RUN', 'STATUS', 'SEQ', 'TASKS', 'ASSIGNMENTS', 'REVIEWERS', 'GATES', 'CANCEL'],
+      rows,
+    ),
+  ].join('\n');
+}
+
+function formatWorkroomRun(output: WorkroomRunOutput): string {
+  const taskRows = output.tasks.map(task => [
+    task.ref,
+    task.status,
+    String(task.revision),
+    String(task.attempt),
+    task.required ? 'yes' : 'no',
+    String(task.blockerCount),
+    task.hasCurrentAssignment ? 'yes' : 'no',
+  ]);
+  const assignmentRows = output.assignments.map(assignment => [
+    assignment.ref,
+    assignment.taskRef,
+    assignment.status,
+    assignment.role,
+    String(assignment.revision),
+    String(assignment.attempt),
+    String(assignment.fence),
+    assignment.outcome ?? '-',
+  ]);
+  return [
+    `Workroom run · ${output.projectId}/${output.runId} · ${output.status} · seq ${output.sequence}`,
+    '',
+    'Tasks',
+    taskRows.length === 0
+      ? '(none)'
+      : formatTable(
+          ['TASK', 'STATUS', 'REV', 'ATTEMPT', 'REQUIRED', 'BLOCKERS', 'ASSIGNED'],
+          taskRows,
+        ),
+    '',
+    'Assignments',
+    assignmentRows.length === 0
+      ? '(none)'
+      : formatTable(
+          ['ASSIGNMENT', 'TASK', 'STATUS', 'ROLE', 'REV', 'ATTEMPT', 'FENCE', 'OUTCOME'],
+          assignmentRows,
+        ),
+  ].join('\n');
+}
+
+function formatTable(headers: readonly string[], rows: readonly (readonly string[])[]): string {
+  const widths = headers.map((header, index) => Math.max(
+    header.length,
+    ...rows.map(row => row[index]?.length ?? 0),
+  ));
+  return [headers, ...rows]
+    .map(row => row.map((cell, index) => cell.padEnd(widths[index] ?? cell.length)).join('  ').trimEnd())
+    .join('\n');
+}
+
+function requireIdentifier(value: string, label: string): string {
+  const normalized = value.trim();
+  if (!normalized || normalized.length > 256) throw new Error(`${label} id 无效`);
+  return normalized;
+}
+
+function requirePathIdentifier(value: string, label: string): string {
+  const normalized = requireIdentifier(value, label);
+  if (/[/?#]/u.test(normalized)) throw new Error(`${label} id 无效`);
+  return normalized;
+}
+
+async function readWorkroomHost(apiPath: string, cwd: string): Promise<unknown> {
+  const http = await loadHostHttpConfig(cwd);
+  if (!http) throw new Error('未找到 zhin.config，无法确定 Host API 地址');
+  if (!http.token.trim()) {
+    throw new Error('Host API token 未配置；请配置绑定 principal 的 full scope token');
+  }
+  const response = await hostGet<unknown>(http, apiPath);
+  if (!response.ok) {
+    throw new Error(response.error ?? `读取 Workroom Run 失败（HTTP ${response.status}）`);
+  }
+  return response.data;
+}
+
+function runOnlineAction(action: () => Promise<unknown>): void {
+  void action().catch((error: unknown) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  });
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function nonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0;
+}
+
+function nonNegativeInteger(value: unknown): value is number {
+  return typeof value === 'number' && Number.isInteger(value) && value >= 0;
+}
+
+function isRunStatus(value: unknown): value is WorkroomRunStatus {
+  return value === 'active' || value === 'blocked' || value === 'needs_replan'
+    || value === 'cancelling' || value === 'completed' || value === 'cancelled';
+}
+
+function isTaskStatus(value: unknown): value is WorkroomTaskStatus {
+  return value === 'ready' || value === 'blocked' || value === 'executing'
+    || value === 'awaiting_acceptance' || value === 'cancelling' || value === 'accepted'
+    || value === 'failed' || value === 'cancelled';
+}
+
+function isAssignmentStatus(value: unknown): value is WorkroomAssignmentStatus {
+  return value === 'leased' || value === 'running' || value === 'cancel_requested'
+    || value === 'execution_completed' || value === 'lost' || value === 'cancelled';
+}
+
+function isExecutionRole(value: unknown): value is WorkroomExecutionRole {
+  return value === 'executor' || value === 'reviewer' || value === 'integration';
+}
+
+function isAssignmentOutcome(value: unknown): value is WorkroomAssignmentOutcome {
+  return value === 'interrupted' || value === 'committed' || value === 'outcome_unknown';
+}

--- a/basic/cli/src/commands/agent.ts
+++ b/basic/cli/src/commands/agent.ts
@@ -1,9 +1,10 @@
 import { Command } from 'commander';
 import { registerLegacyRunsOfflineCommand } from './agent-legacy-runs.js';
 import { registerLegacyPayloadsOfflineCommand } from './agent-legacy-payloads.js';
+import { registerWorkroomOnlineCommands } from './agent-workroom.js';
 
 export const agentCommand = new Command('agent')
-  .description('Agent authoring surface diagnostics (ADR 0039 P2)');
+  .description('Agent diagnostics and Workroom operations');
 
 agentCommand
   .command('info')
@@ -31,3 +32,4 @@ agentCommand
 
 registerLegacyRunsOfflineCommand(agentCommand);
 registerLegacyPayloadsOfflineCommand(agentCommand);
+registerWorkroomOnlineCommands(agentCommand);

--- a/basic/cli/src/plugin-runtime/agent-host-installer.ts
+++ b/basic/cli/src/plugin-runtime/agent-host-installer.ts
@@ -54,6 +54,7 @@ import {
   ActivatableWorkroomCatalog,
   FileWorkroomCatalog,
   WorkroomKernel,
+  createCatalogWorkroomRunControlAuthority,
   asPrivate,
   handleRuntimeOwnerApproveCommand,
   handleRuntimeManagementCommand,
@@ -149,6 +150,7 @@ import {
   type AgentCapabilities,
   type AssistantRuntimeHandle,
   type WorkroomRuntimeHandle,
+  type WorkroomRunControlCommand,
   type SessionTreeRuntimeHandle,
   type ToolCapability,
   type AgentTraceRecorder,
@@ -664,6 +666,7 @@ export function installAgentHost(options: InstallAgentHostOptions): RootResource
         resources.has(workroomPriorityAuthorityToken)
           ? resources.use(workroomPriorityAuthorityToken)
           : undefined),
+      runControlAuthority: createCatalogWorkroomRunControlAuthority(workroomCatalog),
     });
     const activateFileWorkroomJournal = () => {
       if (!workroomJournal.active) {
@@ -1022,6 +1025,13 @@ export function installAgentHost(options: InstallAgentHostOptions): RootResource
       console: Object.freeze({
         sessionTree: sessionTreeRuntime,
         workroom: workroomRuntime,
+        workroomControl: Object.freeze({
+          execute: (
+            command: WorkroomRunControlCommand,
+            authenticatedPrincipal: Readonly<{ principalId: string }>,
+          ) =>
+            workroomKernel.controlRun(command, authenticatedPrincipal),
+        }),
         workroomCatalog,
         listBindings: listGenerationBindings,
         assistant: schedule.assistantRuntime,

--- a/basic/cli/src/plugin-runtime/console-api-installer.ts
+++ b/basic/cli/src/plugin-runtime/console-api-installer.ts
@@ -49,8 +49,11 @@ import {
 import type { RootResourceInstaller, RuntimeConfigDocument } from '@zhin.js/runtime';
 import { installInboxMessageRecorder } from './inbox-installer.js';
 import {
+  parseWorkroomRunControlCommand,
+  WorkroomRunControlUnauthorizedError,
   validateWorkroomDefinitions,
   type PortfolioSponsorProjection,
+  type WorkroomRunControlCommand,
   type WorkroomDefinition,
 } from '@zhin.js/agent';
 import type {
@@ -58,6 +61,7 @@ import type {
   WorkroomEffectSponsorDecisionCommand,
   WorkroomEffectSponsorDecisionRecord,
   WorkroomRuntimeHandle,
+  AgentHostWorkroomRunControlPort,
   WorkroomDataLifecycleConsoleCommand,
   WorkroomDataLifecycleConsoleControlPort,
 } from '@zhin.js/agent/runtime';
@@ -301,6 +305,7 @@ export function resolveGenerationAgentIntrospection(
 type AgentConsolePort = {
   readonly sessionTree: ConsoleAgentRuntime['sessionTree'];
   readonly workroom: WorkroomRuntimeHandle;
+  readonly workroomControl?: AgentHostWorkroomRunControlPort;
   readonly assistant: AssistantRuntime | null;
   readonly workroomCatalog: {
     read(): Promise<Readonly<{
@@ -1070,6 +1075,121 @@ export function registerConsoleApiRoutes(
     }
   }, {
     summary: 'List Workroom runs',
+    tags: ['agent', 'workroom'],
+  });
+
+  http.route('GET', `${base}/agent/workroom/readiness`, async (
+    _request, response, url, authScope, authenticatedPrincipal,
+  ) => {
+    if (authScope !== 'full' || !authenticatedPrincipal) {
+      writeJson(response, 403, {
+        success: false, error: '需要绑定 principal 的 full scope 才能读取 Workroom readiness',
+      });
+      return;
+    }
+    if (url.searchParams.has('principalId')) {
+      writeJson(response, 400, { success: false, error: 'principalId 只能来自认证 token' });
+      return;
+    }
+    const projectId = url.searchParams.get('projectId') ?? '';
+    const runId = url.searchParams.get('runId') ?? '';
+    if (!projectId || !runId) {
+      writeJson(response, 400, { success: false, error: '请提供 projectId 和 runId 查询参数' });
+      return;
+    }
+    const handled = await withGenerationAgentConsole(snapshots, async ({ workroom }) => {
+      const result = await workroom.getReadiness({
+        projectId,
+        runId,
+        authenticatedPrincipal: { principalId: authenticatedPrincipal.principalId },
+      });
+      if (result.status === 'forbidden') {
+        writeJson(response, 403, { success: false, error: '无权读取该 Project 的 Workroom readiness' });
+        return;
+      }
+      if (result.status === 'not_found') {
+        writeJson(response, 404, { success: false, error: 'Run not found' });
+        return;
+      }
+      writeJson(response, 200, { success: true, data: result.readiness });
+    });
+    if (!handled) {
+      writeJson(response, 503, {
+        success: false,
+        error: 'Workroom runtime 未就绪（未安装或未初始化 @zhin.js/agent）',
+      });
+    }
+  }, {
+    summary: 'Diagnose Workroom run readiness',
+    tags: ['agent', 'workroom'],
+  });
+
+  http.route('POST', `${base}/agent/workroom/control`, async (
+    request, response, _url, authScope, authenticatedPrincipal,
+  ) => {
+    if (authScope !== 'full' || !authenticatedPrincipal) {
+      writeJson(response, 403, {
+        success: false, error: '需要绑定 principal 的 full scope 才能控制 Workroom Run',
+      });
+      return;
+    }
+    const body = (await readJsonBody<Record<string, unknown>>(request)) ?? {};
+    if (Object.hasOwn(body, 'principalId') || Object.hasOwn(body, 'authenticatedPrincipalId')
+      || Object.hasOwn(body, 'authority') || Object.hasOwn(body, 'authorization')) {
+      writeJson(response, 400, { success: false, error: 'Workroom control 不能携带身份或权威字段' });
+      return;
+    }
+    let command: WorkroomRunControlCommand;
+    try {
+      command = parseWorkroomRunControlCommand(body);
+    } catch (error) {
+      writeJson(response, 400, {
+        success: false, error: error instanceof Error ? error.message : String(error),
+      });
+      return;
+    }
+    const handled = await withGenerationAgentConsole(snapshots, async ({ workroomControl }) => {
+      if (!workroomControl) {
+        writeJson(response, 503, { success: false, error: 'Workroom Run 控制面尚未就绪' });
+        return;
+      }
+      try {
+        const receipt = await workroomControl.execute(command, {
+          principalId: authenticatedPrincipal.principalId,
+        });
+        if (receipt.status === 'stale') {
+          writeJson(response, 409, { success: false, error: 'Workroom Run sequence 已变化', data: receipt });
+          return;
+        }
+        writeJson(response, 200, {
+          success: true,
+          data: {
+            status: receipt.status,
+            action: receipt.action,
+            operationId: receipt.operationId,
+            receiptRef: receipt.receiptRef,
+            receiptDigest: receipt.receiptDigest,
+            run: {
+              projectId: receipt.state.projectId,
+              runId: receipt.state.runId,
+              status: receipt.state.status,
+              sequence: receipt.state.sequence,
+            },
+          },
+        });
+      } catch (error) {
+        if (error instanceof WorkroomRunControlUnauthorizedError) {
+          writeJson(response, 403, { success: false, error: error.message });
+          return;
+        }
+        writeJson(response, 409, {
+          success: false, error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    });
+    if (!handled) writeJson(response, 503, { success: false, error: 'Agent Runtime 尚未就绪' });
+  }, {
+    summary: 'Execute authenticated typed Workroom Run control',
     tags: ['agent', 'workroom'],
   });
 

--- a/basic/cli/src/utils/host-http.ts
+++ b/basic/cli/src/utils/host-http.ts
@@ -78,10 +78,32 @@ export async function hostGet<T>(
   http: HostHttpConfig,
   apiPath: string,
 ): Promise<HostFetchResult<T>> {
+  return hostFetch(http, apiPath, { method: 'GET' });
+}
+
+/** 带 Bearer 的 JSON POST。 */
+export async function hostPost<T>(
+  http: HostHttpConfig,
+  apiPath: string,
+  body: unknown,
+): Promise<HostFetchResult<T>> {
+  return hostFetch(http, apiPath, { method: 'POST', body });
+}
+
+async function hostFetch<T>(
+  http: HostHttpConfig,
+  apiPath: string,
+  input: Readonly<{ method: 'GET' | 'POST'; body?: unknown }>,
+): Promise<HostFetchResult<T>> {
   const url = `${http.baseUrl}${apiPath.startsWith('/') ? apiPath : `/${apiPath}`}`;
   try {
     const res = await fetch(url, {
-      headers: http.token ? { Authorization: `Bearer ${http.token}` } : {},
+      method: input.method,
+      headers: {
+        ...(http.token ? { Authorization: `Bearer ${http.token}` } : {}),
+        ...(input.body === undefined ? {} : { 'Content-Type': 'application/json' }),
+      },
+      ...(input.body === undefined ? {} : { body: JSON.stringify(input.body) }),
       // Host 无响应时 5s 超时，避免 watch/send 等命令无限挂起。
       signal: AbortSignal.timeout(5_000),
     });

--- a/basic/cli/src/utils/host-http.ts
+++ b/basic/cli/src/utils/host-http.ts
@@ -100,12 +100,23 @@ export async function hostGet<T>(
     return { ok: true, status: res.status, data: body.data ?? (body as T) };
   } catch (e: unknown) {
     const err = e as NodeJS.ErrnoException;
+    const connectionCode = errorCode(e);
     const msg =
       err?.name === 'TimeoutError'
         ? `请求 ${http.baseUrl} 超时（5s 无响应）`
-        : err?.code === 'ECONNREFUSED'
+        : connectionCode === 'ECONNREFUSED'
           ? `无法连接 ${http.baseUrl}（请先 zhin runtime start）`
           : (err?.message ?? String(e));
     return { ok: false, status: 0, error: msg };
   }
+}
+
+function errorCode(value: unknown): string | undefined {
+  if (!value || typeof value !== 'object') return undefined;
+  const direct = Reflect.get(value, 'code');
+  if (typeof direct === 'string') return direct;
+  const cause = Reflect.get(value, 'cause');
+  if (!cause || typeof cause !== 'object') return undefined;
+  const nested = Reflect.get(cause, 'code');
+  return typeof nested === 'string' ? nested : undefined;
 }

--- a/basic/cli/tests/agent-workroom.test.ts
+++ b/basic/cli/tests/agent-workroom.test.ts
@@ -4,6 +4,9 @@ import { join } from 'node:path';
 import { Command } from 'commander';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
+  executeWorkroomCancelCommand,
+  executeWorkroomReadinessCommand,
+  executeWorkroomRequestReplanCommand,
   executeWorkroomRunCommand,
   executeWorkroomRunsCommand,
   registerWorkroomOnlineCommands,
@@ -138,6 +141,99 @@ describe('zhin agent workroom runs', () => {
     expect(JSON.stringify(result)).not.toMatch(/title|reason|progress|objective|owner/u);
   });
 
+  it('diagnoses content-free blockers and actionable readiness for one Run', async () => {
+    const projectRoot = await mkdtemp(join(tmpdir(), 'zhin-workroom-cli-'));
+    await writeFile(join(projectRoot, 'zhin.config.yml'), 'http:\n  token: sponsor-token\n');
+    vi.stubGlobal('fetch', vi.fn(async (input: string | URL | Request) => {
+      expect(String(input)).toBe(
+        'http://127.0.0.1:8086/api/agent/workroom/readiness?projectId=support&runId=run-2',
+      );
+      return new Response(JSON.stringify({
+        success: true,
+        data: {
+          version: 1, projectId: 'support', runId: 'run-2', sequence: 9, state: 'blocked',
+          blockers: [{
+            version: 1, taskRef: 'task:triage', blockerRef: 'blocker:provider',
+            kind: 'capability', deadline: 120,
+            allowedActions: ['resolve', 'replan', 'cancel'], digest: 'sha256:blocker',
+          }],
+          recommendedActions: ['resolve', 'replan', 'cancel'],
+          authorityDigest: 'sha256:authority', digest: 'sha256:readiness',
+        },
+      }), { status: 200, headers: { 'content-type': 'application/json' } });
+    }));
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    const result = await executeWorkroomReadinessCommand({
+      projectId: 'support', runId: 'run-2',
+    }, projectRoot);
+
+    expect(result).toMatchObject({ state: 'blocked', blockers: [{ kind: 'capability' }] });
+    expect(log).toHaveBeenCalledWith([
+      'Workroom readiness · support/run-2 · blocked · seq 9',
+      'TASK         BLOCKER           KIND        DEADLINE  ACTIONS',
+      'task:triage  blocker:provider  capability  120       resolve,replan,cancel',
+      'Recommended: resolve, replan, cancel',
+    ].join('\n'));
+    expect(JSON.stringify(result)).not.toMatch(/reason|owner|title|progress/u);
+  });
+
+  it('submits typed cancel and replan controls without accepting caller identity or free-form reasons', async () => {
+    const projectRoot = await mkdtemp(join(tmpdir(), 'zhin-workroom-cli-'));
+    await writeFile(join(projectRoot, 'zhin.config.yml'), 'http:\n  token: sponsor-token\n');
+    const fetchMock = vi.fn(async (_input: string | URL | Request, init?: RequestInit) => {
+      const command = JSON.parse(String(init?.body)) as { action: string; operationId: string };
+      return new Response(JSON.stringify({
+        success: true,
+        data: {
+          status: 'committed', action: command.action, operationId: command.operationId,
+          receiptRef: `event:${command.operationId}`, receiptDigest: 'sha256:receipt',
+          run: {
+            projectId: 'support', runId: 'run-2',
+            status: command.action === 'cancel' ? 'cancelling' : 'needs_replan', sequence: 10,
+          },
+        },
+      }), { status: 200, headers: { 'content-type': 'application/json' } });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    await executeWorkroomCancelCommand({
+      projectId: 'support', runId: 'run-2', expectedSequence: 9,
+      reasonCode: 'operator_request', controlDeadline: 120, operationId: 'cancel-1',
+    }, projectRoot);
+    await executeWorkroomRequestReplanCommand({
+      projectId: 'support', runId: 'run-2', expectedSequence: 9,
+      reasonCode: 'requirements_changed', operationId: 'replan-1',
+    }, projectRoot);
+
+    expect(fetchMock).toHaveBeenNthCalledWith(1,
+      'http://127.0.0.1:8086/api/agent/workroom/control', expect.objectContaining({
+        method: 'POST',
+        headers: {
+          Authorization: 'Bearer sponsor-token', 'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          version: 1, operationId: 'cancel-1', projectId: 'support', runId: 'run-2',
+          expectedSequence: 9, action: 'cancel', reasonCode: 'operator_request',
+          controlDeadline: 120,
+        }),
+      }));
+    expect(fetchMock).toHaveBeenNthCalledWith(2,
+      'http://127.0.0.1:8086/api/agent/workroom/control', expect.objectContaining({
+        body: JSON.stringify({
+          version: 1, operationId: 'replan-1', projectId: 'support', runId: 'run-2',
+          expectedSequence: 9, action: 'request_replan', reasonCode: 'requirements_changed',
+        }),
+      }));
+    expect(log).toHaveBeenNthCalledWith(
+      1, 'Workroom control · cancel · committed · support/run-2 · cancelling · seq 10',
+    );
+    expect(log).toHaveBeenNthCalledWith(
+      2, 'Workroom control · request_replan · committed · support/run-2 · needs_replan · seq 10',
+    );
+  });
+
   it('prints an explicit empty state instead of an ambiguous header-only table', async () => {
     const projectRoot = await mkdtemp(join(tmpdir(), 'zhin-workroom-cli-'));
     await writeFile(join(projectRoot, 'zhin.config.yml'), [
@@ -244,6 +340,42 @@ describe('zhin agent workroom runs', () => {
       command.parse(['node', 'agent', 'workroom', 'runs', '--project', 'support']);
       await vi.waitFor(() => {
         expect(log).toHaveBeenCalledWith('Workroom runs · support\n(none)');
+      });
+    } finally {
+      process.chdir(previousCwd);
+    }
+  });
+
+  it('maps the synchronous request-replan grammar to one typed Host control command', async () => {
+    const projectRoot = await mkdtemp(join(tmpdir(), 'zhin-workroom-cli-'));
+    await writeFile(join(projectRoot, 'zhin.config.yml'), 'http:\n  token: sponsor-token\n');
+    const fetchMock = vi.fn(async (_input: string | URL | Request, init?: RequestInit) => {
+      const command = JSON.parse(String(init?.body)) as Record<string, unknown>;
+      return new Response(JSON.stringify({
+        success: true,
+        data: {
+          status: 'committed', action: command.action, operationId: command.operationId,
+          receiptRef: 'event-1', receiptDigest: 'sha256:receipt',
+          run: { projectId: 'support', runId: 'run-2', status: 'needs_replan', sequence: 10 },
+        },
+      }), { status: 200, headers: { 'content-type': 'application/json' } });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    const previousCwd = process.cwd();
+    const command = new Command('agent');
+    registerWorkroomOnlineCommands(command);
+    try {
+      process.chdir(projectRoot);
+      command.parse([
+        'node', 'agent', 'workroom', 'request-replan', 'run-2',
+        '--project', 'support', '--expected-sequence', '9',
+        '--reason-code', 'requirements_changed', '--operation-id', 'replan-1',
+      ]);
+      await vi.waitFor(() => expect(fetchMock).toHaveBeenCalled());
+      expect(JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body))).toEqual({
+        version: 1, operationId: 'replan-1', projectId: 'support', runId: 'run-2',
+        expectedSequence: 9, action: 'request_replan', reasonCode: 'requirements_changed',
       });
     } finally {
       process.chdir(previousCwd);

--- a/basic/cli/tests/agent-workroom.test.ts
+++ b/basic/cli/tests/agent-workroom.test.ts
@@ -1,0 +1,276 @@
+import { mkdtemp, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { Command } from 'commander';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  executeWorkroomRunCommand,
+  executeWorkroomRunsCommand,
+  registerWorkroomOnlineCommands,
+} from '../src/commands/agent-workroom.js';
+
+describe('zhin agent workroom runs', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('lists content-free Workroom run headers through the authenticated Host API', async () => {
+    const projectRoot = await mkdtemp(join(tmpdir(), 'zhin-workroom-cli-'));
+    await writeFile(join(projectRoot, 'zhin.config.yml'), [
+      'http:',
+      '  host: 127.0.0.1',
+      '  port: 8086',
+      '  base: /api',
+      '  token: sponsor-token',
+      '',
+    ].join('\n'));
+    const fetchMock = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      expect(String(input)).toBe(
+        'http://127.0.0.1:8086/api/agent/workroom/runs?projectId=support',
+      );
+      expect(init?.headers).toEqual({ Authorization: 'Bearer sponsor-token' });
+      return new Response(JSON.stringify({
+        success: true,
+        data: {
+          projectId: 'support',
+          runs: [{
+            version: 1,
+            projectId: 'support',
+            runId: 'run-2',
+            status: 'active',
+            sequence: 8,
+            cancelRequested: false,
+            counts: { tasks: 3, assignments: 2, reviewerAssignments: 1, sponsorGates: 0 },
+            authorityDigest: 'sha256:authority',
+            digest: 'sha256:run',
+          }],
+        },
+      }), { status: 200, headers: { 'content-type': 'application/json' } });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    const result = await executeWorkroomRunsCommand({ projectId: 'support' }, projectRoot);
+
+    expect(result).toMatchObject({ projectId: 'support', runs: [{ runId: 'run-2' }] });
+    expect(log).toHaveBeenCalledWith([
+      'Workroom runs · support',
+      'RUN    STATUS  SEQ  TASKS  ASSIGNMENTS  REVIEWERS  GATES  CANCEL',
+      'run-2  active  8    3      2            1          0      no',
+    ].join('\n'));
+    expect(JSON.stringify(result)).not.toMatch(/title|reason|progress|objective/u);
+  });
+
+  it('inspects content-free Task and Assignment status for one Run', async () => {
+    const projectRoot = await mkdtemp(join(tmpdir(), 'zhin-workroom-cli-'));
+    await writeFile(join(projectRoot, 'zhin.config.yml'), [
+      'http:',
+      '  port: 8086',
+      '  token: sponsor-token',
+      '',
+    ].join('\n'));
+    vi.stubGlobal('fetch', vi.fn(async (input: string | URL | Request) => {
+      expect(String(input)).toBe(
+        'http://127.0.0.1:8086/api/agent/workroom/runs/run-2?projectId=support',
+      );
+      return new Response(JSON.stringify({
+        success: true,
+        data: {
+          version: 1,
+          projectId: 'support',
+          runId: 'run-2',
+          status: 'active',
+          sequence: 8,
+          cancelRequested: false,
+          counts: { tasks: 2, assignments: 1, reviewerAssignments: 0, sponsorGates: 0 },
+          authorityDigest: 'sha256:authority',
+          digest: 'sha256:run',
+          tasks: [{
+            version: 1,
+            ref: 'task:research:1',
+            status: 'executing',
+            revision: 1,
+            attempt: 1,
+            required: true,
+            blockerCount: 0,
+            hasCurrentAssignment: true,
+            digest: 'sha256:task',
+          }],
+          assignments: [{
+            version: 1,
+            ref: 'assignment:a-1',
+            taskRef: 'task:research:1',
+            status: 'running',
+            role: 'executor',
+            revision: 1,
+            attempt: 1,
+            fence: 3,
+            digest: 'sha256:assignment',
+          }],
+        },
+      }), { status: 200, headers: { 'content-type': 'application/json' } });
+    }));
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    const result = await executeWorkroomRunCommand({
+      projectId: 'support',
+      runId: 'run-2',
+    }, projectRoot);
+
+    expect(result).toMatchObject({
+      projectId: 'support',
+      runId: 'run-2',
+      tasks: [{ ref: 'task:research:1', status: 'executing' }],
+      assignments: [{ ref: 'assignment:a-1', status: 'running' }],
+    });
+    expect(log).toHaveBeenCalledWith([
+      'Workroom run · support/run-2 · active · seq 8',
+      '',
+      'Tasks',
+      'TASK             STATUS     REV  ATTEMPT  REQUIRED  BLOCKERS  ASSIGNED',
+      'task:research:1  executing  1    1        yes       0         yes',
+      '',
+      'Assignments',
+      'ASSIGNMENT      TASK             STATUS   ROLE      REV  ATTEMPT  FENCE  OUTCOME',
+      'assignment:a-1  task:research:1  running  executor  1    1        3      -',
+    ].join('\n'));
+    expect(JSON.stringify(result)).not.toMatch(/title|reason|progress|objective|owner/u);
+  });
+
+  it('prints an explicit empty state instead of an ambiguous header-only table', async () => {
+    const projectRoot = await mkdtemp(join(tmpdir(), 'zhin-workroom-cli-'));
+    await writeFile(join(projectRoot, 'zhin.config.yml'), [
+      'http:',
+      '  token: sponsor-token',
+      '',
+    ].join('\n'));
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({
+      success: true,
+      data: { projectId: 'support', runs: [] },
+    }), { status: 200, headers: { 'content-type': 'application/json' } })));
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    await executeWorkroomRunsCommand({ projectId: 'support' }, projectRoot);
+
+    expect(log).toHaveBeenCalledWith('Workroom runs · support\n(none)');
+  });
+
+  it('surfaces Host authorization failures without printing a success projection', async () => {
+    const projectRoot = await mkdtemp(join(tmpdir(), 'zhin-workroom-cli-'));
+    await writeFile(join(projectRoot, 'zhin.config.yml'), [
+      'http:',
+      '  token: unbound-token',
+      '',
+    ].join('\n'));
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({
+      success: false,
+      error: '需要绑定 principal 的 full scope 才能读取 Workroom Run',
+    }), { status: 403, headers: { 'content-type': 'application/json' } })));
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    await expect(executeWorkroomRunsCommand({ projectId: 'support' }, projectRoot))
+      .rejects.toThrow('需要绑定 principal 的 full scope 才能读取 Workroom Run');
+    expect(log).not.toHaveBeenCalled();
+  });
+
+  it('emits stable JSON for scripts when requested', async () => {
+    const projectRoot = await mkdtemp(join(tmpdir(), 'zhin-workroom-cli-'));
+    await writeFile(join(projectRoot, 'zhin.config.yml'), [
+      'http:',
+      '  token: sponsor-token',
+      '',
+    ].join('\n'));
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({
+      success: true,
+      data: { projectId: 'support', runs: [] },
+    }), { status: 200, headers: { 'content-type': 'application/json' } })));
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    await executeWorkroomRunsCommand({ projectId: 'support', json: true }, projectRoot);
+
+    expect(log).toHaveBeenCalledWith(JSON.stringify({ projectId: 'support', runs: [] }, null, 2));
+  });
+
+  it('fails before fetch when the configured Host token is missing', async () => {
+    const projectRoot = await mkdtemp(join(tmpdir(), 'zhin-workroom-cli-'));
+    await writeFile(join(projectRoot, 'zhin.config.yml'), 'http:\n  port: 8086\n');
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(executeWorkroomRunsCommand({ projectId: 'support' }, projectRoot))
+      .rejects.toThrow('Host API token 未配置');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects unknown Workroom domain states instead of displaying them as authoritative', async () => {
+    const projectRoot = await mkdtemp(join(tmpdir(), 'zhin-workroom-cli-'));
+    await writeFile(join(projectRoot, 'zhin.config.yml'), 'http:\n  token: sponsor-token\n');
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({
+      success: true,
+      data: {
+        projectId: 'support',
+        runs: [{
+          version: 1,
+          projectId: 'support',
+          runId: 'run-1',
+          status: 'mysterious',
+          sequence: 1,
+          cancelRequested: false,
+          counts: { tasks: 0, assignments: 0, reviewerAssignments: 0, sponsorGates: 0 },
+          authorityDigest: 'sha256:authority',
+          digest: 'sha256:run',
+        }],
+      },
+    }), { status: 200, headers: { 'content-type': 'application/json' } })));
+
+    await expect(executeWorkroomRunsCommand({ projectId: 'support' }, projectRoot))
+      .rejects.toThrow('无效的 Workroom Run header');
+  });
+
+  it('registers the confirmed command grammar on the synchronous production Commander seam', async () => {
+    const projectRoot = await mkdtemp(join(tmpdir(), 'zhin-workroom-cli-'));
+    await writeFile(join(projectRoot, 'zhin.config.yml'), 'http:\n  token: sponsor-token\n');
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({
+      success: true,
+      data: { projectId: 'support', runs: [] },
+    }), { status: 200, headers: { 'content-type': 'application/json' } })));
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    const previousCwd = process.cwd();
+    const command = new Command('agent');
+    registerWorkroomOnlineCommands(command);
+    try {
+      process.chdir(projectRoot);
+      command.parse(['node', 'agent', 'workroom', 'runs', '--project', 'support']);
+      await vi.waitFor(() => {
+        expect(log).toHaveBeenCalledWith('Workroom runs · support\n(none)');
+      });
+    } finally {
+      process.chdir(previousCwd);
+    }
+  });
+
+  it('turns an async Workroom action failure into a controlled CLI error', async () => {
+    const projectRoot = await mkdtemp(join(tmpdir(), 'zhin-workroom-cli-'));
+    await writeFile(join(projectRoot, 'zhin.config.yml'), 'http:\n  token: "   "\n');
+    const error = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const previousCwd = process.cwd();
+    const previousExitCode = process.exitCode;
+    const command = new Command('agent');
+    registerWorkroomOnlineCommands(command);
+    try {
+      process.chdir(projectRoot);
+      process.exitCode = undefined;
+      command.parse(['node', 'agent', 'workroom', 'runs', '--project', 'support']);
+      await vi.waitFor(() => {
+        expect(error).toHaveBeenCalledWith(
+          'Host API token 未配置；请配置绑定 principal 的 full scope token',
+        );
+        expect(process.exitCode).toBe(1);
+      });
+    } finally {
+      process.chdir(previousCwd);
+      process.exitCode = previousExitCode;
+    }
+  });
+});

--- a/basic/cli/tests/plugin-runtime/console-api-installer.test.ts
+++ b/basic/cli/tests/plugin-runtime/console-api-installer.test.ts
@@ -443,11 +443,33 @@ describe('console REST routes', () => {
       input.projectId === 'engineering' && input.runId === 'run-1'
         ? { status: 'ready' as const, run: { ...safeRun, tasks: [], assignments: [] } }
         : { status: 'forbidden' as const });
+    const getReadiness = vi.fn(async (input: { projectId: string; runId: string }) =>
+      input.projectId === 'engineering' && input.runId === 'run-1'
+        ? { status: 'ready' as const, readiness: {
+            version: 1, projectId: 'engineering', runId: 'run-1', sequence: 4,
+            state: 'ready', blockers: [], recommendedActions: [],
+            authorityDigest: 'sha256:authority', digest: 'sha256:readiness',
+          } }
+        : { status: 'forbidden' as const });
+    const executeControl = vi.fn(async (command, principal) => ({
+      status: 'committed' as const,
+      action: command.action,
+      operationId: command.operationId,
+      receiptRef: 'event-control-1',
+      receiptDigest: 'sha256:control',
+      state: {
+        projectId: command.projectId, runId: command.runId, status: 'needs_replan', sequence: 6,
+        title: 'must-not-leak', now: 100, cancelRequested: false, replanRequested: true,
+        tasks: {}, assignments: {}, reviewerAssignments: {}, sponsorGates: {},
+      },
+      principal,
+    }));
     const snapshot = {
       root,
       resources: new Map([[root, new Map([[tokenId('zhin.host.agent'), {
         console: {
-          sessionTree: {}, workroom: { listRuns, getRun }, assistant: null,
+          sessionTree: {}, workroom: { listRuns, getRun, getReadiness },
+          workroomControl: { execute: executeControl }, assistant: null,
           trace: { list: () => ({ sessionKey: '', events: [], latestSequence: 0, activeTurnIds: [] }) },
         },
       }]])]]),
@@ -494,6 +516,64 @@ describe('console REST routes', () => {
       projectId: 'engineering', runId: 'run-1',
       authenticatedPrincipal: { principalId: 'human:alice' },
     });
+
+    const readiness = await fetch(
+      `http://127.0.0.1:${port}/api/agent/workroom/readiness?projectId=engineering&runId=run-1`,
+      { headers: { authorization: 'Bearer sponsor-token' } },
+    );
+    expect(readiness.status).toBe(200);
+    expect(await readiness.json()).toMatchObject({
+      success: true, data: { projectId: 'engineering', runId: 'run-1', state: 'ready' },
+    });
+    expect(getReadiness).toHaveBeenCalledWith({
+      projectId: 'engineering', runId: 'run-1',
+      authenticatedPrincipal: { principalId: 'human:alice' },
+    });
+
+    const control = await fetch(
+      `http://127.0.0.1:${port}/api/agent/workroom/control`,
+      {
+        method: 'POST',
+        headers: {
+          authorization: 'Bearer sponsor-token',
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({
+          version: 1, operationId: 'replan-1', projectId: 'engineering', runId: 'run-1',
+          expectedSequence: 4, action: 'request_replan', reasonCode: 'requirements_changed',
+        }),
+      },
+    );
+    expect(control.status).toBe(200);
+    const controlBody = await control.json();
+    expect(controlBody).toMatchObject({
+      success: true,
+      data: {
+        status: 'committed', action: 'request_replan', operationId: 'replan-1',
+        run: { projectId: 'engineering', runId: 'run-1', status: 'needs_replan', sequence: 6 },
+      },
+    });
+    expect(JSON.stringify(controlBody)).not.toContain('must-not-leak');
+    expect(executeControl).toHaveBeenCalledWith(expect.objectContaining({
+      action: 'request_replan', expectedSequence: 4,
+    }), { principalId: 'human:alice' });
+
+    const forgedControl = await fetch(
+      `http://127.0.0.1:${port}/api/agent/workroom/control`,
+      {
+        method: 'POST',
+        headers: {
+          authorization: 'Bearer sponsor-token',
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({
+          version: 1, operationId: 'cancel-1', projectId: 'engineering', runId: 'run-1',
+          expectedSequence: 4, action: 'cancel', reasonCode: 'operator_request',
+          controlDeadline: 120, principalId: 'human:mallory',
+        }),
+      },
+    );
+    expect(forgedControl.status).toBe(400);
   });
 
   it('cancels an active Agent task through the generation-owned console port', async () => {

--- a/basic/cli/tests/utils/host-http.test.ts
+++ b/basic/cli/tests/utils/host-http.test.ts
@@ -34,4 +34,20 @@ describe('hostGet', () => {
     expect(result.error).toContain('超时');
     expect(result.error).toContain('http://127.0.0.1:8086/api');
   });
+
+  it('maps Node fetch connection refusal causes to the runtime-start hint', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => {
+      throw new TypeError('fetch failed', {
+        cause: Object.assign(new Error('connect ECONNREFUSED'), { code: 'ECONNREFUSED' }),
+      });
+    }));
+
+    const result = await hostGet({ baseUrl: 'http://127.0.0.1:8086/api', token: 'token' }, '/stats');
+
+    expect(result).toEqual({
+      ok: false,
+      status: 0,
+      error: '无法连接 http://127.0.0.1:8086/api（请先 zhin runtime start）',
+    });
+  });
 });

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -204,13 +204,18 @@ zhin schedule resume <id>
 zhin agent info [--json]
 zhin agent workroom runs --project <projectId> [--json]
 zhin agent workroom run <runId> --project <projectId> [--json]
+zhin agent workroom readiness <runId> --project <projectId> [--json]
+zhin agent workroom cancel <runId> --project <projectId> --expected-sequence <n> --reason-code <code> --control-deadline <timestamp> [--operation-id <id>] [--json]
+zhin agent workroom request-replan <runId> --project <projectId> --expected-sequence <n> --reason-code <code> [--operation-id <id>] [--json]
 zhin agent legacy-runs <input> [--output <file>]
 zhin agent legacy-payloads <input> --kind journal|projection|evidence|artifact [--storage file|database]
 ```
 
-`info` 列出发现的 `agent/` 创作面（tools / skills 等）。`workroom runs/run` 连接当前项目正在运行的
-Host API，使用配置中的 token-bound principal 读取 content-free Run、Task 与 Assignment 状态；需要先运行
-`zhin runtime start`，且 token 必须具有目标 Project 的 Sponsor/治理授权。`legacy-runs` 与
+`info` 列出发现的 `agent/` 创作面（tools / skills 等）。`workroom runs/run/readiness` 连接当前项目正在运行的
+Host API，使用配置中的 token-bound principal 读取 content-free Run、Task、Assignment 与 Blocker 状态；
+`cancel` 与 `request-replan` 还要求当前 Project Sponsor 权限，并通过 `expected-sequence` 做 CAS。后者只持久化
+重规划请求并暂停调度，不会伪装成已经生成了新 Plan Revision。以上在线命令需要先运行
+`zhin runtime start`。`legacy-runs` 与
 `legacy-payloads` 仅做离线只读审计，不会启动 Host 或写入新 Workroom Journal。以上命令需安装 AI 栈
 （`@zhin.js/agent` + `zod` + `ai`）。
 

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -198,13 +198,21 @@ zhin schedule resume <id>
 
 `add` 选项：`--prompt`（必填，到点发给 AI 的提示词）、`-l/--label`、`--kind`（默认 `solar`）、`--notify-channel im|silent|log`（默认 `silent`）、`--at`（单次 ISO8601）、`--every`（如 `30m`、`1h`、`1d`）。cron 与 `--at`/`--every` 三选一。
 
-## agent：Agent 创作面诊断
+## agent：Agent 诊断与 Workroom 观察
 
 ```bash
 zhin agent info [--json]
+zhin agent workroom runs --project <projectId> [--json]
+zhin agent workroom run <runId> --project <projectId> [--json]
+zhin agent legacy-runs <input> [--output <file>]
+zhin agent legacy-payloads <input> --kind journal|projection|evidence|artifact [--storage file|database]
 ```
 
-列出发现的 `agent/` 创作面（tools / skills 等）。需安装 AI 栈（`@zhin.js/agent` + `zod` + `ai`）。
+`info` 列出发现的 `agent/` 创作面（tools / skills 等）。`workroom runs/run` 连接当前项目正在运行的
+Host API，使用配置中的 token-bound principal 读取 content-free Run、Task 与 Assignment 状态；需要先运行
+`zhin runtime start`，且 token 必须具有目标 Project 的 Sponsor/治理授权。`legacy-runs` 与
+`legacy-payloads` 仅做离线只读审计，不会启动 Host 或写入新 Workroom Journal。以上命令需安装 AI 栈
+（`@zhin.js/agent` + `zod` + `ai`）。
 
 ## service：系统服务
 

--- a/docs/plans/agent-workroom-production-ledger.md
+++ b/docs/plans/agent-workroom-production-ledger.md
@@ -36,6 +36,8 @@ Production slice 4 (2026-08-22): 标准 Host 已组合 generation-owned Sponsor/
 
 Production slice 5 (2026-08-22): 组合级 Host/Kernel fixture 已固定剩余跨模块不变量：chat 保留 `spawn_task` 但执行不产生任何 Workroom Journal fact，Workroom Assignment 物理移除 spawn/typed writer，纯 PlanBuilder 前后 Journal 均为空；Local 与 authenticated Remote completion 归一为同构 `assignment.execution_completed` 且只到 `awaiting_acceptance`；只有 `task.accepted` 才推进 dependent Local Assignment。持续 urgent 输入下，超过 pinned starvation bound 的 low lane Task 仍先行且 lane 不被改写。Remote Assignment 缺 typed checkpoint provider时写带 resolve/replan/cancel 的 durable blocker，重启安装 provider后只重投 request、不伪造 ack；generation retire会 abort在途 delivery。既有 Kernel cancel、Plan Revision `preemption_required` 和 timeout blocker tests继续作为同一SSOT gate。剩余缺口收敛为 Console/Sponsor Room projection、Remote supply composition与外部typed checkpoint transport实装，P2保持 `in_progress`。
 
+Production slice 6 (2026-08-23): `zhin agent workroom readiness` 与 authenticated Host REST 现从 v3 Journal 的 content-free stored headers 投影 opaque Task/Blocker ref、闭集 kind、deadline 与 allowed actions，读取过程不 materialize title/reason/owner/progress；旧 v3 Blocker header缺新增诊断字段时保守显示 unknown。新增 Root-private Run control facade，Console token principal必须是 current enabled Catalog Project Sponsor，命令固定 operationId、expectedSequence、闭集 reasonCode 与 exact authority digest。`cancel` 原子复用 Kernel 两阶段取消；`request-replan` 原子写 control audit + `run.replan_requested`，Run进入 `needs_replan`且Scheduler停止新dispatch，后续真实 Plan Revision admission才恢复。重复operation exact replay，stale/未授权零写。该slice尚未生成新Plan，也未补Sponsor Room queue/priority控制与完整跨Local/Remote E2E，因此组合条目继续不勾选、P2保持 `in_progress`。
+
 ## P7：Risk-tier Acceptance
 
 Status: in_progress

--- a/packages/im/agent/src/index.ts
+++ b/packages/im/agent/src/index.ts
@@ -425,6 +425,7 @@ export * from './workroom/journal.js';
 export * from './workroom/journal-model.js';
 export * from './workroom/catalog.js';
 export * from './workroom/workroom-kernel.js';
+export * from './workroom/workroom-run-control.js';
 export * from './workroom/runtime.js';
 export * from './workroom/remote-callback-inbox.js';
 export * from './workroom/remote-callback-reconciliation-worker.js';

--- a/packages/im/agent/src/plugin-runtime/agent-host-port.ts
+++ b/packages/im/agent/src/plugin-runtime/agent-host-port.ts
@@ -26,6 +26,10 @@ import type {
   ProjectKnowledgeSnapshot,
 } from '../workroom/project-knowledge-registry.js';
 import type { WorkroomDataLifecycleConsoleControlPort } from './workroom-data-lifecycle-console.js';
+import type {
+  WorkroomRunControlCommand,
+  WorkroomRunControlReceipt,
+} from '../workroom/workroom-run-control.js';
 
 /**
  * Stable Host boundary for protocols that expose Agent capabilities externally.
@@ -68,6 +72,8 @@ export interface AgentHostIntrospectionPort {
 export interface AgentHostConsolePort {
   readonly sessionTree: SessionTreeRuntimeHandle;
   readonly workroom: WorkroomRuntimeHandle;
+  /** Sponsor-authorized Run mutation plane; identity is injected from the Host token. */
+  readonly workroomControl?: AgentHostWorkroomRunControlPort;
   /** Persistent topology SSOT; edits take effect without rebuilding the generation. */
   readonly workroomCatalog: WorkroomCatalog;
   /** Bindings from this exact generation, used for Catalog display and validation. */
@@ -84,6 +90,13 @@ export interface AgentHostConsolePort {
   readonly effectSponsor?: AgentHostEffectSponsorControlPort;
   /** Root-role + current P12 authorized, content-free Payload Lifecycle plane. */
   readonly dataLifecycle?: WorkroomDataLifecycleConsoleControlPort;
+}
+
+export interface AgentHostWorkroomRunControlPort {
+  execute(
+    command: WorkroomRunControlCommand,
+    authenticatedPrincipal: Readonly<{ principalId: string }>,
+  ): Promise<WorkroomRunControlReceipt>;
 }
 
 export interface AgentHostPortfolioSponsorControlPort

--- a/packages/im/agent/src/plugin-runtime/index.ts
+++ b/packages/im/agent/src/plugin-runtime/index.ts
@@ -2,6 +2,10 @@ export * from './agent-runtime.js';
 export * from './agent-host-port.js';
 export * from './agent-trace-runtime.js';
 export type { AssistantRuntimeHandle } from '../assistant/runtime-contract.js';
+export type {
+  WorkroomRunControlCommand,
+  WorkroomRunControlReceipt,
+} from '../workroom/workroom-run-control.js';
 export {
   createCatalogGovernedWorkroomProjectionAuthority,
   createCatalogGovernedConsoleDisclosureAuthority,

--- a/packages/im/agent/src/workroom/journal.ts
+++ b/packages/im/agent/src/workroom/journal.ts
@@ -1,7 +1,12 @@
 import { createHash } from 'node:crypto';
 import { readFile, readdir } from 'node:fs/promises';
 import { basename, join } from 'node:path';
-import type { WorkroomEvent, WorkroomEventDraft } from './kernel-contracts.js';
+import type {
+  WorkroomBlocker,
+  WorkroomBlockerKind,
+  WorkroomEvent,
+  WorkroomEventDraft,
+} from './kernel-contracts.js';
 import { assertAcceptanceContract, assertPersistedAcceptanceRecord } from './acceptance-policy.js';
 import {
   canonicalWorkroomJson,
@@ -13,6 +18,10 @@ import { assertWorkflowPlanProposal } from './workflow-plan-builder.js';
 import { assertWorkflowPlanRevisionCandidate } from './plan-revision.js';
 import { parseWorkroomRemoteAssignmentIssuance } from './remote-assignment-issuance.js';
 import { parseWorkroomLocalAssignmentIssuance } from './local-assignment-issuance.js';
+import {
+  isWorkroomRunCancelReasonCode,
+  isWorkroomRunReplanReasonCode,
+} from './workroom-run-control.js';
 import {
   assertWorkroomSchedulerPolicySnapshot,
   parseWorkroomDispatchTaskDecision,
@@ -160,6 +169,9 @@ export interface WorkroomStoredEventControl {
   readonly taskKey?: string;
   readonly assignmentId?: string;
   readonly blockerId?: string;
+  readonly blockerKind?: WorkroomBlockerKind;
+  readonly blockerDeadline?: number;
+  readonly blockerAllowedActions?: WorkroomBlocker['allowedActions'];
   readonly waitId?: string;
   readonly waitStatus?: string;
   readonly role?: WorkroomAssignmentRoleHeader;
@@ -1043,7 +1055,13 @@ function deriveStoredEventControl(event: WorkroomEvent): WorkroomStoredEventCont
       required: payload.required === true,
       maxAttempts: storedHeaderPositiveInteger(payload, 'maxAttempts'),
     });
-    case 'task.blocked':
+    case 'task.blocked': return deepFreeze({
+      taskKey: taskKey(),
+      blockerId: opaqueStoredRef('blocker', event.runId, storedHeaderText(payload, 'blockerId')),
+      blockerKind: storedHeaderBlockerKind(payload.kind),
+      blockerDeadline: storedHeaderNonNegativeInteger(payload, 'deadline'),
+      blockerAllowedActions: Object.freeze(['resolve', 'replan', 'cancel'] as const),
+    });
     case 'task.blocker_resolved': return deepFreeze({
       taskKey: taskKey(),
       blockerId: opaqueStoredRef('blocker', event.runId, storedHeaderText(payload, 'blockerId')),
@@ -1124,7 +1142,9 @@ function deriveStoredEventControl(event: WorkroomEvent): WorkroomStoredEventCont
 const WORKROOM_EVENT_CONTROL_KEYS: Readonly<Record<WorkroomEvent['type'], readonly string[]>> = Object.freeze({
   'run.created': ['projectId'],
   'task.planned': ['taskKey', 'required', 'maxAttempts'],
-  'task.blocked': ['taskKey', 'blockerId'],
+  'task.blocked': [
+    'taskKey', 'blockerId', 'blockerKind', 'blockerDeadline', 'blockerAllowedActions',
+  ],
   'task.blocker_resolved': ['taskKey', 'blockerId'],
   'assignment.claimed': [
     'taskKey', 'assignmentId', 'role', 'attempt', 'assignmentRevision', 'fence',
@@ -1158,6 +1178,8 @@ const WORKROOM_EVENT_CONTROL_KEYS: Readonly<Record<WorkroomEvent['type'], readon
   'plan.admitted': [],
   'plan.revision_applied': [],
   'plan_gate.decided': [],
+  'run.control_decided': [],
+  'run.replan_requested': [],
   'run.cancel_requested': [],
   'run.cancelled': [],
   'scheduler.dispatch_requested': [],
@@ -1174,7 +1196,10 @@ function validateStoredEventControl(
   type: WorkroomEvent['type'],
   control: Readonly<Record<string, unknown>>,
 ): void {
-  assertExactRecordKeys(control, WORKROOM_EVENT_CONTROL_KEYS[type], 'Stored Workroom control');
+  const keys = type === 'task.blocked' && Object.keys(control).length === 2
+    ? ['taskKey', 'blockerId']
+    : WORKROOM_EVENT_CONTROL_KEYS[type];
+  assertExactRecordKeys(control, keys, 'Stored Workroom control');
   if (control.projectId !== undefined) storedHeaderText(control, 'projectId');
   for (const key of ['taskKey', 'assignmentId', 'blockerId', 'waitId'] as const) {
     if (control[key] !== undefined && (typeof control[key] !== 'string'
@@ -1187,6 +1212,13 @@ function validateStoredEventControl(
   }
   if (control.required !== undefined && typeof control.required !== 'boolean') {
     throw new Error('Stored Workroom control required is invalid');
+  }
+  if (control.blockerKind !== undefined) storedHeaderBlockerKind(control.blockerKind);
+  if (control.blockerDeadline !== undefined) {
+    storedHeaderNonNegativeInteger(control, 'blockerDeadline');
+  }
+  if (control.blockerAllowedActions !== undefined) {
+    storedHeaderBlockerActions(control.blockerAllowedActions);
   }
   if (control.role !== undefined) storedHeaderRole(control.role);
   if (control.outcome !== undefined) storedHeaderOutcome(control.outcome);
@@ -1244,6 +1276,33 @@ function storedHeaderPositiveInteger(payload: Readonly<Record<string, unknown>>,
     throw new Error(`Stored Workroom header ${key} is invalid`);
   }
   return Number(value);
+}
+
+function storedHeaderNonNegativeInteger(
+  payload: Readonly<Record<string, unknown>>,
+  key: string,
+): number {
+  const value = payload[key];
+  if (!Number.isSafeInteger(value) || Number(value) < 0) {
+    throw new Error(`Stored Workroom header ${key} is invalid`);
+  }
+  return Number(value);
+}
+
+function storedHeaderBlockerKind(value: unknown): WorkroomBlockerKind {
+  if (value !== 'dependency' && value !== 'approval' && value !== 'capability'
+    && value !== 'external' && value !== 'human_input') {
+    throw new Error('Stored Workroom header Blocker kind is invalid');
+  }
+  return value;
+}
+
+function storedHeaderBlockerActions(value: unknown): WorkroomBlocker['allowedActions'] {
+  if (!Array.isArray(value)
+    || canonicalWorkroomJson(value) !== canonicalWorkroomJson(['resolve', 'replan', 'cancel'])) {
+    throw new Error('Stored Workroom header Blocker allowedActions are invalid');
+  }
+  return Object.freeze([...value]) as WorkroomBlocker['allowedActions'];
 }
 
 function storedHeaderRecord(
@@ -1354,8 +1413,12 @@ async function materializeStoredEvents(
     const payload = await materializeValue(event.payload, '$.payload', event, projectId, payloads);
     if (!isRecord(payload)) throw new Error('Materialized Workroom Journal payload is invalid');
     validatePayload(event.type, payload, event.sequence);
-    if (canonicalWorkroomJson(event.control)
-      !== canonicalWorkroomJson(deriveStoredEventControl({ ...event, version: 1, payload }))) {
+    const derivedControl = deriveStoredEventControl({ ...event, version: 1, payload });
+    const comparableControl = event.type === 'task.blocked'
+      && Object.keys(event.control).length === 2
+      ? Object.freeze({ taskKey: derivedControl.taskKey, blockerId: derivedControl.blockerId })
+      : derivedControl;
+    if (canonicalWorkroomJson(event.control) !== canonicalWorkroomJson(comparableControl)) {
       throw new Error('Stored Workroom control projection does not match the governed payload');
     }
     const { control: _control, ...eventHeader } = event;
@@ -1677,7 +1740,8 @@ function isDigest(value: unknown): value is string {
 }
 
 const WORKROOM_EVENT_TYPES = new Set<WorkroomEvent['type']>([
-  'run.created', 'run.cancel_requested', 'run.cancelled', 'plan.admitted', 'plan_gate.decided',
+  'run.created', 'run.control_decided', 'run.replan_requested',
+  'run.cancel_requested', 'run.cancelled', 'plan.admitted', 'plan_gate.decided',
   'plan.revision_applied',
   'task.planned', 'task.blocked', 'task.blocker_resolved',
   'task.cancel_requested', 'task.cancelled', 'task.failed',
@@ -1707,6 +1771,12 @@ function isWorkroomEventType(value: unknown): value is WorkroomEvent['type'] {
  */
 const WORKROOM_EVENT_PAYLOAD_KEYS: Readonly<Record<WorkroomEvent['type'], readonly string[]>> = Object.freeze({
   'run.created': ['projectId', 'title'],
+  'run.control_decided': [
+    'operationId', 'action', 'reasonCode', 'expectedSequence', 'principalId', 'requestDigest',
+    'catalogRevision', 'projectDigest', 'authorizationRef',
+    'stateSequence', 'stateStatus', 'stateDigest',
+  ],
+  'run.replan_requested': ['operationId', 'reasonCode', 'requestDigest'],
   'run.cancel_requested': ['reason'],
   'run.cancelled': ['reason'],
   'plan.admitted': [
@@ -1836,6 +1906,34 @@ function validatePayload(
   switch (type) {
     case 'run.created':
       requirePayloadString(payload, 'projectId'); requirePayloadString(payload, 'title'); return;
+    case 'run.control_decided':
+      requirePayloadString(payload, 'operationId');
+      requirePayloadEnum(payload, 'action', ['cancel', 'request_replan']);
+      requirePayloadString(payload, 'reasonCode');
+      if (payload.action === 'cancel'
+        ? !isWorkroomRunCancelReasonCode(payload.reasonCode)
+        : !isWorkroomRunReplanReasonCode(payload.reasonCode)) {
+        throw new Error('Invalid Workroom event payload: Run control reasonCode');
+      }
+      if (!Number.isSafeInteger(payload.expectedSequence) || Number(payload.expectedSequence) < 0) {
+        throw new Error('Invalid Workroom event payload: expectedSequence');
+      }
+      requirePayloadString(payload, 'principalId'); requirePayloadDigest(payload, 'requestDigest');
+      requirePayloadString(payload, 'catalogRevision'); requirePayloadDigest(payload, 'projectDigest');
+      requirePayloadString(payload, 'authorizationRef');
+      if (!Number.isSafeInteger(payload.stateSequence) || Number(payload.stateSequence) < 0) {
+        throw new Error('Invalid Workroom event payload: stateSequence');
+      }
+      requirePayloadEnum(payload, 'stateStatus', [
+        'active', 'blocked', 'needs_replan', 'cancelling', 'completed', 'cancelled',
+      ]);
+      requirePayloadDigest(payload, 'stateDigest'); return;
+    case 'run.replan_requested':
+      requirePayloadString(payload, 'operationId'); requirePayloadString(payload, 'reasonCode');
+      if (!isWorkroomRunReplanReasonCode(payload.reasonCode)) {
+        throw new Error('Invalid Workroom event payload: replan reasonCode');
+      }
+      requirePayloadDigest(payload, 'requestDigest'); return;
     case 'plan.admitted':
       requirePayloadString(payload, 'operationId'); requirePayloadString(payload, 'sourceEventRef');
       requirePayloadDigest(payload, 'sourceEventDigest');

--- a/packages/im/agent/src/workroom/kernel-contracts.ts
+++ b/packages/im/agent/src/workroom/kernel-contracts.ts
@@ -142,6 +142,7 @@ export interface WorkroomRunState {
   readonly sequence: number;
   readonly now: number;
   readonly cancelRequested: boolean;
+  readonly replanRequested?: boolean;
   readonly tasks: Readonly<Record<string, WorkroomTaskState>>;
   readonly assignments: Readonly<Record<string, WorkroomAssignmentState>>;
   readonly reviewerAssignments: Readonly<Record<string, WorkroomReviewerAssignmentState>>;
@@ -153,6 +154,8 @@ export type WorkroomEventType =
   | 'plan.admitted'
   | 'plan.revision_applied'
   | 'plan_gate.decided'
+  | 'run.control_decided'
+  | 'run.replan_requested'
   | 'run.cancel_requested'
   | 'run.cancelled'
   | 'task.planned'

--- a/packages/im/agent/src/workroom/kernel-state.ts
+++ b/packages/im/agent/src/workroom/kernel-state.ts
@@ -33,6 +33,7 @@ export function replayWorkroom(events: readonly WorkroomEvent[]): WorkroomRunSta
     sequence: -1,
     now: first.occurredAt,
     cancelRequested: false,
+    replanRequested: false,
     tasks: {},
     assignments: {},
     reviewerAssignments: {},
@@ -41,10 +42,35 @@ export function replayWorkroom(events: readonly WorkroomEvent[]): WorkroomRunSta
   for (const event of events) {
     if (event.runId !== state.runId) throw new Error('Workroom journal contains another run');
     if (event.sequence !== state.sequence + 1) throw new Error('Workroom journal sequence is not contiguous');
+    if (event.type === 'run.control_decided') validateRunControlSuccessor(events, event);
     state = evolveWorkroom(state, event);
   }
   replayWorkroomPreemptions(events);
   return deriveRunStatus(state);
+}
+
+function validateRunControlSuccessor(
+  events: readonly WorkroomEvent[],
+  audit: WorkroomEvent,
+): void {
+  const next = events[audit.sequence + 1];
+  const expectedSequence = Number(audit.payload.expectedSequence);
+  if (!Number.isSafeInteger(expectedSequence) || expectedSequence !== audit.sequence - 1) {
+    throw new Error('Persisted Workroom Run control expectedSequence is not exact');
+  }
+  if (audit.payload.action === 'request_replan') {
+    if (!next || next.type !== 'run.replan_requested'
+      || next.payload.operationId !== audit.payload.operationId
+      || next.payload.reasonCode !== audit.payload.reasonCode
+      || next.payload.requestDigest !== audit.payload.requestDigest) {
+      throw new Error('Persisted Workroom replan request is not bound to its control audit');
+    }
+    return;
+  }
+  if (audit.payload.action !== 'cancel' || !next || next.type !== 'run.cancel_requested'
+    || next.payload.reason !== audit.payload.reasonCode) {
+    throw new Error('Persisted Workroom cancellation is not bound to its control audit');
+  }
 }
 
 export function decideWorkroom(
@@ -151,14 +177,17 @@ export function evolveWorkroom(state: WorkroomRunState, event: WorkroomEvent): W
   let reviewerAssignments = state.reviewerAssignments;
   let sponsorGates = state.sponsorGates;
   let cancelRequested = state.cancelRequested;
+  let replanRequested = state.replanRequested === true;
   let status = state.status;
   const payload = event.payload;
 
   switch (event.type) {
     case 'run.created': break;
     case 'plan.admitted': break;
-    case 'plan.revision_applied': break;
+    case 'plan.revision_applied': replanRequested = false; break;
     case 'plan_gate.decided': break;
+    case 'run.control_decided': break;
+    case 'run.replan_requested': replanRequested = true; status = 'needs_replan'; break;
     case 'local_execution.requested': break;
     case 'remote_dispatch.requested': break;
     case 'scheduler.dispatch_requested': break;
@@ -532,6 +561,7 @@ export function evolveWorkroom(state: WorkroomRunState, event: WorkroomEvent): W
     sequence: event.sequence,
     now: event.type === 'clock.advanced' ? Number(payload.now) : Math.max(state.now, event.occurredAt),
     cancelRequested,
+    replanRequested,
     tasks,
     assignments,
     reviewerAssignments,
@@ -704,6 +734,7 @@ function deriveRunStatus(state: WorkroomRunState): WorkroomRunState {
   if (state.status === 'cancelled') return state;
   const tasks = Object.values(state.tasks);
   if (state.cancelRequested) return { ...state, status: 'cancelling' };
+  if (state.replanRequested) return { ...state, status: 'needs_replan' };
   if (tasks.length > 0 && tasks.every(task => task.status === 'accepted' || (!task.required && TERMINAL_TASKS.has(task.status)))) {
     return { ...state, status: 'completed' };
   }

--- a/packages/im/agent/src/workroom/runtime.ts
+++ b/packages/im/agent/src/workroom/runtime.ts
@@ -8,6 +8,8 @@ import {
 } from './canonical-value.js';
 import type {
   WorkroomAssignmentState,
+  WorkroomBlocker,
+  WorkroomBlockerKind,
   WorkroomRunStatus,
   WorkroomTaskState,
 } from './kernel-contracts.js';
@@ -68,6 +70,16 @@ export interface WorkroomAssignmentHeader {
   readonly digest: string;
 }
 
+export interface WorkroomBlockerHeader {
+  readonly version: 1;
+  readonly taskRef: string;
+  readonly blockerRef: string;
+  readonly kind: WorkroomBlockerKind | 'unknown';
+  readonly deadline?: number;
+  readonly allowedActions: WorkroomBlocker['allowedActions'];
+  readonly digest: string;
+}
+
 export interface WorkroomRunHeader {
   readonly version: 1;
   readonly projectId: string;
@@ -89,6 +101,21 @@ export interface WorkroomRunHeader {
 export interface WorkroomRunDetail extends WorkroomRunHeader {
   readonly tasks: readonly WorkroomTaskHeader[];
   readonly assignments: readonly WorkroomAssignmentHeader[];
+  readonly blockers: readonly WorkroomBlockerHeader[];
+}
+
+export type WorkroomReadinessState = 'ready' | 'blocked' | 'needs_replan' | 'cancelling' | 'terminal';
+
+export interface WorkroomRunReadiness {
+  readonly version: 1;
+  readonly projectId: string;
+  readonly runId: string;
+  readonly sequence: number;
+  readonly state: WorkroomReadinessState;
+  readonly blockers: readonly WorkroomBlockerHeader[];
+  readonly recommendedActions: readonly ('resolve' | 'replan' | 'cancel')[];
+  readonly authorityDigest: string;
+  readonly digest: string;
 }
 
 export type WorkroomRunListResult =
@@ -100,10 +127,18 @@ export type WorkroomRunReadResult =
   | Readonly<{ status: 'not_found' }>
   | Readonly<{ status: 'forbidden' }>;
 
+export type WorkroomRunReadinessResult =
+  | Readonly<{ status: 'ready'; readiness: WorkroomRunReadiness }>
+  | Readonly<{ status: 'not_found' }>
+  | Readonly<{ status: 'forbidden' }>;
+
 /** Read-only, content-free generation projection for authenticated Console inspection. */
 export interface WorkroomRuntimeHandle {
   listRuns(input: WorkroomRuntimeReadInput): Promise<WorkroomRunListResult>;
   getRun(input: WorkroomRuntimeReadInput & Readonly<{ runId: string }>): Promise<WorkroomRunReadResult>;
+  getReadiness(
+    input: WorkroomRuntimeReadInput & Readonly<{ runId: string }>,
+  ): Promise<WorkroomRunReadinessResult>;
 }
 
 export function createWorkroomRuntime(
@@ -133,6 +168,40 @@ export function createWorkroomRuntime(
       const run = projectStoredRun(stored, authorization.bindingDigest);
       if (run.projectId !== input.projectId) return Object.freeze({ status: 'not_found' });
       return deepFreeze({ status: 'ready' as const, run });
+    },
+    getReadiness: async (
+      input: WorkroomRuntimeReadInput & Readonly<{ runId: string }>,
+    ): Promise<WorkroomRunReadinessResult> => {
+      const authorization = await authorizeRead(authority, input);
+      if (!authorization) return Object.freeze({ status: 'forbidden' });
+      const stored = await journal.readStoredHeaders(input.runId);
+      if (!stored) return Object.freeze({ status: 'not_found' });
+      const run = projectStoredRun(stored, authorization.bindingDigest);
+      if (run.projectId !== input.projectId) return Object.freeze({ status: 'not_found' });
+      const actions = new Set<'resolve' | 'replan' | 'cancel'>();
+      for (const blocker of run.blockers) {
+        for (const action of blocker.allowedActions) actions.add(action);
+      }
+      if (run.status === 'needs_replan') {
+        actions.add('replan');
+        actions.add('cancel');
+      }
+      const body = deepFreeze({
+        version: 1 as const,
+        projectId: run.projectId,
+        runId: run.runId,
+        sequence: run.sequence,
+        state: readinessState(run.status),
+        blockers: run.blockers,
+        recommendedActions: Object.freeze(
+          (['resolve', 'replan', 'cancel'] as const).filter(action => actions.has(action)),
+        ),
+        authorityDigest: run.authorityDigest,
+      });
+      return deepFreeze({
+        status: 'ready' as const,
+        readiness: { ...body, digest: digest(body) },
+      });
     },
   });
 }
@@ -225,7 +294,11 @@ interface ProjectedTask {
   attempt: number;
   maxAttempts: number;
   required: boolean;
-  readonly blockers: Set<string>;
+  readonly blockers: Map<string, Readonly<{
+    kind: WorkroomBlockerKind | 'unknown';
+    deadline?: number;
+    allowedActions: WorkroomBlocker['allowedActions'];
+  }>>;
   currentAssignmentId?: string;
   currentReviewerAssignmentId?: string;
   currentSponsorGateId?: string;
@@ -256,14 +329,15 @@ function projectStoredRun(
   const reviewerStatuses = new Map<string, string>();
   const sponsorStatuses = new Map<string, string>();
   let cancelRequested = false;
+  let replanRequested = false;
   let explicitlyCancelled = false;
   for (const event of stored.events) {
     const payload = event.control;
     switch (event.type) {
       case 'run.created':
       case 'plan.admitted':
-      case 'plan.revision_applied':
       case 'plan_gate.decided':
+      case 'run.control_decided':
       case 'local_execution.requested':
       case 'remote_dispatch.requested':
       case 'scheduler.dispatch_requested':
@@ -273,6 +347,8 @@ function projectStoredRun(
       case 'scheduler.preemption_timed_out':
       case 'assignment.checkpoint_requested':
       case 'clock.advanced': break;
+      case 'plan.revision_applied': replanRequested = false; break;
+      case 'run.replan_requested': replanRequested = true; break;
       case 'run.cancel_requested': cancelRequested = true; break;
       case 'run.cancelled': explicitlyCancelled = true; break;
       case 'task.planned': {
@@ -281,13 +357,21 @@ function projectStoredRun(
         tasks.set(key, {
           key, status: 'ready', revision: 1, attempt: 0,
           maxAttempts: headerPositiveInteger(payload, 'maxAttempts'),
-          required: payload.required === true, blockers: new Set(),
+          required: payload.required === true, blockers: new Map(),
         });
         break;
       }
       case 'task.blocked': {
         const task = requireProjectedTask(tasks, payload);
-        task.blockers.add(headerText(payload, 'blockerId'));
+        task.blockers.set(headerText(payload, 'blockerId'), Object.freeze({
+          kind: payload.blockerKind === undefined ? 'unknown' : headerBlockerKind(payload.blockerKind),
+          ...(payload.blockerDeadline === undefined
+            ? {}
+            : { deadline: headerNonNegativeInteger(payload, 'blockerDeadline') }),
+          allowedActions: payload.blockerAllowedActions === undefined
+            ? Object.freeze(['resolve', 'replan', 'cancel'] as const)
+            : headerBlockerActions(payload.blockerAllowedActions),
+        }));
         task.status = 'blocked';
         break;
       }
@@ -442,11 +526,15 @@ function projectStoredRun(
   }
   const taskValues = [...tasks.values()];
   const status = deriveHeaderRunStatus(
-    taskValues, reviewerStatuses, sponsorStatuses, cancelRequested, explicitlyCancelled,
+    taskValues, reviewerStatuses, sponsorStatuses, cancelRequested, replanRequested,
+    explicitlyCancelled,
   );
   const taskHeaders = taskValues.map(task => projectTaskHeader(task));
   const assignmentHeaders = [...assignments.values()].map(assignment =>
     projectAssignmentHeader(assignment));
+  const blockerHeaders = taskValues.flatMap(task => [...task.blockers.entries()].map(
+    ([blockerRef, blocker]) => projectBlockerHeader(task.key, blockerRef, blocker),
+  ));
   const body = deepFreeze({
     version: 1 as const,
     projectId,
@@ -463,6 +551,7 @@ function projectStoredRun(
     authorityDigest,
     tasks: taskHeaders,
     assignments: assignmentHeaders,
+    blockers: blockerHeaders,
   });
   return deepFreeze({ ...body, digest: digest(body) });
 }
@@ -512,6 +601,26 @@ function projectAssignmentHeader(
   return deepFreeze({ ...body, digest: digest(body) });
 }
 
+function projectBlockerHeader(
+  taskRef: string,
+  blockerRef: string,
+  blocker: Readonly<{
+    kind: WorkroomBlockerKind | 'unknown';
+    deadline?: number;
+    allowedActions: WorkroomBlocker['allowedActions'];
+  }>,
+): WorkroomBlockerHeader {
+  const body = deepFreeze({
+    version: 1 as const,
+    taskRef,
+    blockerRef,
+    kind: blocker.kind,
+    ...(blocker.deadline === undefined ? {} : { deadline: blocker.deadline }),
+    allowedActions: blocker.allowedActions,
+  });
+  return deepFreeze({ ...body, digest: digest(body) });
+}
+
 function requireProjectedTask(
   tasks: ReadonlyMap<string, ProjectedTask>,
   payload: WorkroomStoredEventControl,
@@ -551,10 +660,12 @@ function deriveHeaderRunStatus(
   reviewers: ReadonlyMap<string, string>,
   sponsors: ReadonlyMap<string, string>,
   cancelRequested: boolean,
+  replanRequested: boolean,
   explicitlyCancelled: boolean,
 ): WorkroomRunStatus {
   if (explicitlyCancelled) return 'cancelled';
   if (cancelRequested) return 'cancelling';
+  if (replanRequested) return 'needs_replan';
   const terminal = new Set<WorkroomTaskState['status']>(['accepted', 'failed', 'cancelled']);
   if (tasks.length > 0 && tasks.every(task =>
     task.status === 'accepted' || !task.required && terminal.has(task.status))) return 'completed';
@@ -571,12 +682,42 @@ function deriveHeaderRunStatus(
   return tasks.some(task => task.status === 'blocked') ? 'blocked' : 'active';
 }
 
+function readinessState(status: WorkroomRunStatus): WorkroomReadinessState {
+  if (status === 'completed' || status === 'cancelled') return 'terminal';
+  if (status === 'active') return 'ready';
+  return status;
+}
+
 function headerText(payload: object, key: string): string {
   const value = Reflect.get(payload, key) as unknown;
   if (typeof value !== 'string' || !value.trim()) {
     throw new Error(`Stored Workroom header ${key} is invalid`);
   }
   return value;
+}
+
+function headerNonNegativeInteger(payload: object, key: string): number {
+  const value = Reflect.get(payload, key) as unknown;
+  if (!Number.isSafeInteger(value) || Number(value) < 0) {
+    throw new Error(`Stored Workroom header ${key} is invalid`);
+  }
+  return Number(value);
+}
+
+function headerBlockerKind(value: unknown): WorkroomBlockerKind {
+  if (value !== 'dependency' && value !== 'approval' && value !== 'capability'
+    && value !== 'external' && value !== 'human_input') {
+    throw new Error('Stored Workroom header blockerKind is invalid');
+  }
+  return value;
+}
+
+function headerBlockerActions(value: unknown): WorkroomBlocker['allowedActions'] {
+  if (!Array.isArray(value)
+    || JSON.stringify(value) !== JSON.stringify(['resolve', 'replan', 'cancel'])) {
+    throw new Error('Stored Workroom header blockerAllowedActions are invalid');
+  }
+  return Object.freeze([...value]) as WorkroomBlocker['allowedActions'];
 }
 
 function headerPositiveInteger(payload: object, key: string): number {

--- a/packages/im/agent/src/workroom/workroom-kernel.ts
+++ b/packages/im/agent/src/workroom/workroom-kernel.ts
@@ -4,6 +4,7 @@ import type {
   WorkroomEventDraft,
   WorkroomEventType,
   WorkroomRunState,
+  WorkroomRunStatus,
 } from './kernel-contracts.js';
 import { WorkroomSequenceConflictError, type WorkroomJournal } from './journal.js';
 import {
@@ -90,6 +91,14 @@ import {
   type WorkroomPlanGateDecisionInput,
   type WorkroomPlanGateDecisionReceipt,
 } from './plan-approval-control.js';
+import {
+  WorkroomRunControlUnauthorizedError,
+  assertWorkroomRunControlCommand,
+  workroomRunControlRequestDigest,
+  type WorkroomRunControlAuthorityPort,
+  type WorkroomRunControlCommand,
+  type WorkroomRunControlReceipt,
+} from './workroom-run-control.js';
 export interface CreateWorkroomRunInput {
   readonly runId?: string;
   readonly projectId: string;
@@ -109,6 +118,7 @@ export interface WorkroomKernelOptions {
   readonly localAssignmentAuthority?: WorkroomLocalAssignmentAuthorityPort;
   readonly planGateAuthority?: WorkroomPlanGateAuthorityPort;
   readonly priorityAuthority?: WorkroomPriorityAuthorityPort;
+  readonly runControlAuthority?: WorkroomRunControlAuthorityPort;
 }
 
 export interface WorkroomRemoteAssignmentIssuanceReceipt
@@ -197,6 +207,7 @@ export class WorkroomKernel {
   readonly #localAssignmentAuthority?: WorkroomLocalAssignmentAuthorityPort;
   readonly #planGateAuthority?: WorkroomPlanGateAuthorityPort;
   readonly #priorityAuthority?: WorkroomPriorityAuthorityPort;
+  readonly #runControlAuthority?: WorkroomRunControlAuthorityPort;
 
   constructor(options: WorkroomKernelOptions) {
     this.#journal = options.journal;
@@ -209,6 +220,7 @@ export class WorkroomKernel {
     this.#localAssignmentAuthority = options.localAssignmentAuthority;
     this.#planGateAuthority = options.planGateAuthority;
     this.#priorityAuthority = options.priorityAuthority;
+    this.#runControlAuthority = options.runControlAuthority;
     if (!Number.isSafeInteger(this.#assignmentHeartbeatLeaseMs)
       || this.#assignmentHeartbeatLeaseMs < 1) {
       throw new Error('Assignment heartbeat lease must be a positive safe integer');
@@ -682,6 +694,125 @@ export class WorkroomKernel {
     ];
     await this.#journal.append(runId, state.sequence, drafts);
     return drafts.length === 0 ? state : this.read(scopedProjectId, runId);
+  }
+
+  /** Sponsor-authorized, exact-sequence Run cancellation or durable replan request. */
+  async controlRun(
+    command: WorkroomRunControlCommand,
+    authenticatedPrincipal: Readonly<{ principalId: string }>,
+  ): Promise<WorkroomRunControlReceipt> {
+    assertWorkroomRunControlCommand(command);
+    const principalId = authenticatedPrincipal.principalId.trim();
+    if (!principalId) throw new Error('Workroom Run control authenticated principal is required');
+    const events = await this.#journal.read(command.runId);
+    if (events.length === 0) throw new Error(`Workroom run ${command.runId} not found`);
+    const state = replayWorkroom(events);
+    assertProject(state, command.projectId);
+    const requestDigest = workroomRunControlRequestDigest(command, principalId);
+    const replay = events.find(event => event.type === 'run.control_decided'
+      && event.payload.operationId === command.operationId);
+    if (replay) {
+      if (replay.payload.requestDigest !== requestDigest
+        || replay.payload.action !== command.action
+        || replay.payload.principalId !== principalId) {
+        throw new Error(`Workroom Run control replay payload drift: ${command.operationId}`);
+      }
+      await this.#authorizeRunControl(command, principalId, requestDigest, {
+        sequence: Number(replay.payload.stateSequence),
+        status: replay.payload.stateStatus as WorkroomRunStatus,
+        digest: String(replay.payload.stateDigest),
+      }, 'commit');
+      return runControlReceipt('duplicate', command, requestDigest, replay.eventId, state);
+    }
+    if (command.expectedSequence !== state.sequence) {
+      await this.#authorizeRunControl(command, principalId, requestDigest, {
+        sequence: state.sequence,
+        status: state.status,
+        digest: digestCanonicalWorkroomValue(state),
+      }, 'stale_probe');
+      return Object.freeze({ status: 'stale', actualSequence: state.sequence });
+    }
+    if (command.action === 'cancel' && state.cancelRequested) {
+      throw new Error('Workroom Run cancellation is already active');
+    }
+    if (state.status === 'completed' || state.status === 'cancelled') {
+      throw new Error(`Workroom run is terminal: ${state.status}`);
+    }
+    if (command.action === 'cancel' && command.controlDeadline < state.now) {
+      throw new Error('Workroom Run cancellation deadline is before the current Kernel clock');
+    }
+    if (command.action === 'request_replan' && state.cancelRequested) {
+      throw new Error('Cannot request replan while Run cancellation is active');
+    }
+    const stateDigest = digestCanonicalWorkroomValue(state);
+    const authorization = await this.#authorizeRunControl(command, principalId, requestDigest, {
+      sequence: state.sequence, status: state.status, digest: stateDigest,
+    }, 'commit');
+    const audit = this.#event('run.control_decided', {
+      operationId: command.operationId,
+      action: command.action,
+      reasonCode: command.reasonCode,
+      expectedSequence: command.expectedSequence,
+      principalId,
+      requestDigest,
+      catalogRevision: authorization.catalogRevision,
+      projectDigest: authorization.projectDigest,
+      authorizationRef: authorization.authorizationRef,
+      stateSequence: state.sequence,
+      stateStatus: state.status,
+      stateDigest,
+    });
+    const drafts = command.action === 'cancel'
+      ? [
+          audit,
+          ...decideWorkroom(state, {
+            type: 'cancel_run', reason: command.reasonCode,
+            controlDeadline: command.controlDeadline,
+          }, (type, payload) => this.#event(type, payload)),
+        ]
+      : [audit, this.#event('run.replan_requested', {
+          operationId: command.operationId,
+          reasonCode: command.reasonCode,
+          requestDigest,
+        })];
+    const appended = await this.#journal.append(command.runId, state.sequence, drafts);
+    if (appended.length !== drafts.length) {
+      throw new Error('Workroom Run control append did not commit one exact batch');
+    }
+    const next = replayWorkroom([...events, ...appended]);
+    return runControlReceipt('committed', command, requestDigest, appended[0]!.eventId, next);
+  }
+
+  async #authorizeRunControl(
+    command: WorkroomRunControlCommand,
+    principalId: string,
+    requestDigest: string,
+    state: Readonly<{ sequence: number; status: WorkroomRunStatus; digest: string }>,
+    purpose: 'commit' | 'stale_probe',
+  ) {
+    if (!this.#runControlAuthority) {
+      throw new WorkroomRunControlUnauthorizedError('authority_not_installed');
+    }
+    const authorization = await this.#runControlAuthority.authorize(Object.freeze({
+      version: 1 as const,
+      purpose,
+      command,
+      authenticatedPrincipalId: principalId,
+      requestDigest,
+      stateSequence: state.sequence,
+      stateStatus: state.status,
+      stateDigest: state.digest,
+    }));
+    if (!authorization.authorized) {
+      throw new WorkroomRunControlUnauthorizedError(authorization.reason);
+    }
+    if (authorization.principalId !== principalId
+      || !authorization.catalogRevision.trim()
+      || !authorization.projectDigest.trim()
+      || !authorization.authorizationRef.trim()) {
+      throw new WorkroomRunControlUnauthorizedError('authority_decision_not_exact');
+    }
+    return authorization;
   }
 
   /** Atomically persists the local Assignment claim and its exact Envelope. */
@@ -1429,6 +1560,29 @@ function assertProjectId(projectId: string): void {
 
 function assertProject(state: WorkroomRunState, projectId: string): void {
   if (state.projectId !== projectId) throw new Error('Workroom run does not belong to the requested Project');
+}
+
+function runControlReceipt(
+  status: 'committed' | 'duplicate',
+  command: WorkroomRunControlCommand,
+  requestDigest: string,
+  receiptRef: string,
+  state: WorkroomRunState,
+): WorkroomRunControlReceipt {
+  return Object.freeze({
+    status,
+    action: command.action,
+    operationId: command.operationId,
+    receiptRef,
+    receiptDigest: digestCanonicalWorkroomValue({
+      version: 1,
+      operationId: command.operationId,
+      action: command.action,
+      requestDigest,
+      receiptRef,
+    }),
+    state,
+  });
 }
 
 function findLocalAssignmentIssuance(

--- a/packages/im/agent/src/workroom/workroom-run-control.ts
+++ b/packages/im/agent/src/workroom/workroom-run-control.ts
@@ -1,0 +1,232 @@
+import type { WorkroomRunState, WorkroomRunStatus } from './kernel-contracts.js';
+import { digestCanonicalWorkroomValue } from './canonical-value.js';
+import type { WorkroomCatalog } from './catalog.js';
+
+export type WorkroomRunCancelReasonCode =
+  | 'operator_request'
+  | 'no_longer_required'
+  | 'superseded'
+  | 'policy_change';
+
+export type WorkroomRunReplanReasonCode =
+  | 'requirements_changed'
+  | 'blocker_recovery'
+  | 'policy_change'
+  | 'operator_request';
+
+export type WorkroomRunControlCommand =
+  | Readonly<{
+      version: 1;
+      operationId: string;
+      projectId: string;
+      runId: string;
+      expectedSequence: number;
+      action: 'cancel';
+      reasonCode: WorkroomRunCancelReasonCode;
+      controlDeadline: number;
+    }>
+  | Readonly<{
+      version: 1;
+      operationId: string;
+      projectId: string;
+      runId: string;
+      expectedSequence: number;
+      action: 'request_replan';
+      reasonCode: WorkroomRunReplanReasonCode;
+    }>;
+
+export interface WorkroomRunControlAuthorizationInput {
+  readonly version: 1;
+  readonly purpose: 'commit' | 'stale_probe';
+  readonly command: WorkroomRunControlCommand;
+  readonly authenticatedPrincipalId: string;
+  readonly requestDigest: string;
+  readonly stateSequence: number;
+  readonly stateStatus: WorkroomRunStatus;
+  readonly stateDigest: string;
+}
+
+export type WorkroomRunControlAuthorizationDecision =
+  | Readonly<{
+      authorized: true;
+      principalId: string;
+      catalogRevision: string;
+      projectDigest: string;
+      authorizationRef: string;
+    }>
+  | Readonly<{ authorized: false; reason: string }>;
+
+export interface WorkroomRunControlAuthorityPort {
+  authorize(
+    input: WorkroomRunControlAuthorizationInput,
+  ): WorkroomRunControlAuthorizationDecision | Promise<WorkroomRunControlAuthorizationDecision>;
+}
+
+export type WorkroomRunControlReceipt =
+  | Readonly<{
+      status: 'committed' | 'duplicate';
+      action: WorkroomRunControlCommand['action'];
+      operationId: string;
+      receiptRef: string;
+      receiptDigest: string;
+      state: WorkroomRunState;
+    }>
+  | Readonly<{ status: 'stale'; actualSequence: number }>;
+
+export class WorkroomRunControlUnauthorizedError extends Error {
+  constructor(readonly reason: string) {
+    super(`Workroom Run control is unauthorized: ${reason}`);
+    this.name = 'WorkroomRunControlUnauthorizedError';
+  }
+}
+
+export function assertWorkroomRunControlCommand(
+  command: WorkroomRunControlCommand,
+): void {
+  if (!command || command.version !== 1) throw new Error('Workroom Run control version is invalid');
+  requireText(command.operationId, 'Workroom Run control operationId');
+  requireText(command.projectId, 'Workroom Run control projectId');
+  requireText(command.runId, 'Workroom Run control runId');
+  if (!Number.isSafeInteger(command.expectedSequence) || command.expectedSequence < 0) {
+    throw new Error('Workroom Run control expectedSequence is invalid');
+  }
+  if (command.action === 'cancel') {
+    if (!isWorkroomRunCancelReasonCode(command.reasonCode)) {
+      throw new Error('Workroom Run cancellation reasonCode is invalid');
+    }
+    if (!Number.isSafeInteger(command.controlDeadline) || command.controlDeadline < 0) {
+      throw new Error('Workroom Run cancellation controlDeadline is invalid');
+    }
+    assertExactKeys(command, [
+      'version', 'operationId', 'projectId', 'runId', 'expectedSequence',
+      'action', 'reasonCode', 'controlDeadline',
+    ]);
+    return;
+  }
+  if (command.action !== 'request_replan' || !isWorkroomRunReplanReasonCode(command.reasonCode)) {
+    throw new Error('Workroom Run replan reasonCode is invalid');
+  }
+  assertExactKeys(command, [
+    'version', 'operationId', 'projectId', 'runId', 'expectedSequence', 'action', 'reasonCode',
+  ]);
+}
+
+/** Closed transport parser shared by Host and other trusted composition roots. */
+export function parseWorkroomRunControlCommand(value: unknown): WorkroomRunControlCommand {
+  if (!isRecord(value)) throw new Error('Workroom Run control body is invalid');
+  const text = (key: string): string => {
+    const candidate = value[key];
+    if (typeof candidate !== 'string') throw new Error(`Workroom Run control ${key} is invalid`);
+    requireText(candidate, `Workroom Run control ${key}`);
+    return candidate.trim();
+  };
+  if (value.version !== 1 || !Number.isSafeInteger(value.expectedSequence)
+    || Number(value.expectedSequence) < 0) {
+    throw new Error('Workroom Run control version or expectedSequence is invalid');
+  }
+  const common = {
+    version: 1 as const,
+    operationId: text('operationId'),
+    projectId: text('projectId'),
+    runId: text('runId'),
+    expectedSequence: Number(value.expectedSequence),
+  };
+  if (value.action === 'cancel') {
+    if (!isWorkroomRunCancelReasonCode(value.reasonCode)
+      || !Number.isSafeInteger(value.controlDeadline) || Number(value.controlDeadline) < 0) {
+      throw new Error('Workroom Run cancellation scope is invalid');
+    }
+    assertExactKeys(value, [
+      'version', 'operationId', 'projectId', 'runId', 'expectedSequence',
+      'action', 'reasonCode', 'controlDeadline',
+    ]);
+    return Object.freeze({
+      ...common,
+      action: 'cancel',
+      reasonCode: value.reasonCode,
+      controlDeadline: Number(value.controlDeadline),
+    });
+  }
+  if (value.action !== 'request_replan' || !isWorkroomRunReplanReasonCode(value.reasonCode)) {
+    throw new Error('Workroom Run replan scope is invalid');
+  }
+  assertExactKeys(value, [
+    'version', 'operationId', 'projectId', 'runId', 'expectedSequence', 'action', 'reasonCode',
+  ]);
+  return Object.freeze({ ...common, action: 'request_replan', reasonCode: value.reasonCode });
+}
+
+export function workroomRunControlRequestDigest(
+  command: WorkroomRunControlCommand,
+  authenticatedPrincipalId: string,
+): string {
+  assertWorkroomRunControlCommand(command);
+  requireText(authenticatedPrincipalId, 'Workroom Run control authenticated principal');
+  return digestCanonicalWorkroomValue({ version: 1, command, authenticatedPrincipalId });
+}
+
+/** Current persistent Catalog Sponsor membership is the only standard mutation authority. */
+export function createCatalogWorkroomRunControlAuthority(
+  catalog: Pick<WorkroomCatalog, 'read'>,
+): WorkroomRunControlAuthorityPort {
+  return Object.freeze({
+    async authorize(
+      input: WorkroomRunControlAuthorizationInput,
+    ): Promise<WorkroomRunControlAuthorizationDecision> {
+      const snapshot = await catalog.read();
+      if (input.purpose !== 'commit' && input.purpose !== 'stale_probe'
+        || (input.purpose === 'commit') !== (input.command.expectedSequence === input.stateSequence)
+        || input.requestDigest !== workroomRunControlRequestDigest(
+          input.command,
+          input.authenticatedPrincipalId,
+        )
+        || !/^sha256:[a-f0-9]{64}$/u.test(input.stateDigest)) {
+        return Object.freeze({ authorized: false, reason: 'control_scope_not_exact' });
+      }
+      const definition = snapshot.definitions[input.command.projectId];
+      if (!definition || definition.enabled === false) {
+        return Object.freeze({ authorized: false, reason: 'project_not_active' });
+      }
+      if (!definition.sponsors?.includes(input.authenticatedPrincipalId)) {
+        return Object.freeze({ authorized: false, reason: 'principal_is_not_project_sponsor' });
+      }
+      const projectDigest = digestCanonicalWorkroomValue(definition);
+      return Object.freeze({
+        authorized: true,
+        principalId: input.authenticatedPrincipalId,
+        catalogRevision: snapshot.revision,
+        projectDigest,
+        authorizationRef: [
+          'workroom-run-control:v1', snapshot.revision, input.command.projectId,
+          projectDigest, input.authenticatedPrincipalId, input.command.action, input.requestDigest,
+        ].map(encodeURIComponent).join(':'),
+      });
+    },
+  });
+}
+
+export function isWorkroomRunCancelReasonCode(value: unknown): value is WorkroomRunCancelReasonCode {
+  return value === 'operator_request' || value === 'no_longer_required'
+    || value === 'superseded' || value === 'policy_change';
+}
+
+export function isWorkroomRunReplanReasonCode(value: unknown): value is WorkroomRunReplanReasonCode {
+  return value === 'requirements_changed' || value === 'blocker_recovery'
+    || value === 'policy_change' || value === 'operator_request';
+}
+
+function requireText(value: string, label: string): void {
+  if (!value.trim() || value.length > 256) throw new Error(`${label} is invalid`);
+}
+
+function assertExactKeys(value: object, expected: readonly string[]): void {
+  const actual = Object.keys(value).sort();
+  const keys = [...expected].sort();
+  if (actual.length !== keys.length || actual.some((key, index) => key !== keys[index])) {
+    throw new Error('Workroom Run control keys are invalid');
+  }
+}
+
+function isRecord(value: unknown): value is Readonly<Record<string, unknown>> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/packages/im/agent/src/workroom/workroom-scheduler.ts
+++ b/packages/im/agent/src/workroom/workroom-scheduler.ts
@@ -230,6 +230,7 @@ interface SchedulerProjection {
   readonly sequence: number;
   readonly now: number;
   readonly cancelRequested: boolean;
+  readonly replanRequested: boolean;
   readonly policy: WorkroomSchedulerPolicySnapshot;
   readonly tasks: ReadonlyMap<string, ScheduledTaskProjection>;
   readonly activeAssignments: ReadonlyMap<string, Readonly<{
@@ -297,7 +298,7 @@ export function decideWorkroomSchedule(
   events: readonly WorkroomEvent[],
 ): WorkroomScheduleDecision | null {
   const state = projectScheduler(events);
-  if (state.cancelRequested) return null;
+  if (state.cancelRequested || state.replanRequested) return null;
   assertWaitRecoveryMetadata(state.tasks);
   const used = state.activeAssignments.size + state.pendingDispatches.size;
   const candidates = [...state.tasks.values()].filter(task =>
@@ -484,6 +485,7 @@ function projectScheduler(events: readonly WorkroomEvent[]): SchedulerProjection
   let policy: WorkroomSchedulerPolicySnapshot | undefined;
   let now = created.occurredAt;
   let cancelRequested = false;
+  let replanRequested = false;
   let reservedTaskKey: string | undefined;
   let pendingPreemptionDecisionId: string | undefined;
   for (const [index, event] of events.entries()) {
@@ -507,6 +509,8 @@ function projectScheduler(events: readonly WorkroomEvent[]): SchedulerProjection
       }
       case 'run.cancel_requested':
       case 'run.cancelled': cancelRequested = true; break;
+      case 'run.replan_requested': replanRequested = true; break;
+      case 'plan.revision_applied': replanRequested = false; break;
       case 'task.planned': {
         const key = text(event.payload.taskKey, 'Scheduled Task key');
         if (tasks.has(key)) throw new Error(`Scheduled Task ${key} is duplicated`);
@@ -672,6 +676,7 @@ function projectScheduler(events: readonly WorkroomEvent[]): SchedulerProjection
     sequence: events.at(-1)!.sequence,
     now,
     cancelRequested,
+    replanRequested,
     policy,
     tasks,
     activeAssignments,

--- a/packages/im/agent/tests/workroom/runtime.test.ts
+++ b/packages/im/agent/tests/workroom/runtime.test.ts
@@ -94,6 +94,53 @@ describe('Workroom Console runtime projection', () => {
     expect(payloads.readCount).toBe(0);
   });
 
+  it('diagnoses active blockers from content-free stored headers without materializing reasons', async () => {
+    const payloads = new ReadSpyPayloads();
+    const journal = new MemoryWorkroomJournal(payloads);
+    const kernel = new WorkroomKernel({ journal, now: () => 50, createId: (() => {
+      let id = 0; return () => `event-${++id}`;
+    })() });
+    await kernel.createRun({ projectId: 'support', runId: 'run-blocked', title: SECRET_TITLE });
+    await kernel.execute('support', 'run-blocked', {
+      type: 'plan_task', taskKey: 'triage', title: SECRET_TITLE, required: true, maxAttempts: 3,
+    });
+    await journal.append('run-blocked', 1, [{
+      eventId: 'event-blocked', occurredAt: 51, type: 'task.blocked', payload: {
+        taskKey: 'triage', blockerId: 'blocker-1', kind: 'external',
+        owner: 'human:alice', reason: SECRET_REASON, deadline: 80,
+        allowedActions: ['replan', 'cancel'],
+      },
+    }]);
+    payloads.readCount = 0;
+    const runtime = createWorkroomRuntime(journal, {
+      authorize: async () => ({
+        catalogRevision: digest({ catalog: 1 }), projectDigest: digest({ project: 1 }),
+        governanceDigest: digest({ governance: 1 }), bindingDigest: digest({ binding: 1 }),
+      }),
+    });
+
+    const result = await runtime.getReadiness({
+      projectId: 'support', runId: 'run-blocked',
+      authenticatedPrincipal: { principalId: 'human:alice' },
+    });
+
+    expect(result).toMatchObject({
+      status: 'ready',
+      readiness: {
+        projectId: 'support', runId: 'run-blocked', sequence: 2, state: 'blocked',
+        recommendedActions: ['resolve', 'replan', 'cancel'],
+        blockers: [{
+          kind: 'external', deadline: 80, allowedActions: ['resolve', 'replan', 'cancel'],
+        }],
+      },
+    });
+    const encoded = JSON.stringify(result);
+    expect(encoded).not.toContain(SECRET_TITLE);
+    expect(encoded).not.toContain(SECRET_REASON);
+    expect(encoded).not.toContain('human:alice');
+    expect(payloads.readCount).toBe(0);
+  });
+
   it('fails closed before reading stored headers when Project/recipient authority is absent', async () => {
     const store = {
       scanStoredHeaders: vi.fn(async () => []),

--- a/packages/im/agent/tests/workroom/workroom-content-free-journal.test.ts
+++ b/packages/im/agent/tests/workroom/workroom-content-free-journal.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, mkdir, readFile, readdir, rm } from 'node:fs/promises';
+import { mkdtemp, mkdir, readFile, readdir, rm, writeFile } from 'node:fs/promises';
 import { createHash } from 'node:crypto';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
@@ -192,6 +192,58 @@ describe('content-free Workroom Journal', () => {
       expect(payloads.readCount).toBeGreaterThan(readsBeforeRestart);
     } finally {
       await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('replays an early v3 blocker header without requiring newly added readiness fields', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'zhin-v3-blocker-compat-'));
+    const payloads = new TestGovernedJournalPayloadPort();
+    try {
+      const kernel = new WorkroomKernel({
+        journal: new FileWorkroomJournal(directory, payloads),
+        now: () => 100,
+        createId: (() => { let id = 0; return () => `event-${++id}`; })(),
+      });
+      await kernel.createRun({ projectId: 'project-support', runId: 'run-v3', title: 'Run' });
+      await kernel.execute('project-support', 'run-v3', {
+        type: 'plan_task', taskKey: 'triage', title: 'Task', required: true, maxAttempts: 1,
+      });
+      await kernel.execute('project-support', 'run-v3', {
+        type: 'block_task', taskKey: 'triage', blockerId: 'approval', kind: 'human_input',
+        owner: 'sponsor', reason: 'Approval', deadline: 200,
+      });
+      const filenames = (await readdir(directory)).filter(name => name.endsWith('.json'));
+      for (const filename of filenames) {
+        const path = join(directory, filename);
+        const stored = JSON.parse(await readFile(path, 'utf8')) as {
+          version: 3;
+          runId: string;
+          expectedSequence: number;
+          events: Array<{ type: string; control: Record<string, unknown> }>;
+          payloadDigest: string;
+        };
+        const blocked = stored.events.find(event => event.type === 'task.blocked');
+        if (!blocked) continue;
+        blocked.control = {
+          taskKey: blocked.control.taskKey,
+          blockerId: blocked.control.blockerId,
+        };
+        stored.payloadDigest = digest({
+          version: stored.version,
+          runId: stored.runId,
+          expectedSequence: stored.expectedSequence,
+          events: stored.events,
+        });
+        await writeFile(path, canonicalWorkroomJson(stored), 'utf8');
+      }
+
+      await expect(new WorkroomKernel({
+        journal: new FileWorkroomJournal(directory, payloads),
+      }).read('project-support', 'run-v3')).resolves.toMatchObject({
+        tasks: { triage: { blockers: [{ kind: 'human_input', deadline: 200 }] } },
+      });
+    } finally {
+      await rm(directory, { recursive: true, force: true });
     }
   });
 

--- a/packages/im/agent/tests/workroom/workroom-run-control.test.ts
+++ b/packages/im/agent/tests/workroom/workroom-run-control.test.ts
@@ -1,0 +1,206 @@
+import { describe, expect, it, vi } from 'vitest';
+import { digestCanonicalWorkroomValue as digest } from '../../src/workroom/canonical-value.js';
+import { MemoryWorkroomJournal } from '../../src/workroom/journal.js';
+import {
+  WorkroomRunControlUnauthorizedError,
+  createCatalogWorkroomRunControlAuthority,
+  workroomRunControlRequestDigest,
+} from '../../src/workroom/workroom-run-control.js';
+import { WorkroomKernel } from '../../src/workroom/workroom-kernel.js';
+
+describe('Workroom typed Run control', () => {
+  it('derives standard mutation authority only from the current enabled Catalog Sponsor set', async () => {
+    const definition = {
+      name: 'Support', enabled: true,
+      members: [{ agent: 'support-worker', role: 'executor' as const }],
+      sponsors: ['human:alice'],
+    };
+    const catalogRevision = digest({ catalog: 1 });
+    const authority = createCatalogWorkroomRunControlAuthority({
+      read: async () => ({ definitions: { support: definition }, revision: catalogRevision }),
+    });
+    const command = {
+      version: 1 as const, operationId: 'replan-1', projectId: 'support', runId: 'run-1',
+      expectedSequence: 4, action: 'request_replan' as const,
+      reasonCode: 'requirements_changed' as const,
+    };
+    const input = {
+      version: 1 as const,
+      purpose: 'commit' as const,
+      command,
+      authenticatedPrincipalId: 'human:alice',
+      requestDigest: workroomRunControlRequestDigest(command, 'human:alice'),
+      stateSequence: 4,
+      stateStatus: 'active' as const,
+      stateDigest: digest({ state: 4 }),
+    };
+
+    await expect(authority.authorize(input)).resolves.toMatchObject({
+      authorized: true, principalId: 'human:alice', catalogRevision,
+      projectDigest: digest(definition),
+    });
+    await expect(authority.authorize({
+      ...input, authenticatedPrincipalId: 'human:mallory',
+      requestDigest: workroomRunControlRequestDigest(command, 'human:mallory'),
+    })).resolves.toEqual({ authorized: false, reason: 'principal_is_not_project_sponsor' });
+  });
+
+  it('commits an authorized cancellation with exact sequence and an auditable closed reason code', async () => {
+    const journal = new MemoryWorkroomJournal();
+    const authorize = vi.fn(async (input) => ({
+      authorized: true as const,
+      principalId: input.authenticatedPrincipalId,
+      catalogRevision: digest({ catalog: 1 }),
+      projectDigest: digest({ project: 'support' }),
+      authorizationRef: 'catalog:support:sponsor:alice',
+    }));
+    const kernel = new WorkroomKernel({
+      journal, now: () => 100, createId: (() => { let id = 0; return () => `event-${++id}`; })(),
+      runControlAuthority: { authorize },
+    });
+    await kernel.createRun({ projectId: 'support', runId: 'run-1', title: 'private title' });
+    await kernel.execute('support', 'run-1', {
+      type: 'plan_task', taskKey: 'triage', title: 'private task', required: true, maxAttempts: 2,
+    });
+
+    const receipt = await kernel.controlRun({
+      version: 1,
+      operationId: 'cancel-operation-1',
+      projectId: 'support',
+      runId: 'run-1',
+      expectedSequence: 1,
+      action: 'cancel',
+      reasonCode: 'operator_request',
+      controlDeadline: 130,
+    }, { principalId: 'human:alice' });
+
+    expect(receipt).toMatchObject({ status: 'committed', action: 'cancel' });
+    expect(receipt.state).toMatchObject({ status: 'cancelled', cancelRequested: true });
+    expect(authorize).toHaveBeenCalledWith(expect.objectContaining({
+      version: 1,
+      authenticatedPrincipalId: 'human:alice',
+      stateSequence: 1,
+      stateStatus: 'active',
+    }));
+    const events = await journal.read('run-1');
+    expect(events.map(event => event.type)).toEqual([
+      'run.created', 'task.planned', 'run.control_decided',
+      'run.cancel_requested', 'task.cancel_requested', 'task.cancelled', 'run.cancelled',
+    ]);
+    expect(events[2]?.payload).toMatchObject({
+      action: 'cancel', reasonCode: 'operator_request', principalId: 'human:alice',
+    });
+
+    await expect(kernel.controlRun({
+      version: 1, operationId: 'cancel-operation-2', projectId: 'support', runId: 'run-1',
+      expectedSequence: 6, action: 'cancel', reasonCode: 'operator_request', controlDeadline: 140,
+    }, { principalId: 'human:alice' })).rejects.toThrow('cancellation is already active');
+    expect(await journal.read('run-1')).toHaveLength(7);
+  });
+
+  it('records an authorized replan request, pauses scheduling, and replays the same operation idempotently', async () => {
+    const journal = new MemoryWorkroomJournal();
+    const kernel = new WorkroomKernel({
+      journal, now: () => 100, createId: (() => { let id = 0; return () => `event-${++id}`; })(),
+      runControlAuthority: { authorize: async input => ({
+        authorized: true,
+        principalId: input.authenticatedPrincipalId,
+        catalogRevision: digest({ catalog: 1 }),
+        projectDigest: digest({ project: 'support' }),
+        authorizationRef: 'catalog:support:sponsor:alice',
+      }) },
+    });
+    await kernel.createRun({ projectId: 'support', runId: 'run-1', title: 'private title' });
+    const command = {
+      version: 1 as const,
+      operationId: 'replan-operation-1',
+      projectId: 'support',
+      runId: 'run-1',
+      expectedSequence: 0,
+      action: 'request_replan' as const,
+      reasonCode: 'requirements_changed' as const,
+    };
+
+    const committed = await kernel.controlRun(command, { principalId: 'human:alice' });
+    const duplicate = await kernel.controlRun(command, { principalId: 'human:alice' });
+
+    expect(committed).toMatchObject({
+      status: 'committed', action: 'request_replan', state: { status: 'needs_replan' },
+    });
+    expect(duplicate).toMatchObject({
+      status: 'duplicate', action: 'request_replan', state: { status: 'needs_replan' },
+    });
+    expect((await journal.read('run-1')).map(event => event.type)).toEqual([
+      'run.created', 'run.control_decided', 'run.replan_requested',
+    ]);
+  });
+
+  it('fails closed with zero writes for a stale sequence or denied Sponsor authority', async () => {
+    const journal = new MemoryWorkroomJournal();
+    const authorize = vi.fn(async input => input.authenticatedPrincipalId === 'human:alice'
+      ? {
+          authorized: true as const,
+          principalId: input.authenticatedPrincipalId,
+          catalogRevision: digest({ catalog: 1 }),
+          projectDigest: digest({ project: 'support' }),
+          authorizationRef: 'catalog:support:sponsor:alice',
+        }
+      : { authorized: false as const, reason: 'not_project_sponsor' });
+    const kernel = new WorkroomKernel({ journal, runControlAuthority: { authorize } });
+    await kernel.createRun({ projectId: 'support', runId: 'run-1', title: 'private title' });
+
+    const stale = await kernel.controlRun({
+      version: 1, operationId: 'stale', projectId: 'support', runId: 'run-1',
+      expectedSequence: 4, action: 'request_replan', reasonCode: 'requirements_changed',
+    }, { principalId: 'human:alice' });
+    expect(stale).toEqual({ status: 'stale', actualSequence: 0 });
+    expect(authorize).toHaveBeenCalledWith(expect.objectContaining({
+      purpose: 'stale_probe', stateSequence: 0, authenticatedPrincipalId: 'human:alice',
+    }));
+
+    await expect(kernel.controlRun({
+      version: 1, operationId: 'stale-denied', projectId: 'support', runId: 'run-1',
+      expectedSequence: 4, action: 'request_replan', reasonCode: 'requirements_changed',
+    }, { principalId: 'human:mallory' })).rejects
+      .toBeInstanceOf(WorkroomRunControlUnauthorizedError);
+
+    await expect(kernel.controlRun({
+      version: 1, operationId: 'denied', projectId: 'support', runId: 'run-1',
+      expectedSequence: 0, action: 'cancel', reasonCode: 'operator_request',
+      controlDeadline: Number.MAX_SAFE_INTEGER,
+    }, { principalId: 'human:mallory' })).rejects.toBeInstanceOf(WorkroomRunControlUnauthorizedError);
+    expect((await journal.read('run-1'))).toHaveLength(1);
+  });
+
+  it('revalidates current Catalog Sponsor authority before returning a duplicate receipt', async () => {
+    const definition = {
+      name: 'Support', enabled: true,
+      members: [{ agent: 'support-worker', role: 'executor' as const }],
+      sponsors: ['human:alice'],
+    };
+    let enabled = true;
+    const journal = new MemoryWorkroomJournal();
+    const kernel = new WorkroomKernel({
+      journal,
+      runControlAuthority: createCatalogWorkroomRunControlAuthority({
+        read: async () => ({
+          definitions: enabled ? { support: definition } : {},
+          revision: digest({ catalog: enabled ? 1 : 2 }),
+        }),
+      }),
+    });
+    await kernel.createRun({ projectId: 'support', runId: 'run-1', title: 'private title' });
+    const command = {
+      version: 1 as const, operationId: 'replan-1', projectId: 'support', runId: 'run-1',
+      expectedSequence: 0, action: 'request_replan' as const,
+      reasonCode: 'requirements_changed' as const,
+    };
+    await expect(kernel.controlRun(command, { principalId: 'human:alice' }))
+      .resolves.toMatchObject({ status: 'committed' });
+
+    enabled = false;
+    await expect(kernel.controlRun(command, { principalId: 'human:alice' }))
+      .rejects.toBeInstanceOf(WorkroomRunControlUnauthorizedError);
+    expect(await journal.read('run-1')).toHaveLength(3);
+  });
+});

--- a/packages/im/agent/tests/workroom/workroom-scheduler.test.ts
+++ b/packages/im/agent/tests/workroom/workroom-scheduler.test.ts
@@ -109,6 +109,14 @@ describe('Workroom Scheduler', () => {
     ]);
     expect(decideWorkroomSchedule(cancelling)).toBeNull();
 
+    const replanning = journal(policy, [
+      task('build', 2, { sponsorLane: 'normal' }),
+      event(3, 'run.replan_requested', {
+        operationId: 'replan-1', reasonCode: 'requirements_changed', requestDigest: DIGEST_A,
+      }),
+    ]);
+    expect(decideWorkroomSchedule(replanning)).toBeNull();
+
     const malformedWait = journal(policy, [
       task('build', 2, { sponsorLane: 'normal' }),
       event(3, 'task.blocked', {

--- a/tests/snapshots/api-surface.json
+++ b/tests/snapshots/api-surface.json
@@ -89,6 +89,7 @@
     "export * from './workroom/workroom-assignment-knowledge-context.js';",
     "export * from './workroom/workroom-kernel.js';",
     "export * from './workroom/workroom-preemption.js';",
+    "export * from './workroom/workroom-run-control.js';",
     "export * from './workroom/workroom-scheduler-application.js';",
     "export * from './workroom/workroom-scheduler.js';",
     "export * from './workroom/workroom-task-report-store.js';",

--- a/tests/snapshots/plugin-runtime-api.json
+++ b/tests/snapshots/plugin-runtime-api.json
@@ -93,6 +93,7 @@
     "export * from './workroom-scheduler-route-registry.js';",
     "export * from './workroom-scheduler-runtime.js';",
     "export type{AssistantRuntimeHandle}from '../assistant/runtime-contract.js';",
+    "export type{WorkroomRunControlCommand,WorkroomRunControlReceipt,}from '../workroom/workroom-run-control.js';",
     "export{FileJournalStore}from '../journal/file-journal-store.js';",
     "export{capabilityToTool,toolInvocationFromTurn,toolsFromCapabilities,type GenerationStampedTool,}from './capability-tools.js';",
     "export{createCatalogGovernedWorkroomProjectionAuthority,createCatalogGovernedConsoleDisclosureAuthority,createWorkroomRuntime,type WorkroomProjectionReadAuthorityPort,type WorkroomRunDetail,type WorkroomRunHeader,type WorkroomRuntimeHandle,}from '../workroom/runtime.js';",


### PR DESCRIPTION
## Summary
- add content-free Workroom run, task, assignment, and readiness CLI views
- add Sponsor-authorized typed cancel and request-replan controls
- preserve v3 blocker replay compatibility and revalidate current Sponsor authority for stale/duplicate requests

## Validation
- full repository tests: 867 files, 6936 tests passed before merge
- merged build: 87 packages passed
- merged focused tests: 6 files, 78 tests passed
- API surface, Plugin Runtime API, Workroom SSOT, docs, ESLint, and diff checks passed

## Sourcery 摘要

通过 CLI 和 Host API 提供经过身份验证的无内容 Workroom 可观测性，以及由 Sponsor 控制的 Run 操作。

新功能：
- 为无内容的 Workroom Run、Task、Assignment 和就绪状态添加经过身份验证的 CLI 视图。
- 添加由 Sponsor 授权的类型化控制，用于按精确序列取消 Run 和提交持久化重新规划请求。

Bug 修复：
- 保留与早期 v3 阻塞器标头的重放兼容性，同时安全地为缺失的诊断字段设置默认值。
- 拒绝过期、伪造、未授权或重复的控制请求，避免意外写入；对于重放的操作，重新验证当前 Sponsor 权限。

增强：
- 通过 Host REST API 和插件运行时 API 暴露 Workroom 的就绪状态和控制能力。
- 在重新规划请求待处理期间暂停调度，并在应用计划修订后恢复调度。
- 改进 Host HTTP 诊断，以处理缺少令牌、Host 离线和连接被拒绝原因等情况。

文档：
- 记录新的 Workroom 检查和控制命令、身份验证要求，以及基于序列的授权行为。

测试：
- 增加对 CLI 投影、就绪状态诊断、类型化控制、REST 授权、重放兼容性、调度器暂停行为和 Host 连接错误的测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Provide authenticated, content-free Workroom observability and Sponsor-controlled Run operations through the CLI and Host APIs.

New Features:
- Add authenticated CLI views for content-free Workroom Run, Task, Assignment, and readiness status.
- Add Sponsor-authorized typed controls for exact-sequence Run cancellation and durable replan requests.ต่อ

Bug Fixes:
- Preserve replay compatibility for earlier v3 blocker headers while safely defaulting missing diagnostic fields.
- Reject stale, forged, unauthorized, or duplicate control requests without unintended writes, while revalidating current Sponsor authority for replayed operations.

Enhancements:
- Expose Workroom readiness and control capabilities through the Host REST and plugin-runtime APIs.
- Pause scheduling while a replan request is pending and resume after a plan revision is applied.
- Improve Host HTTP diagnostics for missing tokens, offline Hosts, and connection-refusal causes.

Documentation:
- Document the new Workroom inspection and control commands, authentication requirements, and sequence-based authorization behavior.

Tests:
- Add coverage for CLI projections, readiness diagnostics, typed controls, REST authorization, replay compatibility, scheduler pause behavior, and Host connectivity errors.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds content-free Workroom status/readiness CLI and Sponsor-authorized run controls over authenticated Host REST. Previously there was no online inspection or control; now `zhin agent workroom ...` lists runs, shows a run, diagnoses readiness, and issues typed cancel/replan with exact-sequence gating and durable receipts.

- New CLI: `runs`, `run <runId>`, `readiness <runId>`, `cancel <runId>`, and `request-replan <runId>` under `zhin agent workroom`, using Host REST with Bearer auth; improved offline/missing-token diagnostics and optional JSON output.
- Host/Console: adds REST handlers that parse typed `WorkroomRunControlCommand` and execute via a new optional `workroomControl` port; authorization derives from the current enabled Catalog Sponsors; duplicates and stale requests are rejected with clear receipts.
- Kernel/Journal/Scheduler: introduces `run.control_decided` and `run.replan_requested` events; scheduling pauses while cancel or replan is requested; readiness and blocker headers are derived content-free; v3 blocker header replay remains compatible.
- API surface: exports `workroom-run-control` types from `@zhin.js/agent` and `@zhin.js/agent/runtime`; `AgentHostConsolePort` now includes optional `workroomControl`; snapshots updated.
- Required actions: set an `http.token` in `zhin.config.yml` (or provide one via environment) and ensure the Host is running; custom Hosts must wire a `runControlAuthority` to expose control endpoints; CLI cancel/replan require `--expected-sequence` and a `--reason-code`.

<sup>Written for commit 361c4321a071fcb3123fb7e8606653639e8d6c78. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zhinjs/zhin/pull/626?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

