### PR TITLE
feat(adapter): unify endpoint operation capabilities

### DIFF
--- a/.changeset/unified-adapter-operations.md
+++ b/.changeset/unified-adapter-operations.md
@@ -1,0 +1,19 @@
+---
+"@zhin.js/adapter": minor
+"@zhin.js/core": patch
+"@zhin.js/console-protocol": patch
+"@zhin.js/adapter-discord": patch
+"@zhin.js/adapter-kook": patch
+"@zhin.js/adapter-lark": patch
+"@zhin.js/adapter-milky": patch
+"@zhin.js/adapter-napcat": patch
+"@zhin.js/adapter-onebot11": patch
+"@zhin.js/adapter-onebot12": patch
+"@zhin.js/adapter-qq": patch
+"@zhin.js/adapter-satori": patch
+"@zhin.js/adapter-slack": patch
+"@zhin.js/adapter-wecom": patch
+"@zhin.js/adapter-weixin-ilink": patch
+---
+
+Expose exact per-Endpoint message operations through one validated Adapter capability model, route Core control calls through declared active capabilities, and connect existing recall, edit, reaction, and typing implementations across platform adapters.

--- a/docs/adapters/index.md
+++ b/docs/adapters/index.md
@@ -54,6 +54,22 @@ _（当前无）_
 | OneBot v12 | `@zhin.js/adapter-onebot12` | — | [OneBot v12](/adapters/onebot12) |
 | Satori | `@zhin.js/adapter-satori` | — | [Satori](/adapters/satori) |
 
+## 统一消息操作能力
+
+消息发送由所有声明 **outbound** 的 Endpoint 支持；消息级扩展操作通过统一
+**EndpointControl** 暴露，并按每个具体 Endpoint 精确声明。Core 不探测平台 SDK 私有方法。
+
+| 操作 | 已接入平台 |
+|------|------------|
+| recall | Discord、ICQQ、KOOK、飞书、Milky、NapCat、OneBot 11/12、QQ 官方、Satori、Slack、Telegram、企业微信 |
+| edit | Slack |
+| reaction | Discord Gateway、ICQQ、Slack |
+| typing | 微信 iLink |
+
+同一适配器不同接入模式可以具有不同能力。例如 Discord Gateway 支持 reaction，
+Interactions 模式只声明 recall；Host/Console 可从 Endpoint row 的 **operations** 字段读取
+当前模式的准确能力集。
+
 ## 维护说明
 
 - **单一来源（档位）**：`scripts/adapter-meta.mjs`

--- a/docs/en/adapters/index.md
+++ b/docs/en/adapters/index.md
@@ -54,6 +54,24 @@ _(Currently none)_
 | OneBot v12 | `@zhin.js/adapter-onebot12` | — | [OneBot v12](/adapters/onebot12) |
 | Satori | `@zhin.js/adapter-satori` | — | [Satori](/adapters/satori) |
 
+## Unified message operations
+
+Every Endpoint declaring `outbound` supports sending. Additional message operations
+use the platform-neutral `EndpointControl` port and are declared precisely for each
+concrete Endpoint; Core never probes private platform SDK methods.
+
+| Operation | Integrated platforms |
+|-----------|----------------------|
+| `recall` | Discord, ICQQ, KOOK, Lark, Milky, NapCat, OneBot 11/12, QQ Official, Satori, Slack, Telegram, WeCom |
+| `edit` | Slack |
+| `reaction` | Discord Gateway, ICQQ, Slack |
+| `typing` | Weixin iLink |
+
+Connection modes of one adapter may expose different capabilities. For example,
+Discord Gateway supports reactions while Interactions mode declares recall only.
+Host and Console clients can read the concrete capability set from `operations` on
+each Endpoint row.
+
 ## Maintenance Notes
 
 - **Single source of truth (tiers)**: `scripts/adapter-meta.mjs`

--- a/packages/console/protocol/src/index.ts
+++ b/packages/console/protocol/src/index.ts
@@ -259,6 +259,8 @@ export type ConsoleEndpointPhase =
   | 'failed'
   | 'unconfigured';
 
+export type ConsoleEndpointOperation = 'recall' | 'edit' | 'reaction' | 'typing';
+
 /**
  * Forward-compatible Endpoint row shared by both Host implementations and the
  * Remote Console. Optional fields allow clients to consume older Hosts.
@@ -273,6 +275,7 @@ export interface ConsoleEndpointSummary {
   readonly pendingLogin?: boolean;
   readonly pendingRequestCount?: number;
   readonly pendingNoticeCount?: number;
+  readonly operations?: readonly ConsoleEndpointOperation[];
   readonly managementCapabilities?: readonly EndpointManagementCapability[];
 }
 

--- a/packages/im/adapter/README.md
+++ b/packages/im/adapter/README.md
@@ -26,8 +26,13 @@ AdapterIndex 和 generation lifecycle 管理。
 
 Adapter definitions declare `capabilities` for inbound/outbound admission and
 `operations` for optional actions such as `recall`, `edit`, `reaction`, and
-`typing`. Runtime callers should query the resulting `EndpointCapabilities`
-instead of probing optional endpoint methods. The zero-dependency types live in
+`typing`. `operations` accepts either a static list or a resolver receiving the
+concrete `AdapterContext`; use the resolver when connection modes expose different
+operations. `AdapterIndex` resolves, freezes, and exposes the exact set for every
+expanded Endpoint. Runtime callers should query the resulting `EndpointCapabilities`
+instead of probing optional endpoint methods. Declarations and the explicit
+`EndpointControl` port are validated in both directions, so hidden or unimplemented
+operations fail candidate generation before commit. The zero-dependency types live in
 [`@zhin.js/im-contract`](../im-contract/README.md).
 
 Framework-facing outbound code carries a structured `ConversationRef`.
@@ -45,7 +50,8 @@ boundary.
 
 New adapters should provide `control` directly and declare matching
 `operations`. Protocol-specific methods and compound string identifiers are not
-inspected or adapted by the runtime.
+inspected by the runtime. `createRecallEndpointControl()` bridges the common
+platform `recall(messageId)` shape without leaking that shape into Core.
 
 ## Endpoint 生命周期基座（createEndpointLifecycle）
 

--- a/packages/im/adapter/src/adapter-index.ts
+++ b/packages/im/adapter/src/adapter-index.ts
@@ -10,20 +10,31 @@ import {
   type RuntimeSnapshot,
 } from '@zhin.js/plugin-runtime';
 import { createCapabilityContext } from '@zhin.js/feature-kit';
-import type {
-  AdapterCapability,
-  AdapterDefinition,
-  AdapterSegmentPolicy,
-  EndpointInstance,
-  EndpointSendRequest,
+import {
+  endpointCapabilitiesOf,
+  resolveAdapterOperations,
+  type AdapterCapability,
+  type AdapterDefinition,
+  type AdapterOperation,
+  type AdapterSegmentPolicy,
+  type EndpointInstance,
+  type EndpointSendRequest,
 } from './definition.js';
 import {
   listEndpointManagementCapabilities,
   type EndpointManagementCapability,
 } from './endpoint-management.js';
-import { assertDeclaredEndpointOperations } from './endpoint-control.js';
+import {
+  assertDeclaredEndpointOperations,
+  endpointControlOf,
+  type EndpointControl,
+} from './endpoint-control.js';
 import { endpointContentOf, type EndpointContentResolveContext } from './endpoint-content.js';
-import type { ConversationReference, ConversationResolution } from '@zhin.js/im-contract';
+import type {
+  ConversationReference,
+  ConversationResolution,
+  EndpointCapabilities,
+} from '@zhin.js/im-contract';
 
 export interface AdapterDescriptor {
   readonly id: CapabilityId;
@@ -31,6 +42,7 @@ export interface AdapterDescriptor {
   readonly name: string;
   readonly source: string;
   readonly capabilities: readonly AdapterCapability[];
+  readonly operations: readonly AdapterOperation[];
 }
 
 /** Console / Host-facing endpoint row (connected = admission open). */
@@ -80,7 +92,7 @@ export class AdapterIndex {
       for (const slot of [...slots].sort((left, right) => left.id.localeCompare(right.id))) {
         signal.throwIfAborted();
         for (const expansion of expandEndpointConfigs(slot, snapshot)) {
-          const endpoint = await createEndpoint(slot, snapshot, admission, signal, expansion);
+          const created = await createEndpoint(slot, snapshot, admission, signal, expansion);
           signal.throwIfAborted();
           records.push({
             id: expansion.id,
@@ -90,7 +102,8 @@ export class AdapterIndex {
             name: expansion.endpointId,
             source: slot.source,
             capabilities: slot.definition.capabilities,
-            endpoint,
+            operations: created.operations,
+            endpoint: created.endpoint,
             ...(slot.definition.segments ? { segments: slot.definition.segments } : {}),
             started: false,
             open: false,
@@ -122,6 +135,7 @@ export class AdapterIndex {
       name: endpointLiveName(record.endpoint) ?? record.name,
       source: record.source,
       capabilities: record.capabilities,
+      operations: record.operations,
       connected: record.open && !record.stopped,
       status: record.open && !record.stopped ? 'online' as const : 'offline' as const,
       phase: endpointPhase(record),
@@ -156,6 +170,21 @@ export class AdapterIndex {
     const record = this.#records.get(id);
     if (!record) throw new Error(`Unknown Adapter Endpoint: ${id}`);
     return record.owner;
+  }
+
+  /** Exact, serializable capabilities for one concrete Endpoint. */
+  capabilities(id: CapabilityId): EndpointCapabilities {
+    const record = this.#records.get(id);
+    if (!record) throw new Error(`Unknown Adapter Endpoint: ${id}`);
+    return endpointCapabilitiesOf(record, record.operations);
+  }
+
+  /** Returns the control port only when the concrete Endpoint declared the operation and is active. */
+  control(id: CapabilityId, operation: AdapterOperation): EndpointControl | undefined {
+    const record = this.#records.get(id);
+    if (!record || !record.started || record.stopped) return undefined;
+    if (!record.operations.includes(operation)) return undefined;
+    return endpointControlOf(record.endpoint);
   }
 
   /**
@@ -396,15 +425,15 @@ async function createEndpoint(
   admission: GenerationAdmissionGate,
   signal: AbortSignal,
   expansion?: EndpointExpansion,
-): Promise<EndpointInstance> {
-  const endpoint = await slot.definition.create(
-    Object.freeze({
-      ...createCapabilityContext(snapshot, slot.owner, admission, signal),
-      ...(expansion?.config ? { config: expansion.config } : {}),
-      id: expansion?.id ?? slot.id,
-      name: slot.localName,
-    }),
-  );
+): Promise<Readonly<{ endpoint: EndpointInstance; operations: readonly AdapterOperation[] }>> {
+  const context = Object.freeze({
+    ...createCapabilityContext(snapshot, slot.owner, admission, signal),
+    ...(expansion?.config ? { config: expansion.config } : {}),
+    id: expansion?.id ?? slot.id,
+    name: slot.localName,
+  });
+  const operations = resolveAdapterOperations(slot.definition, context);
+  const endpoint = await slot.definition.create(context);
   assertEndpoint(endpoint, expansion?.id ?? slot.id);
   if (slot.definition.capabilities.includes('outbound') && typeof endpoint.send !== 'function') {
     throw new TypeError(
@@ -413,10 +442,10 @@ async function createEndpoint(
   }
   assertDeclaredEndpointOperations(
     endpoint,
-    slot.definition.operations,
+    operations,
     String(expansion?.id ?? slot.id),
   );
-  return endpoint;
+  return Object.freeze({ endpoint, operations });
 }
 
 async function stopRecords(

--- a/packages/im/adapter/src/definition.ts
+++ b/packages/im/adapter/src/definition.ts
@@ -16,6 +16,11 @@ export type AdapterCapability = 'inbound' | 'outbound';
 /** Operations beyond sending, declared by an Adapter definition. */
 export type AdapterOperation = Exclude<EndpointOperation, 'send'>;
 
+/** Resolve operations for one concrete Endpoint configuration. */
+export type AdapterOperationDeclaration<TConfig = unknown> =
+  | readonly AdapterOperation[]
+  | ((context: AdapterContext<TConfig>) => readonly AdapterOperation[]);
+
 /** 端点可消费的出站媒体来源形式。 */
 export type AdapterOutboundMedia = 'url' | 'path' | 'base64' | 'upload';
 
@@ -103,7 +108,7 @@ export interface AdapterDefinition<TConfig = unknown> {
    * `capabilities: ['outbound']`; a method existing on an endpoint is not a
    * capability declaration.
    */
-  readonly operations?: readonly AdapterOperation[];
+  readonly operations?: AdapterOperationDeclaration<TConfig>;
   /** 可选：端点消息段能力声明（出站协商降级挂载点）。 */
   readonly segments?: AdapterSegmentPolicy;
   create(
@@ -134,7 +139,9 @@ export function defineAdapter<TConfig = unknown>(
     throw new TypeError('Adapter capabilities must contain inbound and/or outbound');
   }
   const segments = normalizeSegmentPolicy(definition.segments);
-  const operations = normalizeOperations(definition.operations);
+  const operations = typeof definition.operations === 'function'
+    ? definition.operations
+    : normalizeOperations(definition.operations);
   return Object.freeze({
     ...definition,
     $feature: adapterBrand,
@@ -147,8 +154,14 @@ export function defineAdapter<TConfig = unknown>(
 /** Converts the definition's compact authoring form into the public contract. */
 export function endpointCapabilitiesOf(
   definition: Pick<AdapterDefinition, 'capabilities' | 'operations'>,
+  resolvedOperations?: readonly AdapterOperation[],
 ): EndpointCapabilities {
-  const operations = definition.operations?.reduce<Partial<Record<AdapterOperation, true>>>(
+  if (typeof definition.operations === 'function' && resolvedOperations === undefined) {
+    throw new TypeError('Dynamic Adapter operations must be resolved for one Endpoint');
+  }
+  const declared = resolvedOperations
+    ?? (Array.isArray(definition.operations) ? definition.operations : undefined);
+  const operations = declared?.reduce<Partial<Record<AdapterOperation, true>>>(
     (result, operation) => ({ ...result, [operation]: true }),
     {},
   );
@@ -157,6 +170,18 @@ export function endpointCapabilitiesOf(
     outbound: definition.capabilities.includes('outbound'),
     ...(operations && Object.keys(operations).length > 0 ? { operations: Object.freeze(operations) } : {}),
   });
+}
+
+/** Resolve and validate the operation declaration for one concrete Endpoint. */
+export function resolveAdapterOperations<TConfig>(
+  definition: Pick<AdapterDefinition<TConfig>, 'operations'>,
+  context: AdapterContext<TConfig>,
+): readonly AdapterOperation[] {
+  const declaration = definition.operations;
+  const operations = typeof declaration === 'function'
+    ? declaration(context)
+    : declaration;
+  return normalizeOperations(operations) ?? Object.freeze([]);
 }
 
 function normalizeOperations(
@@ -240,7 +265,9 @@ export function parseAdapterDefinition(value: unknown): AdapterDefinition {
   ) throw invalidAdapter();
   // defineAdapter 已校验过形状；外部手工构造的 definition 也在此兜底
   normalizeSegmentPolicy(definition.segments);
-  normalizeOperations(definition.operations);
+  if (typeof definition.operations !== 'function') {
+    normalizeOperations(definition.operations);
+  }
   return definition as AdapterDefinition;
 }
 

--- a/packages/im/adapter/src/endpoint-control.ts
+++ b/packages/im/adapter/src/endpoint-control.ts
@@ -23,6 +23,15 @@ export interface EndpointWithControl {
   readonly control?: EndpointControl;
 }
 
+/** Bridges the common platform `recall(messageId)` shape into canonical control. */
+export function createRecallEndpointControl(
+  recallById: (messageId: string) => void | Promise<void>,
+): Readonly<EndpointControl> {
+  return Object.freeze<EndpointControl>({
+    recall: (message) => Promise.resolve(recallById(message.id)),
+  });
+}
+
 /** Reads the canonical control port without probing protocol-specific methods. */
 export function endpointControlOf(endpoint: unknown): EndpointControl | undefined {
   if (!endpoint || typeof endpoint !== 'object') return undefined;
@@ -46,6 +55,24 @@ export function hasExplicitEndpointOperation(
   }
 }
 
+/** Lists the semantic operations implemented by an Endpoint's explicit control port. */
+export function listExplicitEndpointOperations(
+  endpoint: unknown,
+): readonly ('recall' | 'edit' | 'reaction' | 'typing')[] {
+  if (!endpoint || typeof endpoint !== 'object') return Object.freeze([]);
+  const control = (endpoint as EndpointWithControl).control;
+  if (!control || typeof control !== 'object') return Object.freeze([]);
+  const operations: Array<'recall' | 'edit' | 'reaction' | 'typing'> = [];
+  if (typeof control.recall === 'function') operations.push('recall');
+  if (typeof control.edit === 'function') operations.push('edit');
+  if (
+    typeof control.addReaction === 'function'
+    || typeof control.removeReaction === 'function'
+  ) operations.push('reaction');
+  if (typeof control.typing === 'function') operations.push('typing');
+  return Object.freeze(operations);
+}
+
 /** Rejects a declaration that cannot be fulfilled by the explicit control port. */
 export function assertDeclaredEndpointOperations(
   endpoint: unknown,
@@ -59,8 +86,25 @@ export function assertDeclaredEndpointOperations(
       );
     }
   }
+  const declared = new Set(operations ?? []);
+  for (const operation of listExplicitEndpointOperations(endpoint)) {
+    if (!declared.has(operation)) {
+      throw new TypeError(
+        `Adapter Endpoint ${id} exposes control.${explicitControlMethodName(endpoint, operation)} but does not declare ${operation}`,
+      );
+    }
+  }
 }
 
 function controlMethodName(operation: 'recall' | 'edit' | 'reaction' | 'typing'): string {
   return operation === 'reaction' ? 'addReaction' : operation;
+}
+
+function explicitControlMethodName(
+  endpoint: unknown,
+  operation: 'recall' | 'edit' | 'reaction' | 'typing',
+): string {
+  if (operation !== 'reaction') return operation;
+  const control = (endpoint as EndpointWithControl).control;
+  return typeof control?.addReaction === 'function' ? 'addReaction' : 'removeReaction';
 }

--- a/packages/im/adapter/tests/adapter.test.ts
+++ b/packages/im/adapter/tests/adapter.test.ts
@@ -24,6 +24,7 @@ import adapterFeature, {
   isAdapterIndex,
   parseAdapterDefinition,
   endpointControlOf,
+  createRecallEndpointControl,
   endpointContentOf,
   resolveEndpointManagement,
   type AdapterSegmentPolicy,
@@ -67,6 +68,22 @@ describe('Adapter Feature', () => {
 
     expect(control?.recall).toBe(explicitRecall);
     expect(endpointControlOf({ recallMessage: async () => undefined })).toBeUndefined();
+  });
+
+  it('adapts platform recall-by-id methods to canonical MessageRef control', async () => {
+    const recall = vi.fn(async () => undefined);
+    const control = createRecallEndpointControl(recall);
+    await control.recall?.({
+      conversation: {
+        endpoint: { id: 'memory', adapter: 'memory' },
+        kind: 'group',
+        id: 'room-1',
+      },
+      id: 'message-1',
+    });
+
+    expect(recall).toHaveBeenCalledWith('message-1');
+    expect(Object.isFrozen(control)).toBe(true);
   });
 
   it('resolves conversation references only through the explicit content port', async () => {
@@ -151,6 +168,94 @@ describe('Adapter Feature', () => {
     });
     const index = await createAdapterIndex([valid], snapshot([valid]));
     await index.stop();
+  });
+
+  it('resolves and exposes exact operations for each expanded Endpoint', async () => {
+    const root = rootPluginId();
+    const slot = createCapabilitySlot({
+      owner: root,
+      feature: adapterFeatureId,
+      localName: 'multi-mode',
+      source: '/adapters/multi-mode.ts',
+      definition: defineAdapter<{ mode: 'gateway' | 'webhook' }>({
+        capabilities: ['inbound', 'outbound'],
+        operations: (context) => context.config.mode === 'gateway'
+          ? ['recall', 'reaction']
+          : ['recall'],
+        create: (context) => ({
+          send: async () => 'message-1',
+          control: {
+            recall: async () => undefined,
+            ...(context.config.mode === 'gateway'
+              ? { addReaction: async () => 'reaction-1' }
+              : {}),
+          },
+        }),
+      }),
+    });
+    expect(() => endpointCapabilitiesOf(slot.definition)).toThrow(
+      'Dynamic Adapter operations must be resolved for one Endpoint',
+    );
+    const index = await createAdapterIndex([slot], snapshot([slot], new Map([[root, {
+      endpoints: [
+        { id: 'socket', mode: 'gateway' },
+        { id: 'hook', mode: 'webhook' },
+      ],
+    }]])));
+
+    const socket = index.describe().find((row) => row.name === 'socket');
+    const hook = index.describe().find((row) => row.name === 'hook');
+    expect(socket?.operations).toEqual(['recall', 'reaction']);
+    expect(hook?.operations).toEqual(['recall']);
+    expect(index.capabilities(socket!.id)).toEqual({
+      inbound: true,
+      outbound: true,
+      operations: { recall: true, reaction: true },
+    });
+    expect(index.capabilities(hook!.id)).toEqual({
+      inbound: true,
+      outbound: true,
+      operations: { recall: true },
+    });
+    await index.stop();
+  });
+
+  it('rejects explicit control operations that were not declared', async () => {
+    const root = rootPluginId();
+    const slot = createCapabilitySlot({
+      owner: root,
+      feature: adapterFeatureId,
+      localName: 'hidden-control',
+      source: '/adapters/hidden-control.ts',
+      definition: defineAdapter({
+        capabilities: ['outbound'],
+        create: () => ({
+          send: async () => 'message-1',
+          control: { recall: async () => undefined },
+        }),
+      }),
+    });
+
+    await expect(createAdapterIndex([slot], snapshot([slot])))
+      .rejects.toThrow('exposes control.recall but does not declare recall');
+
+    const hiddenReactionRemoval = createCapabilitySlot({
+      owner: root,
+      feature: adapterFeatureId,
+      localName: 'hidden-reaction-removal',
+      source: '/adapters/hidden-reaction-removal.ts',
+      definition: defineAdapter({
+        capabilities: ['outbound'],
+        create: () => ({
+          send: async () => 'message-1',
+          control: { removeReaction: async () => undefined },
+        }),
+      }),
+    });
+    await expect(createAdapterIndex(
+      [hiddenReactionRemoval],
+      snapshot([hiddenReactionRemoval]),
+    )).rejects.toThrow('exposes control.removeReaction but does not declare reaction');
   });
 
   it('forwards only the structured conversation request', async () => {

--- a/packages/im/core/src/plugin-runtime/im/im-runtime.ts
+++ b/packages/im/core/src/plugin-runtime/im/im-runtime.ts
@@ -17,8 +17,8 @@ import {
   AdapterIndex,
   adapterFeatureId,
   isAdapterIndex,
-  endpointControlOf,
   resolveEndpointManagement,
+  type AdapterOperation,
   type EndpointControl,
   type EndpointManagement,
   type EndpointManagementCapability,
@@ -804,6 +804,7 @@ export class ImRuntime implements MessageGateway {
     readonly connected: boolean;
     readonly status: 'online' | 'offline';
     readonly phase: AdapterEndpointPhase;
+    readonly operations: readonly AdapterOperation[];
     readonly managementCapabilities: readonly EndpointManagementCapability[];
   }[] {
     try {
@@ -818,6 +819,7 @@ export class ImRuntime implements MessageGateway {
           connected: row.connected,
           status: row.status,
           phase: row.phase,
+          operations: row.operations,
           managementCapabilities: row.managementCapabilities,
         }));
       } finally {
@@ -866,6 +868,7 @@ export class ImRuntime implements MessageGateway {
     readonly connected: boolean;
     readonly status: 'online' | 'offline';
     readonly phase: AdapterEndpointPhase;
+    readonly operations: readonly AdapterOperation[];
     readonly managementCapabilities: readonly EndpointManagementCapability[];
   } | null {
     try {
@@ -884,6 +887,7 @@ export class ImRuntime implements MessageGateway {
           connected: row.connected,
           status: row.status,
           phase: row.phase,
+          operations: row.operations,
           managementCapabilities: row.managementCapabilities,
         });
       } finally {
@@ -931,7 +935,7 @@ export class ImRuntime implements MessageGateway {
     readonly sceneType?: string;
     readonly channelId?: string;
   }): Promise<string | null> {
-    return this.#withEndpointControl(input.adapter, input.endpointKey, (control) =>
+    return this.#withEndpointControl(input.adapter, input.endpointKey, 'reaction', (control) =>
       control.addReaction?.(input.message, input.emoji, {
         sceneType: input.sceneType,
         channelId: input.channelId,
@@ -944,7 +948,7 @@ export class ImRuntime implements MessageGateway {
     readonly message: MessageRef;
     readonly reactionId: string;
   }): Promise<void> {
-    await this.#withEndpointControl(input.adapter, input.endpointKey, (control) =>
+    await this.#withEndpointControl(input.adapter, input.endpointKey, 'reaction', (control) =>
       control.removeReaction?.(
         input.message,
         input.reactionId,
@@ -957,7 +961,7 @@ export class ImRuntime implements MessageGateway {
     readonly endpointKey: string;
     readonly message: MessageRef;
   }): Promise<void> {
-    await this.#withEndpointControl(input.adapter, input.endpointKey, (control) =>
+    await this.#withEndpointControl(input.adapter, input.endpointKey, 'recall', (control) =>
       control.recall?.(input.message), undefined);
   }
 
@@ -967,7 +971,7 @@ export class ImRuntime implements MessageGateway {
     readonly message: MessageRef;
     readonly content: unknown;
   }): Promise<string | null> {
-    return this.#withEndpointControl(input.adapter, input.endpointKey, (control) =>
+    return this.#withEndpointControl(input.adapter, input.endpointKey, 'edit', (control) =>
       control.edit?.(input.message, input.content) ?? null,
     null);
   }
@@ -978,13 +982,14 @@ export class ImRuntime implements MessageGateway {
     readonly conversation: ConversationRef;
     readonly active?: boolean;
   }): Promise<void> {
-    await this.#withEndpointControl(input.adapter, input.endpointKey, (control) =>
+    await this.#withEndpointControl(input.adapter, input.endpointKey, 'typing', (control) =>
       control.typing?.(input.conversation, input.active), undefined);
   }
 
   async #withEndpointControl<T>(
     adapter: string,
     endpointKey: string,
+    operation: AdapterOperation,
     run: (control: EndpointControl) => T | Promise<T>,
     fallback: T,
   ): Promise<T> {
@@ -995,8 +1000,9 @@ export class ImRuntime implements MessageGateway {
       return fallback;
     }
     try {
-      const endpoint = requireAdapters(lease.value).instance(adapter, endpointKey);
-      const control = endpointControlOf(endpoint);
+      const index = requireAdapters(lease.value);
+      const id = index.resolve(adapter, endpointKey);
+      const control = id ? index.control(id, operation) : undefined;
       return control ? await run(control) : fallback;
     } finally {
       lease.release();

--- a/packages/im/core/tests/plugin-runtime/im-runtime.test.ts
+++ b/packages/im/core/tests/plugin-runtime/im-runtime.test.ts
@@ -17,6 +17,7 @@ import {
   AdapterIndex,
   adapterFeatureId,
   defineAdapter,
+  type AdapterOperation,
   type EndpointControl,
   type EndpointManagement,
 } from '@zhin.js/adapter';
@@ -936,7 +937,10 @@ describe('IM Runtime', () => {
         calls.push(`typing:${target}:${String(active)}`);
       },
     };
-    const fixture = await createFixture([], [], undefined, undefined, undefined, { endpointControl: control });
+    const fixture = await createFixture([], [], undefined, undefined, undefined, {
+      endpointControl: control,
+      adapterOperations: ['recall', 'edit', 'reaction', 'typing'],
+    });
     const conversation = {
       endpoint: { id: String(fixture.adapter.id), adapter: String(rootPluginId()) },
       kind: 'group' as const,
@@ -977,7 +981,7 @@ describe('IM Runtime', () => {
       undefined,
       undefined,
       undefined,
-      { endpointControl: control },
+      { endpointControl: control, adapterOperations: ['recall'] },
     );
     let disposed = false;
     fixture.store.commit(0, {
@@ -1011,6 +1015,30 @@ describe('IM Runtime', () => {
     release();
     await recalling;
     await vi.waitFor(() => expect(disposed).toBe(true));
+    await fixture.adapters.stop();
+    await fixture.store.close();
+  });
+
+  it('does not execute control methods added outside the declared capability set', async () => {
+    const calls: string[] = [];
+    const control: EndpointControl = {};
+    const fixture = await createFixture([], [], undefined, undefined, undefined, {
+      endpointControl: control,
+    });
+    control.recall = async () => { calls.push('recall'); };
+    const conversation = {
+      endpoint: { id: String(fixture.adapter.id), adapter: String(rootPluginId()) },
+      kind: 'private' as const,
+      id: 'room-1',
+    };
+
+    await fixture.im.recallEndpointMessage({
+      adapter: 'memory',
+      endpointKey: 'memory',
+      message: { conversation, id: 'message-1' },
+    });
+
+    expect(calls).toEqual([]);
     await fixture.adapters.stop();
     await fixture.store.close();
   });
@@ -1061,8 +1089,10 @@ describe('IM Runtime', () => {
       source: '/adapters/icqq.ts',
       definition: defineAdapter({
         capabilities: ['inbound', 'outbound'],
+        operations: ['recall'],
         create: () => ({
           name: '111111',
+          control: { recall: async () => undefined },
           management: {
             async listFriends() { return []; },
             async listGroups() { return []; },
@@ -1107,6 +1137,7 @@ describe('IM Runtime', () => {
       adapter: 'icqq',
       connected: true,
       status: 'online',
+      operations: ['recall'],
       managementCapabilities: ['listFriends', 'listGroups', 'kickGroupMember'],
     })]);
     // tree 仅 root → plugins=0；endpoints 与 listEndpoints 对齐
@@ -1121,6 +1152,7 @@ describe('IM Runtime', () => {
       adapter: 'icqq',
       connected: true,
       status: 'online',
+      operations: ['recall'],
       managementCapabilities: ['listFriends', 'listGroups', 'kickGroupMember'],
     }));
     // 用 live name 解析（console endpoint.info 路径）
@@ -1675,6 +1707,7 @@ async function createFixture(
     middleware?: boolean;
     adapterSegments?: { interactive?: 'native' | 'text'; outboundMedia?: readonly ('url' | 'path' | 'base64' | 'upload')[] };
     adapterCapabilities?: readonly ('inbound' | 'outbound')[];
+    adapterOperations?: readonly AdapterOperation[];
     endpointSend?: (request: unknown) => string;
     endpointControl?: EndpointControl;
     endpointManagement?: EndpointManagement;
@@ -1690,6 +1723,7 @@ async function createFixture(
     source: '/adapters/memory.ts',
     definition: defineAdapter({
       capabilities: options?.adapterCapabilities ?? ['inbound', 'outbound'],
+      ...(options?.adapterOperations ? { operations: options.adapterOperations } : {}),
       ...(options?.adapterSegments ? { segments: options.adapterSegments } : {}),
       create: () => ({
         ...(options?.endpointControl ? { control: options.endpointControl } : {}),

--- a/plugins/adapters/discord/adapters/discord.ts
+++ b/plugins/adapters/discord/adapters/discord.ts
@@ -27,7 +27,9 @@ export type {
 
 export default defineAdapter<DiscordAdapterConfig>({
   capabilities: ['inbound', 'outbound'],
-  operations: ['recall'],
+  operations: (context) => context.config.connection === 'interactions'
+    ? ['recall']
+    : ['recall', 'reaction'],
   // 媒体 url 直发或由 AttachmentBuilder 物化本地文件上传；message components 原生按钮承载交互段。
   segments: {
     outboundMedia: ['url', 'upload'],

--- a/plugins/adapters/discord/tests/discord-runtime.test.ts
+++ b/plugins/adapters/discord/tests/discord-runtime.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it, vi, afterEach } from 'vitest';
-import { createEndpointRuntimeState, listEndpointManagementCapabilities } from 'zhin.js/adapter';
+import {
+  createEndpointRuntimeState,
+  listEndpointManagementCapabilities,
+  resolveAdapterOperations,
+} from 'zhin.js/adapter';
 import { discordRuntimeStateToken } from '../src/discord-runtime-state.js';
 import { generateKeyPairSync, sign as cryptoSign } from 'node:crypto';
 import { createHttpHost, httpHostToken } from '@zhin.js/host-http';
@@ -339,6 +343,15 @@ describe('discord protocol helpers', () => {
     expect(formatOutboundBody([
       { type: 'markdown', data: { content: '# Title\n\n**important**' } },
     ])).toEqual({ content: '# Title\n\n**important**' });
+  });
+
+  it('declares reaction only for the gateway Endpoint mode', () => {
+    expect(resolveAdapterOperations(defineDiscordAdapter, {
+      config: { connection: 'gateway' },
+    } as never)).toEqual(['recall', 'reaction']);
+    expect(resolveAdapterOperations(defineDiscordAdapter, {
+      config: { connection: 'interactions' },
+    } as never)).toEqual(['recall']);
   });
 
   it('maps canonical MediaRef media to outbound files and drops unusable media with a warn', () => {

--- a/plugins/adapters/kook/adapters/kook.ts
+++ b/plugins/adapters/kook/adapters/kook.ts
@@ -27,6 +27,7 @@ export type { CreateKookClient, KookClientTransport } from '../src/ws.js';
 
 export default defineAdapter<KookAdapterConfig>({
   capabilities: ['inbound', 'outbound'],
+  operations: ['recall'],
   // KOOK 图片消息消费远程 URL；KMarkdown 由 endpoint codec 原生消费；
   // 无按钮交互面，交互段降级纯文本。
   segments: {

--- a/plugins/adapters/kook/src/endpoint.ts
+++ b/plugins/adapters/kook/src/endpoint.ts
@@ -2,12 +2,14 @@
  * KookEndpoint — lifecycle, outbound, admit, OpenAPI helpers for agent tools.
  */
 import { Client } from 'kook-client';
-import type {
-  EndpointChannel,
-  EndpointGroup,
-  EndpointInstance,
-  EndpointManagement,
-  EndpointSendRequest,
+import {
+  createRecallEndpointControl,
+  type EndpointControl,
+  type EndpointChannel,
+  type EndpointGroup,
+  type EndpointInstance,
+  type EndpointManagement,
+  type EndpointSendRequest,
 } from 'zhin.js/adapter';
 import type { MessageGateway, SideEventGateway } from '@zhin.js/core/runtime';
 import type { HttpHost, HttpRouteRegistration } from '@zhin.js/host-http';
@@ -52,6 +54,7 @@ export class KookWebsocketEndpoint implements EndpointInstance {
   #started = false;
   #unregisterAgent?: () => void;
   readonly management: EndpointManagement = createKookEndpointManagement(() => this.#requireClient());
+  readonly control: EndpointControl = createRecallEndpointControl((id) => this.recallMessage(id));
 
   constructor(options: KookEndpointOptions) {
     this.#logger = getAdapterLogger('kook', options.config.id);
@@ -226,6 +229,7 @@ export class KookWebhookEndpoint implements EndpointInstance {
   #started = false;
   #unregisterAgent?: () => void;
   readonly management: EndpointManagement = createKookEndpointManagement(() => this.#requireClient());
+  readonly control: EndpointControl = createRecallEndpointControl((id) => this.recallMessage(id));
 
   constructor(options: KookWebhookEndpointOptions) {
     this.#logger = getAdapterLogger('kook', options.config.id);

--- a/plugins/adapters/lark/adapters/lark.ts
+++ b/plugins/adapters/lark/adapters/lark.ts
@@ -16,6 +16,7 @@ export type { LarkEndpointOptions, LarkFetch } from '../src/endpoint.js';
 
 export default defineAdapter<LarkAdapterConfig>({
   capabilities: ['inbound', 'outbound'],
+  operations: ['recall'],
   // image 段 canonical MediaRef 经 /im/v1/images 物化为 image_key
   // （base64 解码 / path 读盘 / url 下载后上传，kind=file 平台引用直通）；
   // canonical Markdown 由 endpoint codec 转为 lark_md 消息卡片；

--- a/plugins/adapters/lark/src/endpoint.ts
+++ b/plugins/adapters/lark/src/endpoint.ts
@@ -3,7 +3,14 @@
  */
 import { readFile } from 'node:fs/promises';
 import { basename } from 'node:path';
-import type { EndpointGroup, EndpointInstance, EndpointManagement, EndpointSendRequest } from 'zhin.js/adapter';
+import {
+  createRecallEndpointControl,
+  type EndpointControl,
+  type EndpointGroup,
+  type EndpointInstance,
+  type EndpointManagement,
+  type EndpointSendRequest,
+} from 'zhin.js/adapter';
 import type { MessageGateway, SideEventGateway } from '@zhin.js/core/runtime';
 import type { HttpHost, HttpRouteRegistration } from '@zhin.js/host-http';
 import { formatCompact, getAdapterLogger } from '@zhin.js/logger';
@@ -86,6 +93,7 @@ export class LarkEndpoint implements EndpointInstance {
       { member_id_type: 'open_id' },
     ),
   });
+  readonly control: EndpointControl = createRecallEndpointControl((id) => this.recallMessage(id));
   #routeReleases: HttpRouteRegistration[] = [];
   #accessToken: AccessToken = { token: '', expires_in: 0, timestamp: 0 };
   #refreshPromise: Promise<string> | null = null;

--- a/plugins/adapters/milky/adapters/milky.ts
+++ b/plugins/adapters/milky/adapters/milky.ts
@@ -34,6 +34,7 @@ export type {
 
 export default defineAdapter<MilkyAdapterConfig>({
   capabilities: ['inbound', 'outbound'],
+  operations: ['recall'],
   // Milky 协议资源 uri 消费 http(s):// 与 base64:// 形式；无卡片交互面，交互段降级纯文本。
   segments: {
     outboundMedia: ['url', 'base64'],

--- a/plugins/adapters/milky/src/sse-endpoint.ts
+++ b/plugins/adapters/milky/src/sse-endpoint.ts
@@ -2,8 +2,10 @@
  * Milky SSE client endpoint — GET text/event-stream on /event.
  */
 import {
+  createRecallEndpointControl,
   createEndpointLifecycle,
   type EndpointConnectHandle,
+  type EndpointControl,
   type EndpointInstance,
   type EndpointLifecycle,
   type EndpointManagement,
@@ -58,6 +60,7 @@ export class MilkySseEndpoint implements EndpointInstance {
   readonly #options: MilkySseEndpointOptions;
   readonly #callApi: typeof callApi;
   readonly management: EndpointManagement = createMilkyEndpointManagement(this);
+  readonly control: EndpointControl = createRecallEndpointControl((id) => this.recallMessage(id));
   readonly #lifecycle: EndpointLifecycle;
   #stream?: SseClientHandle;
   #open = false;

--- a/plugins/adapters/milky/src/webhook-endpoint.ts
+++ b/plugins/adapters/milky/src/webhook-endpoint.ts
@@ -2,10 +2,12 @@
  * Milky webhook endpoint — httpHostToken POST inbound + baseUrl HTTP API outbound.
  */
 import type { IncomingMessage, ServerResponse } from 'node:http';
-import type {
-  EndpointInstance,
-  EndpointManagement,
-  EndpointSendRequest,
+import {
+  createRecallEndpointControl,
+  type EndpointControl,
+  type EndpointInstance,
+  type EndpointManagement,
+  type EndpointSendRequest,
 } from 'zhin.js/adapter';
 import type { MessageGateway, SideEventGateway } from '@zhin.js/core/runtime';
 import type { HttpHost, HttpRouteRegistration } from '@zhin.js/host-http';
@@ -48,6 +50,7 @@ export class MilkyWebhookEndpoint implements EndpointInstance {
   readonly #options: MilkyWebhookEndpointOptions;
   readonly #callApi: typeof callApi;
   readonly management: EndpointManagement = createMilkyEndpointManagement(this);
+  readonly control: EndpointControl = createRecallEndpointControl((id) => this.recallMessage(id));
   #routeReleases: HttpRouteRegistration[] = [];
   #open = false;
   #started = false;

--- a/plugins/adapters/milky/src/ws-endpoint.ts
+++ b/plugins/adapters/milky/src/ws-endpoint.ts
@@ -3,8 +3,10 @@
  */
 import WebSocket from 'ws';
 import {
+  createRecallEndpointControl,
   createEndpointLifecycle,
   type EndpointConnectHandle,
+  type EndpointControl,
   type EndpointInstance,
   type EndpointLifecycle,
   type EndpointManagement,
@@ -56,6 +58,7 @@ export class MilkyWsEndpoint implements EndpointInstance {
   readonly #options: MilkyWsEndpointOptions;
   readonly #callApi: typeof callApi;
   readonly management: EndpointManagement = createMilkyEndpointManagement(this);
+  readonly control: EndpointControl = createRecallEndpointControl((id) => this.recallMessage(id));
   readonly #lifecycle: EndpointLifecycle;
   #ws?: MilkyWsSocket;
   #open = false;

--- a/plugins/adapters/milky/src/wss-endpoint.ts
+++ b/plugins/adapters/milky/src/wss-endpoint.ts
@@ -2,10 +2,12 @@
  * Milky reverse WSS endpoint — httpHostToken WS upgrade inbound + baseUrl HTTP API outbound.
  */
 import { clearInterval } from 'node:timers';
-import type {
-  EndpointInstance,
-  EndpointManagement,
-  EndpointSendRequest,
+import {
+  createRecallEndpointControl,
+  type EndpointControl,
+  type EndpointInstance,
+  type EndpointManagement,
+  type EndpointSendRequest,
 } from 'zhin.js/adapter';
 import type { MessageGateway, SideEventGateway } from '@zhin.js/core/runtime';
 import type { HttpHost, WsConnection } from '@zhin.js/host-http';
@@ -51,6 +53,7 @@ export class MilkyWssEndpoint implements EndpointInstance {
   readonly #options: MilkyWssEndpointOptions;
   readonly #callApi: typeof callApi;
   readonly management: EndpointManagement = createMilkyEndpointManagement(this);
+  readonly control: EndpointControl = createRecallEndpointControl((id) => this.recallMessage(id));
   #ws?: MilkyWsSocket;
   #wsRelease?: () => void;
   #heartbeatTimer?: NodeJS.Timeout;

--- a/plugins/adapters/napcat/adapters/napcat.ts
+++ b/plugins/adapters/napcat/adapters/napcat.ts
@@ -32,6 +32,7 @@ declare module '@zhin.js/core' {
 
 export default defineAdapter<NapCatAdapterConfig>({
   capabilities: ['inbound', 'outbound'],
+  operations: ['recall'],
   // OneBot file 参数原生消费 url / base64:// 媒体，file:// 本地路径由 NapCat 侧读盘；
   // 无卡片交互面，交互段降级纯文本。
   segments: {

--- a/plugins/adapters/napcat/src/http-endpoint.ts
+++ b/plugins/adapters/napcat/src/http-endpoint.ts
@@ -2,7 +2,13 @@
  * NapCat HTTP endpoint — POST inbound events + HTTP API outbound.
  */
 import type { IncomingMessage, ServerResponse } from 'node:http';
-import type { EndpointInstance, EndpointManagement, EndpointSendRequest } from 'zhin.js/adapter';
+import {
+  createRecallEndpointControl,
+  type EndpointControl,
+  type EndpointInstance,
+  type EndpointManagement,
+  type EndpointSendRequest,
+} from 'zhin.js/adapter';
 import type { MessageGateway, SideEventGateway } from '@zhin.js/core/runtime';
 import type { HttpHost, HttpRouteRegistration } from '@zhin.js/host-http';
 import { formatCompact, getAdapterLogger } from '@zhin.js/logger';
@@ -49,6 +55,7 @@ export class NapCatHttpEndpoint implements EndpointInstance {
   readonly #options: NapCatHttpEndpointOptions;
   readonly #inboundDeduper = new InboundMessageDeduper();
   readonly management: EndpointManagement = createNapCatEndpointManagement(this);
+  readonly control: EndpointControl = createRecallEndpointControl((id) => this.recallMessage(id));
   readonly content = createNapCatContentPort((action, params) => this.callApi(action, params));
   readonly #callHttpAction: typeof callNapCatHttpAction;
   #routeReleases: HttpRouteRegistration[] = [];

--- a/plugins/adapters/napcat/src/ws-endpoint.ts
+++ b/plugins/adapters/napcat/src/ws-endpoint.ts
@@ -3,8 +3,10 @@
  */
 import WebSocket from 'ws';
 import {
+  createRecallEndpointControl,
   createEndpointLifecycle,
   type EndpointConnectHandle,
+  type EndpointControl,
   type EndpointInstance,
   type EndpointLifecycle,
   type EndpointManagement,
@@ -64,6 +66,7 @@ export class NapCatWsEndpoint implements EndpointInstance {
   readonly #options: NapCatWsEndpointOptions;
   readonly #inboundDeduper = new InboundMessageDeduper();
   readonly management: EndpointManagement = createNapCatEndpointManagement(this);
+  readonly control: EndpointControl = createRecallEndpointControl((id) => this.recallMessage(id));
   readonly content = createNapCatContentPort((action, params) => this.callApi(action, params));
   readonly #lifecycle: EndpointLifecycle;
   #ws?: NapCatWsSocket;

--- a/plugins/adapters/napcat/src/wss-endpoint.ts
+++ b/plugins/adapters/napcat/src/wss-endpoint.ts
@@ -2,7 +2,13 @@
  * NapCat reverse WSS endpoint — accepts inbound WebSocket from NapCat.
  */
 import { clearInterval } from 'node:timers';
-import type { EndpointInstance, EndpointManagement, EndpointSendRequest } from 'zhin.js/adapter';
+import {
+  createRecallEndpointControl,
+  type EndpointControl,
+  type EndpointInstance,
+  type EndpointManagement,
+  type EndpointSendRequest,
+} from 'zhin.js/adapter';
 import type { MessageGateway, SideEventGateway } from '@zhin.js/core/runtime';
 import type { HttpHost, WsConnection } from '@zhin.js/host-http';
 import { formatCompact, getAdapterLogger } from '@zhin.js/logger';
@@ -56,6 +62,7 @@ export class NapCatWssEndpoint implements EndpointInstance {
   readonly #options: NapCatWssEndpointOptions;
   readonly #inboundDeduper = new InboundMessageDeduper();
   readonly management: EndpointManagement = createNapCatEndpointManagement(this);
+  readonly control: EndpointControl = createRecallEndpointControl((id) => this.recallMessage(id));
   readonly content = createNapCatContentPort((action, params) => this.callApi(action, params));
   #ws?: NapCatWsSocket;
   #wsRelease?: () => void;

--- a/plugins/adapters/onebot11/adapters/onebot11.ts
+++ b/plugins/adapters/onebot11/adapters/onebot11.ts
@@ -26,6 +26,7 @@ declare module '@zhin.js/core' {
 
 export default defineAdapter<OneBot11AdapterConfig>({
   capabilities: ['inbound', 'outbound'],
+  operations: ['recall'],
   // OneBot file 参数原生消费 url / base64:// 媒体；无卡片交互面，交互段降级纯文本。
   segments: {
     outboundMedia: ['url', 'base64'],

--- a/plugins/adapters/onebot11/src/ws-endpoint.ts
+++ b/plugins/adapters/onebot11/src/ws-endpoint.ts
@@ -3,8 +3,10 @@
  */
 import WebSocket from 'ws';
 import {
+  createRecallEndpointControl,
   createEndpointLifecycle,
   type EndpointConnectHandle,
+  type EndpointControl,
   type EndpointInstance,
   type EndpointLifecycle,
   type EndpointManagement,
@@ -57,6 +59,7 @@ export class OneBot11WsEndpoint implements EndpointInstance {
 
   readonly #options: OneBot11WsEndpointOptions;
   readonly management: EndpointManagement = createOneBot11EndpointManagement(this);
+  readonly control: EndpointControl = createRecallEndpointControl((id) => this.recallMessage(id));
   readonly content = createOneBot11ContentPort((action, params) => this.callApi(action, params));
   readonly #lifecycle: EndpointLifecycle;
   #ws?: OneBot11WsSocket;

--- a/plugins/adapters/onebot11/src/wss-endpoint.ts
+++ b/plugins/adapters/onebot11/src/wss-endpoint.ts
@@ -2,7 +2,13 @@
  * OneBot11 reverse WSS endpoint — accepts inbound WebSocket from OneBot implementation.
  */
 import { clearInterval } from 'node:timers';
-import type { EndpointInstance, EndpointManagement, EndpointSendRequest } from 'zhin.js/adapter';
+import {
+  createRecallEndpointControl,
+  type EndpointControl,
+  type EndpointInstance,
+  type EndpointManagement,
+  type EndpointSendRequest,
+} from 'zhin.js/adapter';
 import type { MessageGateway, SideEventGateway } from '@zhin.js/core/runtime';
 import type { HttpHost, WsConnection } from '@zhin.js/host-http';
 import { formatCompact, getAdapterLogger } from '@zhin.js/logger';
@@ -49,6 +55,7 @@ export class OneBot11WssEndpoint implements EndpointInstance {
 
   readonly #options: OneBot11WssEndpointOptions;
   readonly management: EndpointManagement = createOneBot11EndpointManagement(this);
+  readonly control: EndpointControl = createRecallEndpointControl((id) => this.recallMessage(id));
   readonly content = createOneBot11ContentPort((action, params) => this.callApi(action, params));
   #ws?: OneBot11WsSocket;
   #wsRelease?: () => void;

--- a/plugins/adapters/onebot12/adapters/onebot12.ts
+++ b/plugins/adapters/onebot12/adapters/onebot12.ts
@@ -29,6 +29,7 @@ declare module '@zhin.js/core' {
 
 export default defineAdapter<OneBot12AdapterConfig>({
   capabilities: ['inbound', 'outbound'],
+  operations: ['recall'],
   // 媒体段经 upload_file 物化为 file_id（spec 正式投递）；上传失败降级扩展字段透传。
   // 无卡片交互面，交互段降级纯文本。
   segments: {

--- a/plugins/adapters/onebot12/src/webhook.ts
+++ b/plugins/adapters/onebot12/src/webhook.ts
@@ -2,7 +2,13 @@
  * OneBot12 HTTP webhook endpoint — POST inbound + api_url outbound.
  */
 import type { IncomingMessage, ServerResponse } from 'node:http';
-import type { EndpointInstance, EndpointManagement, EndpointSendRequest } from 'zhin.js/adapter';
+import {
+  createRecallEndpointControl,
+  type EndpointControl,
+  type EndpointInstance,
+  type EndpointManagement,
+  type EndpointSendRequest,
+} from 'zhin.js/adapter';
 import type { MessageGateway, SideEventGateway } from '@zhin.js/core/runtime';
 import type { HttpHost, HttpRouteRegistration } from '@zhin.js/host-http';
 import { formatCompact, getLogger } from '@zhin.js/logger';
@@ -40,6 +46,7 @@ export interface OneBot12WebhookEndpointOptions {
 export class OneBot12WebhookEndpoint implements EndpointInstance {
   readonly #options: OneBot12WebhookEndpointOptions;
   readonly management: EndpointManagement = createOneBot12EndpointManagement(this);
+  readonly control: EndpointControl = createRecallEndpointControl((id) => this.recallMessage(id));
   readonly content = createOneBot12ContentPort((action, params) => this.callApi(action, params));
   readonly #callAction: typeof callOneBot12Action;
   #routeReleases: HttpRouteRegistration[] = [];
@@ -111,6 +118,11 @@ export class OneBot12WebhookEndpoint implements EndpointInstance {
       messageId,
     }));
     return messageId;
+  }
+
+  async recallMessage(messageId: string): Promise<void> {
+    if (!messageId) return;
+    await this.callApi('delete_message', { message_id: messageId });
   }
 
   /** Public API for management surface / callers；webhook 模式走 api_url。 */

--- a/plugins/adapters/onebot12/src/ws-endpoint.ts
+++ b/plugins/adapters/onebot12/src/ws-endpoint.ts
@@ -4,8 +4,10 @@
 import WebSocket from 'ws';
 import { clearTimeout } from 'node:timers';
 import {
+  createRecallEndpointControl,
   createEndpointLifecycle,
   type EndpointConnectHandle,
+  type EndpointControl,
   type EndpointInstance,
   type EndpointLifecycle,
   type EndpointManagement,
@@ -55,6 +57,7 @@ export class OneBot12WsEndpoint implements EndpointInstance {
 
   readonly #options: OneBot12WsEndpointOptions;
   readonly management: EndpointManagement = createOneBot12EndpointManagement(this);
+  readonly control: EndpointControl = createRecallEndpointControl((id) => this.recallMessage(id));
   readonly content = createOneBot12ContentPort((action, params) => this.callApi(action, params));
   readonly #lifecycle: EndpointLifecycle;
   #ws?: OneBot12WsSocket;

--- a/plugins/adapters/onebot12/src/wss-endpoint.ts
+++ b/plugins/adapters/onebot12/src/wss-endpoint.ts
@@ -2,7 +2,13 @@
  * OneBot12 reverse WSS endpoint — accepts inbound WebSocket from OneBot implementation.
  */
 import { clearInterval } from 'node:timers';
-import type { EndpointInstance, EndpointManagement, EndpointSendRequest } from 'zhin.js/adapter';
+import {
+  createRecallEndpointControl,
+  type EndpointControl,
+  type EndpointInstance,
+  type EndpointManagement,
+  type EndpointSendRequest,
+} from 'zhin.js/adapter';
 import type { MessageGateway, SideEventGateway } from '@zhin.js/core/runtime';
 import type { HttpHost, WsConnection } from '@zhin.js/host-http';
 import { formatCompact, getAdapterLogger } from '@zhin.js/logger';
@@ -41,6 +47,7 @@ export class OneBot12WssEndpoint implements EndpointInstance {
 
   readonly #options: OneBot12WssEndpointOptions;
   readonly management: EndpointManagement = createOneBot12EndpointManagement(this);
+  readonly control: EndpointControl = createRecallEndpointControl((id) => this.recallMessage(id));
   readonly content = createOneBot12ContentPort((action, params) => this.callApi(action, params));
   #ws?: OneBot12WsSocket;
   #wsRelease?: () => void;

--- a/plugins/adapters/qq/adapters/qq.ts
+++ b/plugins/adapters/qq/adapters/qq.ts
@@ -32,6 +32,7 @@ declare module '@zhin.js/core' {
 
 export default defineAdapter<QqAdapterConfig>({
   capabilities: ['inbound', 'outbound'],
+  operations: ['recall'],
   // 媒体 url 直发，base64/path 由 SDK formatMediaData 物化走 /files 上传；
   // markdown/keyboard 原生按钮承载交互段。
   segments: {

--- a/plugins/adapters/qq/src/endpoint.ts
+++ b/plugins/adapters/qq/src/endpoint.ts
@@ -1,11 +1,13 @@
 /**
  * QQ endpoints — lifecycle, outbound, admit, agent tool surface.
  */
-import type {
-  EndpointChannel,
-  EndpointInstance,
-  EndpointManagement,
-  EndpointSendRequest,
+import {
+  createRecallEndpointControl,
+  type EndpointControl,
+  type EndpointChannel,
+  type EndpointInstance,
+  type EndpointManagement,
+  type EndpointSendRequest,
 } from 'zhin.js/adapter';
 import type { MessageGateway, SideEventGateway } from '@zhin.js/core/runtime';
 import type { HttpHost } from '@zhin.js/host-http';
@@ -64,6 +66,7 @@ export class QqWebsocketEndpoint implements EndpointInstance {
   #started = false;
   #unregisterAgent?: () => void;
   readonly management: EndpointManagement = createQqEndpointManagement(this);
+  readonly control: EndpointControl = createRecallEndpointControl((id) => this.recallMessage(id));
 
   constructor(options: QqEndpointOptions) {
     this.#logger = getAdapterLogger('qq', options.config.id);
@@ -291,6 +294,7 @@ export class QqHttpEndpoint implements EndpointInstance {
   #started = false;
   #unregisterAgent?: () => void;
   readonly management: EndpointManagement = createQqEndpointManagement(this);
+  readonly control: EndpointControl = createRecallEndpointControl((id) => this.recallMessage(id));
 
   constructor(options: QqHttpEndpointOptions) {
     this.#logger = getAdapterLogger('qq', options.config.id);

--- a/plugins/adapters/satori/adapters/satori.ts
+++ b/plugins/adapters/satori/adapters/satori.ts
@@ -22,6 +22,7 @@ export type {
 
 export default defineAdapter<SatoriAdapterConfig>({
   capabilities: ['inbound', 'outbound'],
+  operations: ['recall'],
   // Satori 协议 img/file 元素消费 url 与 base64 内联数据；无卡片交互面，交互段降级纯文本。
   segments: {
     outboundMedia: ['url', 'base64'],

--- a/plugins/adapters/satori/src/endpoint.ts
+++ b/plugins/adapters/satori/src/endpoint.ts
@@ -5,6 +5,7 @@ import {
   createEndpointLifecycle,
   type EndpointChannel,
   type EndpointConnectHandle,
+  type EndpointControl,
   type EndpointGroup,
   type EndpointInstance,
   type EndpointLifecycle,
@@ -66,6 +67,9 @@ export class SatoriWsEndpoint implements EndpointInstance {
   readonly management: EndpointManagement = createSatoriEndpointManagement(
     (resource, method, params) => this.#api(resource, method, params),
   );
+  readonly control: EndpointControl = Object.freeze<EndpointControl>({
+    recall: (message) => this.recall(message.id, message.conversation.id),
+  });
 
   constructor(options: SatoriWsEndpointOptions) {
     this.#logger = getAdapterLogger('satori', options.config.id);
@@ -168,10 +172,10 @@ export class SatoriWsEndpoint implements EndpointInstance {
     });
   }
 
-  async recall(id: string): Promise<void> {
+  async recall(id: string, fallbackChannelId?: string): Promise<void> {
     const { channelId, messageId } = parseMessageRef(id);
     await this.#api('message', 'delete', {
-      channel_id: channelId,
+      channel_id: channelId || fallbackChannelId || '',
       message_id: messageId,
     });
   }
@@ -325,6 +329,9 @@ export class SatoriWebhookEndpoint implements EndpointInstance {
   readonly management: EndpointManagement = createSatoriEndpointManagement(
     (resource, method, params) => this.#api(resource, method, params),
   );
+  readonly control: EndpointControl = Object.freeze<EndpointControl>({
+    recall: (message) => this.recall(message.id, message.conversation.id),
+  });
 
   constructor(options: SatoriWebhookEndpointOptions) {
     this.#logger = getAdapterLogger('satori', options.config.id);
@@ -425,10 +432,10 @@ export class SatoriWebhookEndpoint implements EndpointInstance {
     });
   }
 
-  async recall(id: string): Promise<void> {
+  async recall(id: string, fallbackChannelId?: string): Promise<void> {
     const { channelId, messageId } = parseMessageRef(id);
     await this.#api('message', 'delete', {
-      channel_id: channelId,
+      channel_id: channelId || fallbackChannelId || '',
       message_id: messageId,
     });
   }

--- a/plugins/adapters/satori/tests/satori-runtime.test.ts
+++ b/plugins/adapters/satori/tests/satori-runtime.test.ts
@@ -349,6 +349,35 @@ describe('satori plugin runtime adapter', () => {
     await endpoint.stop();
   });
 
+  it('maps canonical recall control to Satori message.delete', async () => {
+    const callApi = vi.fn(async () => undefined);
+    const endpoint = new SatoriWsEndpoint({
+      id: capabilityId(rootPluginId(), adapterFeature, 'satori'),
+      gateway: {
+        receive: vi.fn(async () => Object.freeze({ matched: false })),
+        send: vi.fn(async () => 'sent'),
+      },
+      config: baseConfig,
+      createWebSocket: createWsFactory(createMockSocket()),
+      callApi,
+    });
+    endpoint.setLogin({ platform: 'test', user: { id: 'bot-1' } });
+    const conversation = {
+      endpoint: { id: 'test-endpoint', adapter: 'satori' },
+      kind: 'group' as const,
+      id: 'ch-9',
+    };
+
+    await endpoint.control.recall?.({ conversation, id: 'inbound-1' });
+
+    expect(callApi).toHaveBeenCalledWith(
+      expect.objectContaining({ platform: 'test', userId: 'bot-1' }),
+      'message',
+      'delete',
+      { channel_id: 'ch-9', message_id: 'inbound-1' },
+    );
+  });
+
   it('creates webhook endpoint when httpHostToken provided', async () => {
     const http = createHttpHost({ host: '127.0.0.1', port: 0 });
     hosts.push(http);

--- a/plugins/adapters/slack/adapters/slack.ts
+++ b/plugins/adapters/slack/adapters/slack.ts
@@ -16,6 +16,7 @@ export type { SlackEndpointOptions, SlackSocketLike, SlackWebClientLike } from '
 
 export default defineAdapter<SlackAdapterConfig>({
   capabilities: ['inbound', 'outbound'],
+  operations: ['recall', 'edit', 'reaction'],
   // 媒体段（canonical MediaRef）：kind=url 直发（image 走 attachment image_url，
   // 其余拉取后上传）；kind=base64 解码后经 files.uploadV2 上传；kind=path 读盘上传；
   // kind=file 无 Slack 对应物，丢弃留痕。Block Kit 原生按钮承载交互段。

--- a/plugins/adapters/slack/src/endpoint.ts
+++ b/plugins/adapters/slack/src/endpoint.ts
@@ -6,6 +6,7 @@ import { WebClient } from '@slack/web-api';
 import type {
   EndpointFriend,
   EndpointGroup,
+  EndpointControl,
   EndpointInstance,
   EndpointManagement,
   EndpointSendRequest,
@@ -116,6 +117,31 @@ export class SlackEndpoint implements EndpointInstance, SlackWebhookHandler {
   #started = false;
   #unregisterAgent?: () => void;
   readonly management: EndpointManagement = createSlackEndpointManagement(this);
+  readonly control: EndpointControl = Object.freeze<EndpointControl>({
+    recall: async (message) => {
+      const ref = this.resolveMessageRef(message.id, message.conversation.id);
+      if (!ref || !this.#client) return;
+      await this.#client.chat.delete(ref);
+    },
+    edit: async (message, content) => {
+      const ref = this.resolveMessageRef(message.id, message.conversation.id);
+      if (!ref) return null;
+      await this.editMessage(ref.channel, ref.ts, content);
+      return message.id;
+    },
+    addReaction: async (message, emoji) => {
+      const ref = this.resolveMessageRef(message.id, message.conversation.id);
+      if (!ref) return null;
+      const reaction = normalizeSlackReactionName(emoji);
+      await this.addReaction(ref.channel, ref.ts, reaction);
+      return reaction;
+    },
+    removeReaction: async (message, reactionId) => {
+      const ref = this.resolveMessageRef(message.id, message.conversation.id);
+      if (!ref) return;
+      await this.removeReaction(ref.channel, ref.ts, reactionId);
+    },
+  });
 
   constructor(options: SlackEndpointOptions) {
     this.#logger = getAdapterLogger('slack', options.config.id);

--- a/plugins/adapters/slack/tests/slack-runtime.test.ts
+++ b/plugins/adapters/slack/tests/slack-runtime.test.ts
@@ -257,6 +257,46 @@ describe('slack plugin runtime adapter (socket)', () => {
     await endpoint.stop();
   });
 
+  it('maps canonical message controls to Slack chat and reaction APIs', async () => {
+    const client = mockClient();
+    const endpoint = new SlackEndpoint({
+      id: capabilityId(rootPluginId(), adapterFeature, 'slack'),
+      gateway: {
+        receive: vi.fn(async () => Object.freeze({ matched: false })),
+        send: vi.fn(async () => 'sent'),
+      },
+      config: socketConfig,
+      createClient: () => client,
+      createSocket: () => mockSocket(),
+    });
+    await endpoint.start();
+    const conversation = {
+      endpoint: { id: 'test-endpoint', adapter: 'slack' },
+      kind: 'channel' as const,
+      id: 'C001',
+    };
+    const message = { conversation, id: '1700000001.000000' };
+
+    await endpoint.control.recall?.(message);
+    await expect(endpoint.control.edit?.(message, 'updated')).resolves.toBe(message.id);
+    await expect(endpoint.control.addReaction?.(message, ':thumbsup:')).resolves.toBe('thumbsup');
+    await endpoint.control.removeReaction?.(message, 'thumbsup');
+
+    expect(client.chat.delete).toHaveBeenCalledWith({ channel: 'C001', ts: message.id });
+    expect(client.chat.update).toHaveBeenCalledWith(expect.objectContaining({
+      channel: 'C001',
+      ts: message.id,
+      text: 'updated',
+    }));
+    expect(client.reactions.add).toHaveBeenCalledWith({
+      channel: 'C001', timestamp: message.id, name: 'thumbsup',
+    });
+    expect(client.reactions.remove).toHaveBeenCalledWith({
+      channel: 'C001', timestamp: message.id, name: 'thumbsup',
+    });
+    await endpoint.stop();
+  });
+
   it('registers agent endpoint on start', async () => {
     const endpoint = new SlackEndpoint({
       id: capabilityId(rootPluginId(), adapterFeature, 'slack'),

--- a/plugins/adapters/wecom/adapters/wecom.ts
+++ b/plugins/adapters/wecom/adapters/wecom.ts
@@ -17,6 +17,7 @@ export type { WecomEndpointOptions, WecomFetch } from '../src/endpoint.js';
 
 export default defineAdapter<WecomAdapterConfig>({
   capabilities: ['inbound', 'outbound'],
+  operations: ['recall'],
   // image 段全部经 /cgi-bin/media/upload 物化为 media_id（url 下载后上传、
   // base64/path 直接上传、file 引用直用 media_id）；无卡片交互面，交互段降级纯文本。
   segments: {

--- a/plugins/adapters/wecom/src/endpoint.ts
+++ b/plugins/adapters/wecom/src/endpoint.ts
@@ -1,7 +1,12 @@
 /**
  * WecomEndpoint — lifecycle, outbound send, inbound admit, OpenAPI helpers for agent tools.
  */
-import type { EndpointInstance, EndpointSendRequest } from 'zhin.js/adapter';
+import {
+  createRecallEndpointControl,
+  type EndpointControl,
+  type EndpointInstance,
+  type EndpointSendRequest,
+} from 'zhin.js/adapter';
 import type { MessageGateway, SideEventGateway } from '@zhin.js/core/runtime';
 import type { HttpHost, HttpRouteRegistration } from '@zhin.js/host-http';
 import { formatCompact, getAdapterLogger } from '@zhin.js/logger';
@@ -59,6 +64,7 @@ export class WecomEndpoint implements EndpointInstance {
   readonly #logger!: ReturnType<typeof getAdapterLogger>;
 
   readonly #options: WecomEndpointOptions;
+  readonly control: EndpointControl = createRecallEndpointControl((id) => this.recallMessage(id));
   readonly #fetch: WecomFetch;
   #routeReleases: HttpRouteRegistration[] = [];
   #accessToken: AccessToken = { access_token: '', expires_in: 0, timestamp: 0 };

--- a/plugins/adapters/weixin-ilink/adapters/weixin-ilink.ts
+++ b/plugins/adapters/weixin-ilink/adapters/weixin-ilink.ts
@@ -21,6 +21,7 @@ export type {
 
 export default defineAdapter<WeixinIlinkAdapterConfig>({
   capabilities: ['inbound', 'outbound'],
+  operations: ['typing'],
   // 所有媒体（url 下载 / base64 落盘 / 本地 path）统一物化后走 CDN 上传（sendWeixinMediaFile），
   // 无直发面；微信无卡片交互面，交互段降级纯文本。
   segments: {

--- a/plugins/adapters/weixin-ilink/src/endpoint.ts
+++ b/plugins/adapters/weixin-ilink/src/endpoint.ts
@@ -6,6 +6,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import type {
   EndpointFriend,
+  EndpointControl,
   EndpointInstance,
   EndpointManagement,
   EndpointSendRequest,
@@ -107,6 +108,12 @@ export class WeixinIlinkEndpoint implements EndpointInstance {
   #open = false;
   #started = false;
   readonly management: EndpointManagement = createWeixinIlinkEndpointManagement(this);
+  readonly control: EndpointControl = Object.freeze<EndpointControl>({
+    typing: (conversation, active) => this.sendTypingToUser(
+      conversation.id,
+      active === false ? 2 : 1,
+    ),
+  });
 
   constructor(options: WeixinIlinkEndpointOptions) {
     this.#logger = getAdapterLogger('weixin-ilink', options.config.id);

--- a/plugins/adapters/weixin-ilink/tests/weixin-ilink-runtime.test.ts
+++ b/plugins/adapters/weixin-ilink/tests/weixin-ilink-runtime.test.ts
@@ -128,6 +128,25 @@ describe('weixin-ilink protocol helpers', () => {
 });
 
 describe('weixin-ilink plugin runtime adapter', () => {
+  it('maps canonical typing control to the iLink typing status', async () => {
+    const endpoint = new WeixinIlinkEndpoint({
+      id: capabilityId(rootPluginId(), adapterFeature, 'weixin-ilink'),
+      gateway: {
+        receive: vi.fn(async () => Object.freeze({ matched: false })),
+        send: vi.fn(async () => 'sent'),
+      },
+      config: baseConfig,
+      resolveCredentials: async () => ({ botToken: 'tok' }),
+    });
+    const sendTyping = vi.spyOn(endpoint, 'sendTypingToUser').mockResolvedValue(undefined);
+
+    await endpoint.control.typing?.(privateConversation('user-1'), true);
+    await endpoint.control.typing?.(privateConversation('user-1'), false);
+
+    expect(sendTyping).toHaveBeenNthCalledWith(1, 'user-1', 1);
+    expect(sendTyping).toHaveBeenNthCalledWith(2, 'user-1', 2);
+  });
+
   it('routes admitted messages through MessageGateway when open', async () => {
     const receive = vi.fn(async () => Object.freeze({ matched: true, value: 'ok' }));
     const gateway: MessageGateway = { receive, send: vi.fn(async () => 'sent') };

--- a/scripts/sync-adapter-docs.mjs
+++ b/scripts/sync-adapter-docs.mjs
@@ -156,6 +156,22 @@ ${buildTierTable('Advanced')}
 ## Experimental
 
 ${buildTierTable('Experimental')}
+## 统一消息操作能力
+
+消息发送由所有声明 **outbound** 的 Endpoint 支持；消息级扩展操作通过统一
+**EndpointControl** 暴露，并按每个具体 Endpoint 精确声明。Core 不探测平台 SDK 私有方法。
+
+| 操作 | 已接入平台 |
+|------|------------|
+| recall | Discord、ICQQ、KOOK、飞书、Milky、NapCat、OneBot 11/12、QQ 官方、Satori、Slack、Telegram、企业微信 |
+| edit | Slack |
+| reaction | Discord Gateway、ICQQ、Slack |
+| typing | 微信 iLink |
+
+同一适配器不同接入模式可以具有不同能力。例如 Discord Gateway 支持 reaction，
+Interactions 模式只声明 recall；Host/Console 可从 Endpoint row 的 **operations** 字段读取
+当前模式的准确能力集。
+
 ## 维护说明
 
 - **单一来源（档位）**：\`scripts/adapter-meta.mjs\`


### PR DESCRIPTION
## Summary

- resolve and validate exact message operations per concrete Endpoint
- route Core control calls through declared active Adapter capabilities
- expose operations to Host/Console and connect existing recall, edit, reaction, and typing support across platform adapters
- document the unified capability model and add a release changeset

## Validation

- 106 targeted test files passed, 1051 tests
- pnpm type-check
- pnpm check:architecture
- pnpm check:adapter-docs
- pnpm check:doc-links
- git diff --check origin/main...HEAD

## Sourcery 总结

在经过验证的能力模型下统一 Endpoint 消息操作，并在运行时和客户端层面一致地公开这些操作。

新功能：
- 向 Core、Host 和 Console 客户端公开每个具体 Endpoint 的精确消息操作能力。
- 在受支持的平台适配器之间连接撤回、编辑、回应和输入状态控制。

错误修复：
- 防止 Core 调用 Endpoint 中不可用或未明确声明的控制方法。

改进：
- 支持取决于配置的适配器连接模式操作能力，并根据已实现的 Endpoint 控制项验证能力声明。
- 通过当前激活且已声明的适配器能力路由 Core 控制调用，并提供共享的撤回控制桥接。

文档：
- 在适配器文档中记录统一的 Endpoint 操作能力模型及其平台集成。

测试：
- 增加对每个 Endpoint 的动态操作解析、声明验证、运行时门控和平台控制映射的测试覆盖。

杂项：
- 为适配器能力模型及相关软件包更新添加发布变更集。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

统一 Endpoint 消息操作能力，并在适配器运行时和客户端界面中强制执行已声明的控制项。

新功能：
- 为 Core、Host 和 Console 客户端公开每个具体 Endpoint 的精确消息操作。
- 在受支持的平台适配器中接入撤回、编辑、反应和输入状态控制，包括特定模式下的能力。

错误修复：
- 防止 Core 调用 Endpoint 不可用或未明确声明的控制项。

增强功能：
- 将适配器操作声明与经过验证的 EndpointControl 接口统一，并支持随连接模式变化的能力。
- 通过活动适配器的能力路由运行时控制调用，并提供共享的撤回控制桥接。

文档：
- 记录统一的 Endpoint 消息操作能力模型及其平台集成。

测试：
- 增加对动态操作解析、声明验证、运行时门控和平台控制映射的覆盖。

杂项：
- 为适配器能力模型及受影响的软件包添加发布变更集条目。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify Endpoint message-operation capabilities and enforce declared controls throughout the adapter runtime and client surfaces.

New Features:
- Expose precise message operations for each concrete Endpoint to Core, Host, and Console clients.
- Connect recall, edit, reaction, and typing controls across the supported platform adapters, including mode-specific capabilities.

Bug Fixes:
- Prevent Core from invoking Endpoint controls that are unavailable or not explicitly declared.

Enhancements:
- Unify adapter operation declarations with validated EndpointControl interfaces and support capabilities that vary by connection mode.
- Route runtime control calls through the active adapter capabilities and provide a shared recall-control bridge.

Documentation:
- Document the unified Endpoint message-operation capability model and its platform integrations.

Tests:
- Add coverage for dynamic operation resolution, declaration validation, runtime gating, and platform control mappings.

Chores:
- Add release changeset entries for the adapter capability model and affected packages.

</details>

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies per-Endpoint message operations and gates Core control calls through declared capabilities. Previously Core probed optional endpoint methods; now adapters declare `operations` and expose an explicit `EndpointControl`, and the runtime enforces the contract.

- Adapter API (`@zhin.js/adapter`): add `operations` (static or resolver) to definitions; `AdapterIndex` resolves and exposes exact ops per endpoint; bidirectional validation rejects undeclared or unimplemented ops; add `createRecallEndpointControl()` to bridge common recall-by-id.
- Runtime/Console (`@zhin.js/core`, `@zhin.js/console-protocol`): endpoint summaries include `operations`; Core calls control via `AdapterIndex.control(id, operation)` only when declared and active; no probing of platform SDK methods.
- Adapters: Discord declares dynamic ops by mode (Gateway: recall+reaction; Interactions: recall). Slack implements recall/edit/reaction control. KOOK/Lark/Milky/NapCat/OneBot 11/12/QQ/Satori/WeCom declare recall and provide control; Weixin iLink declares typing.

Migration

- Adapter maintainers must declare every implemented control operation; hidden control methods now fail endpoint creation.
- Use a function for `operations` when capabilities vary by connection mode; map legacy recall-by-id via `createRecallEndpointControl()`.
- Callers should read `operations` (or `capabilities()`) and must not invoke controls outside the declared set; prior implicit calls will be ignored.

<sup>Written for commit f2c532f9195128fa4a1f14b488cd7bd3afb28326. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zhinjs/zhin/pull/627?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

