### PR TITLE
fix: unify IM capabilities and lifecycle ownership

### DIFF
--- a/.changeset/calm-agent-lifecycle-boundaries.md
+++ b/.changeset/calm-agent-lifecycle-boundaries.md
@@ -1,0 +1,5 @@
+---
+"@zhin.js/agent": major
+---
+
+Close lifecycle races across IM activity indicators, subagent cancellation and schedule feedback: retry inactive starts, serialize native typing keepalives with cleanup, await generation disposal without task-observer self-deadlocks, propagate subagent abort signals without delivering retired-generation results, preserve spawn/start/finish ordering, and make same-scene schedule locks executor-owned and lifecycle-drained. The deprecated global schedule-lock drain remains exported for compatibility but now fails explicitly with migration guidance instead of falsely reporting that generation-owned executors were drained.

--- a/.changeset/email-reconnect-ownership.md
+++ b/.changeset/email-reconnect-ownership.md
@@ -1,0 +1,5 @@
+---
+'@zhin.js/adapter-email': patch
+---
+
+Ignore late disconnect events from replaced IMAP transports so reconnect does not leak duplicate connections.

--- a/.changeset/icqq-hmr-transport-retire.md
+++ b/.changeset/icqq-hmr-transport-retire.md
@@ -1,0 +1,5 @@
+---
+'@zhin.js/adapter-icqq': patch
+---
+
+Keep a replacement ICQQ connection alive when configuration hot reload retires the previous endpoint.

--- a/.changeset/sandbox-hmr-path-ownership.md
+++ b/.changeset/sandbox-hmr-path-ownership.md
@@ -1,0 +1,5 @@
+---
+'@zhin.js/adapter-sandbox': patch
+---
+
+Preserve WebSocket path ownership when a previous hot-reload generation stops after its replacement starts.

--- a/.changeset/smooth-activity-feedback.md
+++ b/.changeset/smooth-activity-feedback.md
@@ -6,4 +6,4 @@
 "@zhin.js/service-activity-feedback": patch
 ---
 
-Project exact Endpoint control capabilities through the outbound Host and connect native typing, editable progress, ordered Agent/subagent/tool events, and transient Schedule completion states to IM activity feedback.
+Project exact Endpoint control capabilities through the outbound Host and connect native typing, editable progress, ordered Agent/subagent/tool events, and transient Schedule completion states to IM activity feedback. Gate event ingress by the committed Runtime generation, pin Endpoint operations and retirement cleanup to that generation's IM snapshot, and guarantee terminal cleanup across public Agent error and cancellation paths.

--- a/.changeset/smooth-activity-feedback.md
+++ b/.changeset/smooth-activity-feedback.md
@@ -1,0 +1,9 @@
+---
+"@zhin.js/plugin-runtime": minor
+"@zhin.js/core": minor
+"@zhin.js/agent": patch
+"@zhin.js/cli": patch
+"@zhin.js/service-activity-feedback": patch
+---
+
+Project exact Endpoint control capabilities through the outbound Host and connect native typing, editable progress, ordered Agent/subagent/tool events, and transient Schedule completion states to IM activity feedback.

--- a/basic/cli/src/plugin-runtime/agent-host-installer.ts
+++ b/basic/cli/src/plugin-runtime/agent-host-installer.ts
@@ -2980,6 +2980,7 @@ function wireRuntimeSchedule(
     dispose: async () => {
       jobEngine.unload();
       await jobWorker.stop();
+      await executor.dispose();
     },
   };
 }

--- a/basic/cli/src/plugin-runtime/agent-host-installer.ts
+++ b/basic/cli/src/plugin-runtime/agent-host-installer.ts
@@ -3058,10 +3058,10 @@ function observeTrace(
 
 function createScheduleActivityPort(agent: ZhinAgent) {
   return Object.freeze({
-    publish: (event: ScheduleActivityEvent) => {
+    publish: async (event: ScheduleActivityEvent) => {
       const payload = scheduleActivityPayload(event);
       if (!payload) return;
-      agent.getEventEmitter().emit(`schedule.${event.phase}`, payload);
+      await agent.getEventEmitter().dispatch(`schedule.${event.phase}`, payload);
     },
   });
 }

--- a/basic/cli/src/plugin-runtime/outbound-host-installer.ts
+++ b/basic/cli/src/plugin-runtime/outbound-host-installer.ts
@@ -11,6 +11,7 @@ const logger = getLogger('OutboundHost');
 
 export function createOutboundHost(im: ImRuntime): OutboundHost {
   return {
+    runWithView: (operation) => im.runWithSnapshotView(operation),
     capabilities(input) {
       const capabilities = im.endpointCapabilities(input);
       const operations = capabilities?.operations;

--- a/basic/cli/src/plugin-runtime/outbound-host-installer.ts
+++ b/basic/cli/src/plugin-runtime/outbound-host-installer.ts
@@ -11,6 +11,17 @@ const logger = getLogger('OutboundHost');
 
 export function createOutboundHost(im: ImRuntime): OutboundHost {
   return {
+    capabilities(input) {
+      const capabilities = im.endpointCapabilities(input);
+      const operations = capabilities?.operations;
+      if (!operations) return { operations: Object.freeze([]) };
+      return {
+        operations: Object.freeze(
+          (['recall', 'edit', 'reaction', 'typing'] as const)
+            .filter((operation) => operations[operation] === true),
+        ),
+      };
+    },
     async send(input: OutboundSendInput): Promise<string | null> {
       try {
         const result = await im.sendEndpointMessage({
@@ -78,6 +89,41 @@ export function createOutboundHost(im: ImRuntime): OutboundHost {
         endpointKey: input.endpointKey,
         message: input.message,
       });
+    },
+    async edit(input) {
+      try {
+        return await im.editEndpointMessage({
+          adapter: input.adapter,
+          endpointKey: input.endpointKey,
+          message: input.message,
+          content: input.content,
+        });
+      } catch (error) {
+        logger.debug(formatCompact({
+          op: 'outbound_edit_failed',
+          adapter: input.adapter,
+          endpointKey: input.endpointKey,
+          error: error instanceof Error ? error.message : String(error),
+        }));
+        return null;
+      }
+    },
+    async typing(input) {
+      try {
+        await im.setEndpointTyping({
+          adapter: input.adapter,
+          endpointKey: input.endpointKey,
+          conversation: input.conversation,
+          active: input.active,
+        });
+      } catch (error) {
+        logger.debug(formatCompact({
+          op: 'outbound_typing_failed',
+          adapter: input.adapter,
+          endpointKey: input.endpointKey,
+          error: error instanceof Error ? error.message : String(error),
+        }));
+      }
     },
   };
 }

--- a/basic/cli/tests/plugin-runtime/outbound-host.test.ts
+++ b/basic/cli/tests/plugin-runtime/outbound-host.test.ts
@@ -46,4 +46,50 @@ describe('OutboundHost', () => {
       reactionId: '104',
     })).resolves.toBeUndefined();
   });
+
+  it('projects endpoint capabilities and delegates edit/typing controls', async () => {
+    const message = {
+      conversation: {
+        endpoint: { id: 'bot', adapter: 'discord' },
+        kind: 'channel' as const,
+        id: 'channel-1',
+      },
+      id: 'message-1',
+    };
+    const endpointCapabilities = vi.fn().mockReturnValue({
+      inbound: true,
+      outbound: true,
+      operations: { edit: true, typing: true },
+    });
+    const editEndpointMessage = vi.fn().mockResolvedValue('message-1');
+    const setEndpointTyping = vi.fn().mockResolvedValue(undefined);
+    const host = createOutboundHost({
+      endpointCapabilities,
+      editEndpointMessage,
+      setEndpointTyping,
+    } as unknown as ImRuntime);
+
+    expect(host.capabilities?.({ adapter: 'discord', endpointKey: 'bot' })).toEqual({
+      operations: ['edit', 'typing'],
+    });
+    await expect(host.edit?.({
+      adapter: 'discord',
+      endpointKey: 'bot',
+      message,
+      content: 'working',
+    })).resolves.toBe('message-1');
+    await expect(host.typing?.({
+      adapter: 'discord',
+      endpointKey: 'bot',
+      conversation: message.conversation,
+      active: true,
+    })).resolves.toBeUndefined();
+
+    expect(editEndpointMessage).toHaveBeenCalledWith({
+      adapter: 'discord', endpointKey: 'bot', message, content: 'working',
+    });
+    expect(setEndpointTyping).toHaveBeenCalledWith({
+      adapter: 'discord', endpointKey: 'bot', conversation: message.conversation, active: true,
+    });
+  });
 });

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -20,6 +20,7 @@ const USE_DOC_PREFIXES = [
   '/configuration/',
   '/cli/',
   '/ai/',
+  '/advanced/',
   '/console/',
   '/examples/',
   '/paths/',
@@ -86,6 +87,7 @@ const zhUseDocsSidebar: DefaultTheme.SidebarItem[] = [
   sidebarGroup('AI 模块', [
     { text: '总览', link: '/ai/' },
     { text: 'Agent 深入', link: '/ai/agent' },
+    { text: '执行状态反馈', link: '/advanced/activity-feedback' },
     { text: '语音', link: '/ai/speech' },
     { text: '智能家居（HA）', link: '/advanced/assistant-home-setup' },
   ]),
@@ -271,10 +273,11 @@ export default withMermaid(defineConfig({
           },
           {
             text: 'AI 模块',
-            activeMatch: '^/ai/',
+            activeMatch: '^/(ai|advanced)/',
             items: [
               { text: '总览', link: '/ai/' },
               { text: 'Agent 深入', link: '/ai/agent' },
+              { text: '执行状态反馈', link: '/advanced/activity-feedback' },
               { text: '语音', link: '/ai/speech' },
             ],
           },

--- a/docs/adr/0034-activity-feedback-service-plugin.md
+++ b/docs/adr/0034-activity-feedback-service-plugin.md
@@ -10,6 +10,8 @@ Agent、子 Agent、工具迭代与 Schedule 只发布传输无关的生命周�
 
 同一 IM 会话的事件必须串行投影；不同会话可以并行。终态反馈必须自动清理，插件卸载时必须撤销订阅、定时器和仍存活的临时状态。
 
+Runtime 候选代通过插件自有的 generation admission Resource fail closed，只有已提交代可接收 AI 状态事件。事件入口同时固定 IM Runtime snapshot view；generation 退役信号会在 snapshot 指针切换前关闭入口、停掉 keepalive/timer，并在同一旧代 view 内完成全部清理。临时消息只接受平台返回的真实 message id；reaction 与消息清理必须可等待完成。缺少 generation-bound outbound view 的 Host 必须禁用本服务，不能静默降级为 current/latest snapshot。
+
 ## 结果
 
 - 不支持原生 typing 的平台可降级为状态消息。

--- a/docs/adr/0034-activity-feedback-service-plugin.md
+++ b/docs/adr/0034-activity-feedback-service-plugin.md
@@ -1,0 +1,18 @@
+# ADR 0034：Activity Feedback 服务插件
+
+状态：Accepted
+
+## 决策
+
+Agent、子 Agent、工具迭代与 Schedule 只发布传输无关的生命周期事件。可选的 `@zhin.js/service-activity-feedback` 订阅这些事件，并通过 `outboundHostToken` 将状态投影到 IM。
+
+平台操作只允许通过 Adapter Endpoint 显式声明的 `recall`、`edit`、`reaction`、`typing` 控制端口执行。服务插件不得按平台 SDK 方法名探测能力，也不得持有跨 generation 的 Endpoint 单例。
+
+同一 IM 会话的事件必须串行投影；不同会话可以并行。终态反馈必须自动清理，插件卸载时必须撤销订阅、定时器和仍存活的临时状态。
+
+## 结果
+
+- 不支持原生 typing 的平台可降级为状态消息。
+- 支持 edit 的平台能原位显示工具/迭代进度，减少消息刷屏。
+- 子 Agent 使用独立状态键，不覆盖主回合。
+- Schedule 的开始、完成、失败拥有一致的用户可见反馈。

--- a/docs/adr/0034-activity-feedback-service-plugin.md
+++ b/docs/adr/0034-activity-feedback-service-plugin.md
@@ -1,3 +1,7 @@
+---
+sidebar: false
+---
+
 # ADR 0034：Activity Feedback 服务插件
 
 状态：Accepted

--- a/docs/advanced/activity-feedback.md
+++ b/docs/advanced/activity-feedback.md
@@ -1,0 +1,77 @@
+# Activity Feedback
+
+`@zhin.js/service-activity-feedback` 把 Agent 执行状态投影到原始 IM 会话，让用户在等待时知道系统仍在工作。
+
+## 覆盖的状态
+
+- 主 Agent：排队、处理中、thinking、完成或失败时清理。
+- 工具与 Task 迭代：更新当前状态消息，例如“处理中 [2/15]…”、“调用工具：web_search…”。
+- 子 Agent：按 `agentId + taskId` 使用独立状态，不覆盖主 Agent；结束时自动清理。
+- Schedule：显示开始状态，并短暂展示完成或失败终态。
+
+所有状态事件在同一 IM 会话内按顺序处理。不同会话仍可并行，慢平台不会阻塞其他用户。
+
+## 安装与挂载
+
+```bash
+pnpm add @zhin.js/service-activity-feedback @zhin.js/agent
+```
+
+在项目 `package.json` 的 `zhin.plugins` 中加入：
+
+```json
+{
+  "package": "@zhin.js/service-activity-feedback",
+  "instanceKey": "activity-feedback"
+}
+```
+
+## 配置
+
+插件配置位于 `zhin.config.yml` 的实例命名空间：
+
+```yaml
+plugins:
+  activity-feedback:
+    enabled: true
+    defaults:
+      phases:
+        active:
+          private: { type: message, message: "正在处理中…" }
+    platforms:
+      icqq:
+        phases:
+          active:
+            group: { type: reaction, emoji: "60" }
+      discord:
+        phases:
+          active:
+            channel: { type: typing }
+    schedule:
+      phases:
+        finish:
+          private: { type: message, message: "✅ 定时任务完成", removeDelay: 3000 }
+```
+
+配置按 `defaults → platforms.<platform> → endpoints.<platform:endpointKey>` 合并。每个 phase 可按 `private`、`group`、`channel` 分别配置。
+
+支持的 `type`：
+
+- `reaction`：在触发消息上添加回应，停止时移除。
+- `typing`：使用平台原生输入状态，并定时续期。
+- `message`：发送状态消息；支持 edit 时会原位更新，支持 recall 时会在结束时撤回。
+- `none`：关闭该 phase。
+
+实际执行以 Endpoint 的 `operations` 声明为准。配置请求了平台不支持的类型时，插件会降级到该 Endpoint 可用的 typing、message 或 none，不会调用未声明的隐藏能力。
+
+## Schedule
+
+Schedule Job 需要启用 `activityFeedback`，并且通知目标能够解析为 IM 会话，才会产生状态：
+
+```yaml
+activityFeedback: true
+notify:
+  channel: im
+```
+
+完成与失败状态默认显示 3 秒；可以在对应 phase 上用 `removeDelay` 调整。

--- a/docs/advanced/activity-feedback.md
+++ b/docs/advanced/activity-feedback.md
@@ -21,8 +21,14 @@ pnpm add @zhin.js/service-activity-feedback @zhin.js/agent
 
 ```json
 {
-  "package": "@zhin.js/service-activity-feedback",
-  "instanceKey": "activity-feedback"
+  "zhin": {
+    "plugins": [
+      {
+        "package": "@zhin.js/service-activity-feedback",
+        "instanceKey": "activity-feedback"
+      }
+    ]
+  }
 }
 ```
 
@@ -59,10 +65,10 @@ plugins:
 
 - `reaction`：在触发消息上添加回应，停止时移除。
 - `typing`：使用平台原生输入状态，并定时续期。
-- `message`：发送状态消息；支持 edit 时会原位更新，支持 recall 时会在结束时撤回。
+- `message`：仅在 Endpoint 声明 recall 时发送可清理的临时状态消息；若同时支持 edit，会原位更新。
 - `none`：关闭该 phase。
 
-实际执行以 Endpoint 的 `operations` 声明为准。配置请求了平台不支持的类型时，插件会降级到该 Endpoint 可用的 typing、message 或 none，不会调用未声明的隐藏能力。
+实际执行以 Endpoint 的 `operations` 声明为准。配置请求了平台不支持的类型时，插件会降级到该 Endpoint 可安全清理的 reaction、typing、message 或 none，不会调用未声明的隐藏能力，也不会伪造平台 message id。
 
 ## Schedule
 

--- a/packages/im/agent/src/activity-feedback/adapter-integration.ts
+++ b/packages/im/agent/src/activity-feedback/adapter-integration.ts
@@ -238,7 +238,7 @@ export class AdapterActivityFeedbackManager {
     platform: string,
     outbound?: OutboundAdapter,
   ): ActivityFeedbackManager {
-    const botKey = `${platform}:${endpoint.$id}`;
+    const botKey = JSON.stringify([platform, endpoint.$id]);
     if (this.managers.has(botKey)) {
       return this.managers.get(botKey)!;
     }
@@ -250,11 +250,11 @@ export class AdapterActivityFeedbackManager {
   }
 
   getManager(platform: string, endpointKey: string): ActivityFeedbackManager | undefined {
-    return this.managers.get(`${platform}:${endpointKey}`);
+    return this.managers.get(JSON.stringify([platform, endpointKey]));
   }
 
   async stopAll(platform: string, endpointKey: string): Promise<void> {
-    await this.managers.get(`${platform}:${endpointKey}`)?.stopAll();
+    await this.managers.get(JSON.stringify([platform, endpointKey]))?.stopAll();
   }
 
   clearAll(): void {

--- a/packages/im/agent/src/activity-feedback/adapter-integration.ts
+++ b/packages/im/agent/src/activity-feedback/adapter-integration.ts
@@ -20,7 +20,6 @@ import {
   PLATFORM_FEATURES,
   buildTypingSendContent,
   type PlatformFeatures,
-  type BotWithEditing,
 } from '../typing-indicator/adapter-integration.js';
 import { ActivityFeedbackManager } from './manager.js';
 import type { ActivityFeedbackPhase, ResolvedActivityFeedbackPhaseConfig } from './types.js';
@@ -194,10 +193,8 @@ class EndpointActivityFeedbackAdapter implements TypingIndicatorAdapter {
           if (message) await this.endpoint.control!.recall!(message);
         },
         async (messageId, content) => {
-          const editBot = this.endpoint as BotWithEditing;
           const message = this.messages.get(messageId);
           if (message && this.endpoint.control?.edit) await this.endpoint.control.edit(message, content);
-          else if (typeof editBot.$updateMessage === 'function') await editBot.$updateMessage(messageId, content);
         },
       );
     }

--- a/packages/im/agent/src/activity-feedback/adapter-integration.ts
+++ b/packages/im/agent/src/activity-feedback/adapter-integration.ts
@@ -4,12 +4,16 @@
 
 import { getLogger } from '@zhin.js/logger';
 import type { Adapter, Endpoint, SendOptions } from '@zhin.js/core';
-import type { MessageRef } from '@zhin.js/im-contract';
+import type { ConversationRef, MessageRef } from '@zhin.js/im-contract';
 import { createGenerationStore, type GenerationStoreContext } from '@zhin.js/plugin-runtime';
 import {
-  ReactionTypingIndicatorAdapter,
-  GenericTypingIndicatorAdapter,
+  MessageTypingIndicator,
+  NativeTypingIndicator,
+  NoneTypingIndicator,
+  ReactionTypingIndicator,
   type TypingIndicator,
+  type TypingIndicatorAdapter,
+  type TypingIndicatorConfig,
   type TypingIndicatorOptions,
 } from '../typing-indicator/index.js';
 import {
@@ -113,62 +117,92 @@ function registerPlatformAdapters(
   manager: ActivityFeedbackManager,
   endpoint: EndpointWithActivityFeedback,
   platform: string,
-  features: PlatformFeatures,
   outbound?: OutboundAdapter,
 ): void {
   const messages = new Map<string, MessageRef>();
   const sendMessage = createOutboundSendMessage(endpoint, platform, messages, outbound);
-  if (features.supportsReaction && endpoint.control?.addReaction && endpoint.control.removeReaction) {
-    manager.registerAdapter(new ReactionTypingIndicatorAdapter(
-      platform,
-      async (messageId, emoji, options) => {
-        try {
-          const message = toMessageRef(endpoint, platform, options, messageId);
-          messages.set(messageId, message);
-          return await endpoint.control!.addReaction!(message, emoji, {
-            sceneType: options.sceneType,
-            channelId: options.groupId,
-          });
-        } catch (error) {
-          logger.error(`[${platform}] Failed to add reaction:`, error);
-          return null;
-        }
-      },
-      async (messageId, reactionId) => {
-        const message = messages.get(messageId);
-        if (!message) return;
-        void Promise.resolve(endpoint.control!.removeReaction!(message, reactionId)).catch((error) => {
-          logger.warn(`[${platform}] Failed to remove reaction:`, error);
-        });
-      },
-      sendMessage,
-      async (messageId) => {
-        const message = messages.get(messageId);
-        if (message) await endpoint.control?.recall?.(message);
-      },
-      async (messageId, content) => {
-        const editBot = endpoint as BotWithEditing;
-        const message = messages.get(messageId);
-        if (message && endpoint.control?.edit) await endpoint.control.edit(message, content);
-        else if (typeof editBot.$updateMessage === 'function') await editBot.$updateMessage(messageId, content);
-      },
-    ));
-    return;
-  }
-  manager.registerAdapter(new GenericTypingIndicatorAdapter(
+  manager.registerAdapter(new EndpointActivityFeedbackAdapter(
     platform,
+    endpoint,
+    messages,
     sendMessage,
-    async (messageId) => {
-      const message = messages.get(messageId);
-      if (message) await endpoint.control?.recall?.(message);
-    },
-    async (messageId, content) => {
-      const editBot = endpoint as BotWithEditing;
-      const message = messages.get(messageId);
-      if (message && endpoint.control?.edit) await endpoint.control.edit(message, content);
-      else if (typeof editBot.$updateMessage === 'function') await editBot.$updateMessage(messageId, content);
-    },
   ));
+}
+
+/** One adapter selected from the concrete Endpoint control contract, not its platform name. */
+class EndpointActivityFeedbackAdapter implements TypingIndicatorAdapter {
+  readonly supportedTypes: import('../typing-indicator/index.js').TypingIndicatorType[];
+
+  constructor(
+    readonly platform: string,
+    private readonly endpoint: EndpointWithActivityFeedback,
+    private readonly messages: Map<string, MessageRef>,
+    private readonly sendMessage: (options: TypingIndicatorOptions, content: string) => Promise<string | null>,
+  ) {
+    const types: import('../typing-indicator/index.js').TypingIndicatorType[] = [];
+    if (endpoint.control?.addReaction && endpoint.control.removeReaction) types.push('reaction');
+    if (endpoint.control?.typing) types.push('typing');
+    // Activity messages are transient state, so advertising them without a
+    // matching recall operation would leave permanent “processing” debris in IM.
+    if (endpoint.control?.recall) types.push('message');
+    types.push('none');
+    this.supportedTypes = types;
+  }
+
+  createIndicator(options: TypingIndicatorOptions, config: TypingIndicatorConfig): TypingIndicator {
+    if (config.type === 'reaction' && this.endpoint.control?.addReaction && this.endpoint.control.removeReaction) {
+      return new ReactionTypingIndicator(
+        options,
+        config,
+        async (messageId, emoji, current) => {
+          const message = toMessageRef(this.endpoint, this.platform, current, messageId);
+          this.messages.set(messageId, message);
+          return this.endpoint.control!.addReaction!(message, emoji, {
+            sceneType: current.sceneType,
+            channelId: current.groupId,
+          });
+        },
+        async (messageId, reactionId) => {
+          const message = this.messages.get(messageId);
+          if (message) await this.endpoint.control!.removeReaction!(message, reactionId);
+        },
+      );
+    }
+    if (config.type === 'typing' && this.endpoint.control?.typing) {
+      return new NativeTypingIndicator(
+        options,
+        config,
+        async (current) => this.endpoint.control!.typing!(toConversationRef(
+          this.endpoint,
+          this.platform,
+          current,
+        ), true),
+        async (current) => this.endpoint.control!.typing!(toConversationRef(
+          this.endpoint,
+          this.platform,
+          current,
+        ), false),
+      );
+    }
+    if (config.type === 'message' && this.endpoint.control?.recall) {
+      return new MessageTypingIndicator(
+        options,
+        config,
+        this.sendMessage,
+        async (messageId) => {
+          const message = this.messages.get(messageId);
+          if (message) await this.endpoint.control!.recall!(message);
+        },
+        async (messageId, content) => {
+          const editBot = this.endpoint as BotWithEditing;
+          const message = this.messages.get(messageId);
+          if (message && this.endpoint.control?.edit) await this.endpoint.control.edit(message, content);
+          else if (typeof editBot.$updateMessage === 'function') await editBot.$updateMessage(messageId, content);
+        },
+      );
+    }
+    return new NoneTypingIndicator();
+  }
 }
 
 function toMessageRef(
@@ -177,14 +211,22 @@ function toMessageRef(
   options: TypingIndicatorOptions,
   id: string,
 ): MessageRef {
+  return {
+    conversation: toConversationRef(endpoint, platform, options),
+    id,
+  };
+}
+
+function toConversationRef(
+  endpoint: Endpoint,
+  platform: string,
+  options: TypingIndicatorOptions,
+): ConversationRef {
   const target = resolveSendTarget(options);
   return {
-    conversation: {
-      endpoint: { id: endpoint.$id, adapter: platform },
-      kind: options.sceneType,
-      id: target.id,
-    },
-    id,
+    endpoint: { id: endpoint.$id, adapter: platform },
+    kind: options.sceneType,
+    id: target.id,
   };
 }
 
@@ -200,16 +242,8 @@ export class AdapterActivityFeedbackManager {
     if (this.managers.has(botKey)) {
       return this.managers.get(botKey)!;
     }
-    const features = PLATFORM_FEATURES[platform] ?? {
-      platform,
-      supportsReaction: false,
-      supportsEdit: false,
-      supportsDelete: true,
-      supportsTyping: false,
-      defaultType: 'message' as const,
-    };
     const manager = new ActivityFeedbackManager();
-    registerPlatformAdapters(manager, endpoint, platform, features, outbound);
+    registerPlatformAdapters(manager, endpoint, platform, outbound);
     this.managers.set(botKey, manager);
     endpoint.$activityFeedback = manager;
     return manager;

--- a/packages/im/agent/src/activity-feedback/ai-bus.ts
+++ b/packages/im/agent/src/activity-feedback/ai-bus.ts
@@ -46,13 +46,17 @@ export class ActivityFeedbackAIBus {
     // generation handler is still settling. A live Set iterator would then
     // leak this in-flight event into the newly registered generation.
     const listeners = [...set];
-    for (const listener of listeners) {
+    const pending = listeners.map((listener) => {
       try {
-        await listener(payload);
+        // Invoke every snapshot listener before awaiting. Generation admission
+        // must be sampled at dispatch ingress, not after an earlier listener settles.
+        return Promise.resolve(listener(payload)).catch(() => undefined);
       } catch {
         // Listener errors must not break the Agent emit path.
+        return Promise.resolve();
       }
-    }
+    });
+    await Promise.all(pending);
   }
 
   /** Test helper — clears all listeners. */

--- a/packages/im/agent/src/activity-feedback/ai-bus.ts
+++ b/packages/im/agent/src/activity-feedback/ai-bus.ts
@@ -3,7 +3,7 @@ import type { AIEventPayload } from '../ai-event-subscriber.js';
 
 const logger = getLogger('AIBus');
 
-type AIBusListener = (payload: AIEventPayload) => void;
+type AIBusListener = (payload: AIEventPayload) => void | Promise<void>;
 
 /**
  * Module-level AI event bus for Plugin Runtime consumers that cannot use
@@ -31,6 +31,10 @@ export class ActivityFeedbackAIBus {
   }
 
   emit(event: string, payload: AIEventPayload): void {
+    void this.dispatch(event, payload);
+  }
+
+  async dispatch(event: string, payload: AIEventPayload): Promise<void> {
     const set = this.listeners.get(event);
     if (!set || set.size === 0) {
       // 零订阅 = activity-feedback 插件未加载，或运行时装了双份 @zhin.js/agent
@@ -38,9 +42,13 @@ export class ActivityFeedbackAIBus {
       logger.debug(formatCompact({ op: 'ai_bus_no_listener', event }));
       return;
     }
-    for (const listener of set) {
+    // Snapshot before the first await: HMR may replace listeners while an old
+    // generation handler is still settling. A live Set iterator would then
+    // leak this in-flight event into the newly registered generation.
+    const listeners = [...set];
+    for (const listener of listeners) {
       try {
-        listener(payload);
+        await listener(payload);
       } catch {
         // Listener errors must not break the Agent emit path.
       }

--- a/packages/im/agent/src/activity-feedback/manager.ts
+++ b/packages/im/agent/src/activity-feedback/manager.ts
@@ -10,13 +10,25 @@ function phaseSessionId(sessionId: string, phase: ActivityFeedbackPhase): string
   return `${sessionId}::phase:${phase}`;
 }
 
+function reactionPhaseSessionId(
+  sessionId: string,
+  phase: ActivityFeedbackPhase,
+  messageId: string,
+): string {
+  return `${phaseSessionId(sessionId, phase)}::message:${messageId}`;
+}
+
 function withPhase(
   options: TypingIndicatorOptions,
   phase: ActivityFeedbackPhase,
+  messageScoped = false,
 ): TypingIndicatorOptions {
+  const sessionId = options.sessionId ?? options.messageId ?? '';
   return {
     ...options,
-    sessionId: phaseSessionId(options.sessionId ?? options.messageId ?? '', phase),
+    sessionId: messageScoped && options.messageId
+      ? reactionPhaseSessionId(sessionId, phase, options.messageId)
+      : phaseSessionId(sessionId, phase),
   };
 }
 
@@ -36,10 +48,21 @@ export class ActivityFeedbackManager {
     options: TypingIndicatorOptions,
     config: ResolvedActivityFeedbackPhaseConfig,
   ): Promise<TypingIndicator> {
-    return this.inner.start(withPhase(options, phase), toTypingIndicatorConfig(config));
+    const typingConfig = toTypingIndicatorConfig(config);
+    const adapter = this.inner.getAdapter(options.platform);
+    const resolvedType = adapter?.supportedTypes.includes(config.type)
+      ? config.type
+      : adapter?.supportedTypes[0];
+    return this.inner.start(
+      withPhase(options, phase, resolvedType === 'reaction'),
+      typingConfig,
+    );
   }
 
   async stop(phase: ActivityFeedbackPhase, options: TypingIndicatorOptions): Promise<void> {
+    if (options.messageId) {
+      await this.inner.stop(withPhase(options, phase, true));
+    }
     return this.inner.stop(withPhase(options, phase));
   }
 
@@ -47,7 +70,10 @@ export class ActivityFeedbackManager {
     phase: ActivityFeedbackPhase,
     options: TypingIndicatorOptions,
   ): TypingIndicator | undefined {
-    return this.inner.getActiveIndicator(withPhase(options, phase));
+    return (options.messageId
+      ? this.inner.getActiveIndicator(withPhase(options, phase, true))
+      : undefined)
+      ?? this.inner.getActiveIndicator(withPhase(options, phase));
   }
 
   async stopAll(): Promise<void> {

--- a/packages/im/agent/src/activity-feedback/turn-event-projector.ts
+++ b/packages/im/agent/src/activity-feedback/turn-event-projector.ts
@@ -1,0 +1,68 @@
+import type { TurnEvent } from '../event/turn-event.js';
+import type { AIEventName, AIEventPayload } from '../ai-event-subscriber.js';
+
+export interface TurnActivityProjectorOptions {
+  readonly payload: AIEventPayload;
+  readonly publish: (event: AIEventName, payload: AIEventPayload) => void;
+  readonly thinkingPreview: boolean;
+  readonly thinkingMaxLength: number;
+}
+
+/** Projects canonical TurnEvents into the shared IM activity lifecycle. */
+export function createTurnActivityProjector(options: TurnActivityProjectorOptions):
+(event: TurnEvent) => void {
+  let thinkingSent = false;
+  let accumulatedThinking = '';
+  return (event) => {
+    const payload = options.payload;
+    if (event.type === 'tool_call') {
+      options.publish('ai.tool.call', {
+        ...payload,
+        toolName: event.toolName,
+        args: event.args,
+      });
+      return;
+    }
+    if (event.type === 'tool_result') {
+      options.publish('ai.tool.result', {
+        ...payload,
+        toolName: event.toolName,
+        result: event.output,
+        status: 'ok',
+      });
+      return;
+    }
+    if (
+      event.type === 'tool_failed'
+      || event.type === 'tool_denied'
+      || event.type === 'tool_cancelled'
+    ) {
+      options.publish('ai.tool.result', {
+        ...payload,
+        toolName: event.toolName,
+        error: event.type === 'tool_failed' ? event.error : event.reason,
+        status: 'error',
+      });
+      return;
+    }
+    if (event.type === 'iteration_start' && event.iteration > 1) {
+      options.publish('ai.processing.start', {
+        ...payload,
+        iterations: event.iteration,
+        content: `处理中 [${event.iteration}/${event.maxIterations}]...`,
+      });
+      return;
+    }
+    if (event.type !== 'thinking' || !event.text) return;
+    accumulatedThinking += event.text;
+    if (options.thinkingPreview) {
+      const preview = accumulatedThinking.length > options.thinkingMaxLength
+        ? accumulatedThinking.slice(0, options.thinkingMaxLength) + '...'
+        : accumulatedThinking;
+      options.publish('ai.thinking', { ...payload, thinking: preview });
+    } else if (!thinkingSent) {
+      thinkingSent = true;
+      options.publish('ai.thinking', { ...payload, thinking: event.text });
+    }
+  };
+}

--- a/packages/im/agent/src/ai-event-subscriber.ts
+++ b/packages/im/agent/src/ai-event-subscriber.ts
@@ -113,8 +113,8 @@ function matchesFilter(payload: AIEventPayload, filter?: AIEventFilter): boolean
 
 /** Plugin-agnostic on/off target (no AsyncLocalStorage). */
 export interface AIEventTarget {
-  on(event: string, listener: (payload: AIEventPayload) => void): unknown;
-  off(event: string, listener: (payload: AIEventPayload) => void): unknown;
+  on(event: string, listener: (payload: AIEventPayload) => void | Promise<void>): unknown;
+  off(event: string, listener: (payload: AIEventPayload) => void | Promise<void>): unknown;
 }
 
 function invokeHandlers(
@@ -144,7 +144,7 @@ export function subscribeAIEventsOnTarget(
   const disposers = AI_EVENT_NAMES.map((eventName) => {
     const listener = (payload: AIEventPayload) => {
       if (!matchesFilter(payload, filter)) return;
-      void invokeHandlers(eventName, payload, handlers);
+      return invokeHandlers(eventName, payload, handlers);
     };
     target.on(eventName, listener);
     return () => {

--- a/packages/im/agent/src/event/event-emitter.ts
+++ b/packages/im/agent/src/event/event-emitter.ts
@@ -63,7 +63,7 @@ export class ZhinAgentEventEmitter {
   ): Promise<void> {
     // Always fan-out for Plugin Runtime subscribers (activity-feedback, etc.).
     // Legacy Feature path still receives the same event via root.dispatch below.
-    activityFeedbackAiBus.emit(String(name), payload);
+    await activityFeedbackAiBus.dispatch(String(name), payload);
     const root = this.hostPlugin?.root ?? this.hostPlugin;
     if (!root) return;
     await root.dispatch(name as any, payload);

--- a/packages/im/agent/src/init/dispose-zhin-agent.ts
+++ b/packages/im/agent/src/init/dispose-zhin-agent.ts
@@ -14,12 +14,12 @@ export type DisposeZhinAgentTarget = Pick<
   lastTurnMetrics: unknown;
 };
 
-export function disposeZhinAgentResources(target: DisposeZhinAgentTarget): void {
+export async function disposeZhinAgentResources(target: DisposeZhinAgentTarget): Promise<void> {
   target.externalTools.clear();
   target.userProfiles.dispose();
   target.rateLimiter.dispose();
   if (target.subagentSystem) {
-    target.subagentSystem.dispose();
+    await target.subagentSystem.dispose();
     target.subagentSystem = null;
   }
   target.promptController.abort();

--- a/packages/im/agent/src/plugin-runtime/full-agent-turn-engine.ts
+++ b/packages/im/agent/src/plugin-runtime/full-agent-turn-engine.ts
@@ -21,6 +21,7 @@ import type { TurnTerminalProjection } from '../turn/execute-agent-turn.js';
 import { createScheduleCapabilityPlan } from './schedule-capability-plan.js';
 import type { TurnIngress } from '../turn/turn-ingress.js';
 import { buildTextTurnOutbound } from '../turn/turn-complete.js';
+import { createTurnActivityProjector } from '../activity-feedback/turn-event-projector.js';
 
 export interface FullAgentTurnEngineOptions {
   readonly host: ZhinAgentPrivate;
@@ -196,62 +197,13 @@ async function* runInteractiveTurn(
     }),
   });
 
-  let thinkingSent = false;
-  let accumulatedThinking = '';
-  const thinkingPreview = host.config.thinkingPreview === true;
-  const thinkingMaxLen = host.config.thinkingPreviewMaxLength ?? 200;
-  const completion = yield* bufferTerminal(stream, (event) => {
-    if (!payload) return;
-    if (event.type === 'tool_call') {
-      emitActivityEvent(host, 'ai.tool.call', {
-        ...payload,
-        toolName: event.toolName,
-        args: event.args,
-      });
-      return;
-    }
-    if (event.type === 'tool_result') {
-      emitActivityEvent(host, 'ai.tool.result', {
-        ...payload,
-        toolName: event.toolName,
-        result: event.output,
-        status: 'ok',
-      });
-      return;
-    }
-    if (
-      event.type === 'tool_failed'
-      || event.type === 'tool_denied'
-      || event.type === 'tool_cancelled'
-    ) {
-      emitActivityEvent(host, 'ai.tool.result', {
-        ...payload,
-        toolName: event.toolName,
-        error: event.type === 'tool_failed' ? event.error : event.reason,
-        status: 'error',
-      });
-      return;
-    }
-    if (event.type === 'iteration_start' && event.iteration > 1) {
-      emitActivityEvent(host, 'ai.processing.start', {
-        ...payload,
-        iterations: event.iteration,
-        content: `处理中 [${event.iteration}/${event.maxIterations}]...`,
-      });
-      return;
-    }
-    if (event.type !== 'thinking' || !event.text) return;
-    accumulatedThinking += event.text;
-    if (thinkingPreview) {
-      const preview = accumulatedThinking.length > thinkingMaxLen
-        ? accumulatedThinking.slice(0, thinkingMaxLen) + '...'
-        : accumulatedThinking;
-      emitActivityEvent(host, 'ai.thinking', { ...payload, thinking: preview });
-    } else if (!thinkingSent) {
-      thinkingSent = true;
-      emitActivityEvent(host, 'ai.thinking', { ...payload, thinking: event.text });
-    }
-  });
+  const projectActivity = payload ? createTurnActivityProjector({
+    payload,
+    publish: (event, next) => emitActivityEvent(host, event, next),
+    thinkingPreview: host.config.thinkingPreview === true,
+    thinkingMaxLength: host.config.thinkingPreviewMaxLength ?? 200,
+  }) : undefined;
+  const completion = yield* bufferTerminal(stream, projectActivity);
   yield completion.terminal;
   return {
     project: async () => {

--- a/packages/im/agent/src/plugin-runtime/full-agent-turn-engine.ts
+++ b/packages/im/agent/src/plugin-runtime/full-agent-turn-engine.ts
@@ -202,6 +202,36 @@ async function* runInteractiveTurn(
   const thinkingMaxLen = host.config.thinkingPreviewMaxLength ?? 200;
   const completion = yield* bufferTerminal(stream, (event) => {
     if (!payload) return;
+    if (event.type === 'tool_call') {
+      emitActivityEvent(host, 'ai.tool.call', {
+        ...payload,
+        toolName: event.toolName,
+        args: event.args,
+      });
+      return;
+    }
+    if (event.type === 'tool_result') {
+      emitActivityEvent(host, 'ai.tool.result', {
+        ...payload,
+        toolName: event.toolName,
+        result: event.output,
+        status: 'ok',
+      });
+      return;
+    }
+    if (
+      event.type === 'tool_failed'
+      || event.type === 'tool_denied'
+      || event.type === 'tool_cancelled'
+    ) {
+      emitActivityEvent(host, 'ai.tool.result', {
+        ...payload,
+        toolName: event.toolName,
+        error: event.type === 'tool_failed' ? event.error : event.reason,
+        status: 'error',
+      });
+      return;
+    }
     if (event.type === 'iteration_start' && event.iteration > 1) {
       emitActivityEvent(host, 'ai.processing.start', {
         ...payload,

--- a/packages/im/agent/src/subagent/subagent-runtime.ts
+++ b/packages/im/agent/src/subagent/subagent-runtime.ts
@@ -9,6 +9,7 @@
  */
 
 import { randomUUID } from 'node:crypto';
+import { AsyncLocalStorage } from 'node:async_hooks';
 import * as path from 'node:path';
 import { type Message, getLogger } from '@zhin.js/core';
 import { formatCompact, formatCompactUsage, truncatePreview } from '@zhin.js/logger';
@@ -197,6 +198,12 @@ export class SubagentRuntime {
   private eventEmitter: ZhinAgentEventEmitter | null;
   private resolveAgentMetaFn: ((agentName: string) => Promise<AgentMeta | null>) | null;
   private getParentContextSnapshotFn: ((origin: SubagentOrigin) => Promise<string | undefined>) | null;
+  private disposed = false;
+  private disposalStarted = false;
+  private externalDisposal?: Promise<void>;
+  private internalDisposalOwner?: string;
+  private readonly taskContext = new AsyncLocalStorage<string>();
+  private readonly taskSettlements = new Map<string, Promise<void>>();
 
   constructor(options: SubagentRuntimeOptions) {
     this.provider = options.provider;
@@ -275,15 +282,22 @@ export class SubagentRuntime {
   }
 
   /** 同步执行子 agent（入站 route 用）；返回最终文本，不经过 resultSender */
-  async spawnSync(options: SpawnOptions): Promise<string> {
+  spawnSync(options: SpawnOptions): Promise<string> {
+    return this.spawnSyncInner(options);
+  }
+
+  private async spawnSyncInner(options: SpawnOptions): Promise<string> {
+    if (this.disposed) throw new Error('SubagentRuntime has been disposed');
     const capError = this.parallelCapacityError();
     if (capError) return capError;
 
     const enriched = await this.enrichSpawnOptions(options);
+    this.assertActive();
     const role = enriched.role || 'subtask';
     const displayLabel = resolveSubagentDisplayLabel(enriched.label, enriched.task);
     const taskId = randomUUID().slice(0, 8);
     this.trackRunningTask(taskId);
+    const signal = this.runningTasks.get(taskId)!.signal;
     try {
       if (enriched.notifyContext) {
         await notifySubagentGoal(enriched.notifyContext, {
@@ -292,15 +306,10 @@ export class SubagentRuntime {
           label: displayLabel,
           agent: enriched.agent,
         });
+        this.assertActive(signal);
       }
-      const result = await this.runSubagent(
-        taskId,
-        enriched.task,
-        displayLabel,
-        enriched.origin,
-        role,
-        enriched.context,
-        {
+      const running = this.runAdmittedTask(taskId, () => this.runSubagent(
+        taskId, enriched.task, displayLabel, enriched.origin, role, enriched.context, {
           binding: enriched.binding ?? (enriched.agent ? this.resolveBindingFn?.(enriched.agent) ?? null : null),
           systemPrompt: enriched.systemPrompt,
           contextPreamble: enriched.contextPreamble,
@@ -313,19 +322,27 @@ export class SubagentRuntime {
           requestedSkills: enriched.requestedSkills,
           parentSessionLoaded: enriched.parentSessionLoaded,
           parentLoadedSkills: enriched.parentLoadedSkills,
+          signal,
         },
-      );
+      ));
+      const result = await running;
       return result ?? '任务已完成，但未生成最终响应。';
     } finally {
       this.releaseRunningTask(taskId);
     }
   }
 
-  async spawn(options: SpawnOptions): Promise<string> {
+  spawn(options: SpawnOptions): Promise<string> {
+    return this.spawnInner(options);
+  }
+
+  private async spawnInner(options: SpawnOptions): Promise<string> {
+    if (this.disposed) throw new Error('SubagentRuntime has been disposed');
     const capError = this.parallelCapacityError();
     if (capError) return capError;
 
     const enriched = await this.enrichSpawnOptions(options);
+    this.assertActive();
     const taskId = randomUUID().slice(0, 8);
     const role = enriched.role || 'subtask';
     const displayLabel = resolveSubagentDisplayLabel(enriched.label, enriched.task);
@@ -337,31 +354,11 @@ export class SubagentRuntime {
         label: displayLabel,
         agent: enriched.agent,
       });
+      this.assertActive();
     }
 
     const abortController = new AbortController();
     this.runningTasks.set(taskId, abortController);
-
-    const binding = enriched.binding ?? (enriched.agent ? this.resolveBindingFn?.(enriched.agent) ?? null : null);
-    const done = this.runSubagent(taskId, enriched.task, displayLabel, enriched.origin, role, enriched.context, {
-      binding,
-      systemPrompt: enriched.systemPrompt,
-      contextPreamble: enriched.contextPreamble,
-      presetName: enriched.agent ?? enriched.label,
-      agentMeta: enriched._agentMeta,
-      requestedTools: enriched.requestedTools,
-      requestedSkills: enriched.requestedSkills,
-      parentSessionLoaded: enriched.parentSessionLoaded,
-      parentLoadedSkills: enriched.parentLoadedSkills,
-    })
-      .then(() => undefined)
-      .catch((error) => {
-        logger.error({ error, taskId }, 'Subagent failed');
-      })
-      .finally(() => {
-        this.runningTasks.delete(taskId);
-      });
-    this.registerSubagentTask?.(done);
 
     logger.info(formatCompact({
       subagent: 'spawn',
@@ -371,7 +368,7 @@ export class SubagentRuntime {
       role,
       task: truncatePreview(enriched.task, 300),
     }));
-    void this.onEvent?.({
+    await this.publishLifecycleEvent({
       phase: 'spawn',
       taskId,
       label: displayLabel,
@@ -380,6 +377,34 @@ export class SubagentRuntime {
       role,
       agent: enriched.agent,
     });
+    try {
+      this.assertActive(abortController.signal);
+    } catch (error) {
+      this.runningTasks.delete(taskId);
+      throw error;
+    }
+
+    const binding = enriched.binding ?? (enriched.agent ? this.resolveBindingFn?.(enriched.agent) ?? null : null);
+    const done = this.runAdmittedTask(taskId, async () => {
+      try {
+        await this.runSubagent(taskId, enriched.task, displayLabel, enriched.origin, role, enriched.context, {
+          binding,
+          systemPrompt: enriched.systemPrompt,
+          contextPreamble: enriched.contextPreamble,
+          presetName: enriched.agent ?? enriched.label,
+          agentMeta: enriched._agentMeta,
+          requestedTools: enriched.requestedTools,
+          requestedSkills: enriched.requestedSkills,
+          parentSessionLoaded: enriched.parentSessionLoaded,
+          parentLoadedSkills: enriched.parentLoadedSkills,
+          signal: abortController.signal,
+        });
+      } catch (error) {
+        logger.error({ error, taskId }, 'Subagent failed');
+      }
+    }, () => this.runningTasks.delete(taskId));
+    this.registerSubagentTask?.(done);
+
     return `子任务 [${displayLabel}] 已启动 (id: ${taskId})，完成后会自动通知你。`;
   }
 
@@ -395,7 +420,6 @@ export class SubagentRuntime {
     } catch {
       // ignore
     }
-    this.runningTasks.delete(taskId);
     return true;
   }
 
@@ -416,6 +440,45 @@ export class SubagentRuntime {
 
   private releaseRunningTask(taskId: string): void {
     this.runningTasks.delete(taskId);
+  }
+
+  private async publishLifecycleEvent(event: SubagentLifecycleEvent): Promise<void> {
+    try {
+      await this.onEvent?.(event);
+    } catch (error) {
+      logger.error({ taskId: event.taskId, phase: event.phase, error }, 'Subagent lifecycle observer failed');
+    }
+  }
+
+  private assertActive(signal?: AbortSignal): void {
+    signal?.throwIfAborted();
+    if (this.disposed) {
+      throw new DOMException('SubagentRuntime generation retired', 'AbortError');
+    }
+  }
+
+  private runAdmittedTask<T>(
+    taskId: string,
+    operation: () => Promise<T>,
+    finalize: () => void = () => undefined,
+  ): Promise<T> {
+    let settle!: () => void;
+    const settlement = new Promise<void>((resolve) => { settle = resolve; });
+    this.taskSettlements.set(taskId, settlement);
+    let running: Promise<T>;
+    try {
+      running = this.taskContext.run(taskId, operation);
+    } catch (error) {
+      finalize();
+      this.taskSettlements.delete(taskId);
+      settle();
+      throw error;
+    }
+    return running.finally(() => {
+      finalize();
+      if (this.taskSettlements.get(taskId) === settlement) this.taskSettlements.delete(taskId);
+      settle();
+    });
   }
 
   // ── 内部方法 ──────────────────────────────────────────────────────
@@ -441,6 +504,7 @@ export class SubagentRuntime {
       requestedSkills?: string[];
       parentSessionLoaded?: string[];
       parentLoadedSkills?: string[];
+      signal?: AbortSignal;
     },
   ): Promise<string | void> {
     const startedAt = Date.now();
@@ -471,7 +535,7 @@ export class SubagentRuntime {
       await aiEvents.processingStart(task);
     }
 
-    await this.onEvent?.({
+    await this.publishLifecycleEvent({
       phase: 'start',
       taskId,
       label,
@@ -539,6 +603,7 @@ export class SubagentRuntime {
         maxIterations: effortIterations ?? this.maxIterations,
         commMessage: bashCommMessage,
         callbacks: aiEvents?.createAgentLoopCallbacks(model),
+        signal: opts?.signal,
       });
       this.onSubagentUsage?.(result.usage);
       const rawResult = result.content || '任务已完成，但未生成最终响应。';
@@ -558,7 +623,7 @@ export class SubagentRuntime {
         model,
         result: truncatePreview(finalResult, 480),
       }));
-      await this.onEvent?.({
+      await this.publishLifecycleEvent({
         phase: 'finish',
         taskId,
         label,
@@ -598,7 +663,7 @@ export class SubagentRuntime {
         ok: false,
         error: truncatePreview(errorMsg, 300),
       }));
-      await this.onEvent?.({
+      await this.publishLifecycleEvent({
         phase: 'finish',
         taskId,
         label,
@@ -625,6 +690,10 @@ export class SubagentRuntime {
   }
 
   private async deliverAsyncResult(payload: SubagentCompletePayload): Promise<void> {
+    // Generation retirement aborts work to release resources. Its cancellation
+    // terminal is still emitted above for activity cleanup, but an old runtime
+    // must never enqueue a new main-agent continuation or direct IM delivery.
+    if (this.disposed) return;
     if (this.onSubagentCompleteFn) {
       // 勿 await：onSubagentComplete → auto-continue 会 waitForIdle()，而主回合仍在
       // waitForPendingSubagents 中等待本 subagent 的 done，同步 await 会死锁。
@@ -693,10 +762,41 @@ Workspace path: ${this.workspace}
 When done, provide a clear summary of findings or actions.`;
   }
 
-  dispose(): void {
-    for (const [taskId, controller] of this.runningTasks.entries()) {
-      try { controller.abort(); } catch { /* ignore */ }
+  dispose(): Promise<void> {
+    if (!this.disposalStarted) {
+      this.disposalStarted = true;
+      this.disposed = true;
+      for (const controller of this.runningTasks.values()) {
+        try { controller.abort(); } catch { /* ignore */ }
+      }
     }
-    this.runningTasks.clear();
+
+    const currentTaskId = this.taskContext.getStore();
+    if (currentTaskId) {
+      // The first in-task disposer may wait for peers, but never itself. Any
+      // peer that also disposes must return immediately so two terminal
+      // observers cannot cross-wait each other.
+      if (this.internalDisposalOwner) return Promise.resolve();
+      this.internalDisposalOwner = currentTaskId;
+      return this.awaitTaskSettlements(currentTaskId);
+    }
+
+    if (!this.externalDisposal) {
+      this.externalDisposal = this.awaitTaskSettlements();
+    }
+    return this.externalDisposal;
+  }
+
+  private async awaitTaskSettlements(excludedTaskId?: string): Promise<void> {
+    while (true) {
+      const pending = [...this.taskSettlements.entries()]
+        .filter(([taskId]) => taskId !== excludedTaskId)
+        .map(([, settlement]) => settlement);
+      if (pending.length === 0) break;
+      await Promise.allSettled(pending);
+    }
+    if (!excludedTaskId) {
+      this.runningTasks.clear();
+    }
   }
 }

--- a/packages/im/agent/src/subagent/subagent-system-init.ts
+++ b/packages/im/agent/src/subagent/subagent-system-init.ts
@@ -31,7 +31,7 @@ export function createSubagentSystem(opts: SubagentSystemInitOptions): SubagentS
     onSubagentUsage: (usage) => getActiveTurnTracker()?.addSubagentUsage(usage),
     registerSubagentTask: (done) => getActiveTurnTracker()?.trackSubagent(done),
     eventEmitter: opts.emitter,
-    onEvent: (event) => {
+    onEvent: async (event) => {
       const sessionId = resolveIMSessionIdFromMessage(event.origin.message);
       const payload = opts.emitter.createPayload(sessionId, event.origin.message, 'text', {
         source: 'subagent',
@@ -48,11 +48,11 @@ export function createSubagentSystem(opts: SubagentSystemInitOptions): SubagentS
         },
       });
       if (event.phase === 'spawn') {
-        opts.emitter.emit('ai.subagent.spawn', payload);
+        await opts.emitter.dispatch('ai.subagent.spawn', payload);
       } else if (event.phase === 'start') {
-        opts.emitter.emit('ai.subagent.start', payload);
+        await opts.emitter.dispatch('ai.subagent.start', payload);
       } else {
-        opts.emitter.emit('ai.subagent.finish', payload);
+        await opts.emitter.dispatch('ai.subagent.finish', payload);
       }
     },
     onSubagentComplete: opts.onSubagentComplete,

--- a/packages/im/agent/src/subagent/subagent-system.ts
+++ b/packages/im/agent/src/subagent/subagent-system.ts
@@ -18,6 +18,7 @@ export class SubagentSystem {
   private readonly senders: SubagentResultSender[] = [];
   private readonly definitions = new Map<string, SubagentDefinition>();
   private runtime: SubagentRuntime | null = null;
+  private disposal?: Promise<void>;
 
   constructor(private readonly _config: SubagentSystemConfig = {}) {}
 
@@ -107,11 +108,16 @@ export class SubagentSystem {
     return this.runtime?.getRunningCount() ?? 0;
   }
 
-  dispose(): void {
-    this.runtime?.dispose();
+  dispose(): Promise<void> {
+    if (this.disposal) return this.disposal;
+    const runtime = this.runtime;
     this.runtime = null;
-    this.resultSinks.length = 0;
-    this.senders.length = 0;
+    this.disposal = (async () => {
+      await runtime?.dispose();
+      this.resultSinks.length = 0;
+      this.senders.length = 0;
+    })();
+    return this.disposal;
   }
 }
 

--- a/packages/im/agent/src/task-executor.ts
+++ b/packages/im/agent/src/task-executor.ts
@@ -1,5 +1,6 @@
 /** Delivery boundary for the independent schedule execution domain. */
 import { getLogger } from '@zhin.js/logger';
+import { AsyncLocalStorage } from 'node:async_hooks';
 import { createNotificationRouter, type NotificationRouter } from './assistant/notification-router.js';
 import type { ScheduleJob, ScheduleJobExecutionPlan } from './assistant/types.js';
 import { scheduleJobCreatorFromPrincipal } from './assistant/job-creator.js';
@@ -17,7 +18,6 @@ import type { ZhinAgentConfig } from './config/zhin-agent-config.js';
 import { DEFAULT_CONFIG } from './config/zhin-agent-defaults.js';
 
 const logger = getLogger('task-executor');
-const sceneLocks = new KeyedMutex();
 
 export interface TaskExecutionResult extends ScheduleExecutionResult {
   responseText: string;
@@ -52,6 +52,10 @@ export interface ScheduleActivityPort {
 }
 
 export function createTaskExecutor(deps: TaskExecutorDeps) {
+  const sceneLocks = new KeyedMutex();
+  const executionContext = new AsyncLocalStorage<boolean>();
+  let disposed = false;
+  let disposal: Promise<void> | undefined;
   const router = deps.router ?? createNotificationRouter({ resolveAdapter: deps.resolveAdapter });
   const domain = deps.domain ?? new ScheduleExecutionDomainImpl({
     turn: deps.turn ?? missingScheduleTurnPort(),
@@ -60,6 +64,7 @@ export function createTaskExecutor(deps: TaskExecutorDeps) {
   });
 
   async function execute(job: ScheduleJob, options: TaskExecutionOptions = {}): Promise<TaskExecutionResult> {
+    if (disposed) throw new Error('TaskExecutor has been disposed');
     options.signal?.throwIfAborted();
     const previewSource = options.previewSource;
     const effectiveNotify = router.resolveEffectiveNotify(job.notify, deps.defaultNotify);
@@ -71,52 +76,57 @@ export function createTaskExecutor(deps: TaskExecutorDeps) {
       ? `preview:${previewSource.sessionKey}`
       : scheduleLockKey(job, effectiveNotify);
 
-    await event('start');
-    let result: ScheduleExecutionResult;
-    try {
-      result = await sceneLocks.run(lockKey, () => domain.execute(job, {
-        preview: Boolean(previewSource),
-        signal: options.signal,
-      }), options.signal);
-      options.signal?.throwIfAborted();
-    } catch (error) {
-      await event('error');
-      throw error;
-    }
-    const executionPlan = previewSource
-      ? {
-          prompt: job.action.prompt,
-          tools: result.audit.toolsResolved.length ? result.audit.toolsResolved : undefined,
-          skills: result.audit.skillsResolved?.length ? result.audit.skillsResolved : undefined,
-          previewSample: result.output || undefined,
-          previewedAt: Date.now(),
-          confirmed: false,
-        }
-      : job.executionPlan;
-
-    if (!result.success) {
-      await event('error');
-      logger.error(`[TaskExecutor] 执行失败: ${result.error ?? 'unknown error'}`);
-    } else if (previewSource) {
-      await event('finish');
-    } else {
-      if (result.output) {
-        try {
-          await deliverScheduleToAdapter({
-            notify: effectiveNotify,
-            content: result.output,
-            router,
-            source: 'scheduled',
-          });
-        } catch (error) {
-          await event('error');
-          throw error;
-        }
+    return sceneLocks.run(lockKey, () => executionContext.run(true, async () => {
+      // Activity belongs to admitted execution, not to time spent waiting for
+      // the per-scene mutex. Keeping its terminal inside the same critical
+      // section prevents a prior run from clearing a later run's indicator.
+      await event('start');
+      let result: ScheduleExecutionResult;
+      try {
+        result = await domain.execute(job, {
+          preview: Boolean(previewSource),
+          signal: options.signal,
+        });
+        options.signal?.throwIfAborted();
+      } catch (error) {
+        await event('error');
+        throw error;
       }
-      await event('finish');
-    }
+      const executionPlan = previewSource
+        ? {
+            prompt: job.action.prompt,
+            tools: result.audit.toolsResolved.length ? result.audit.toolsResolved : undefined,
+            skills: result.audit.skillsResolved?.length ? result.audit.skillsResolved : undefined,
+            previewSample: result.output || undefined,
+            previewedAt: Date.now(),
+            confirmed: false,
+          }
+        : job.executionPlan;
 
-    return { ...result, responseText: result.output, executionPlan };
+      if (!result.success) {
+        await event('error');
+        logger.error(`[TaskExecutor] 执行失败: ${result.error ?? 'unknown error'}`);
+      } else if (previewSource) {
+        await event('finish');
+      } else {
+        if (result.output) {
+          try {
+            await deliverScheduleToAdapter({
+              notify: effectiveNotify,
+              content: result.output,
+              router,
+              source: 'scheduled',
+            });
+          } catch (error) {
+            await event('error');
+            throw error;
+          }
+        }
+        await event('finish');
+      }
+
+      return { ...result, responseText: result.output, executionPlan };
+    }), options.signal);
   }
 
   async function preview(
@@ -141,7 +151,19 @@ export function createTaskExecutor(deps: TaskExecutorDeps) {
     return execute(job, { previewSource: source });
   }
 
-  return { execute, preview, resolveAdapter: deps.resolveAdapter };
+  function dispose(): Promise<void> {
+    if (executionContext.getStore()) {
+      return Promise.reject(new Error(
+        'TaskExecutor cannot dispose from inside its own execution callback; dispose it from the owning lifecycle',
+      ));
+    }
+    if (disposal) return disposal;
+    disposed = true;
+    disposal = sceneLocks.drain();
+    return disposal;
+  }
+
+  return { execute, preview, resolveAdapter: deps.resolveAdapter, dispose };
 }
 
 function missingScheduleTurnPort(): ScheduleTurnPort {
@@ -158,8 +180,15 @@ function scheduleLockKey(job: ScheduleJob, notify: import('./assistant/types.js'
   return `im:${scene.platform}:${scene.endpointKey}:${scene.kind}:${scene.sceneId}`;
 }
 
-export async function drainTaskExecutorLocks(timeoutMs: number): Promise<void> {
-  await sceneLocks.drain(timeoutMs);
+/**
+ * @deprecated Task executors now own and drain their own scene locks through
+ * `executor.dispose()`. Retained only to provide explicit migration guidance;
+ * calling it now rejects because no process-global lock owner exists.
+ */
+export async function drainTaskExecutorLocks(_timeoutMs: number): Promise<void> {
+  throw new Error(
+    'Global TaskExecutor lock draining is no longer supported; retain the executor and await executor.dispose()',
+  );
 }
 
 export type TaskExecutor = ReturnType<typeof createTaskExecutor>;

--- a/packages/im/agent/src/turn/inbound-turn-queue.ts
+++ b/packages/im/agent/src/turn/inbound-turn-queue.ts
@@ -19,6 +19,7 @@ interface QueuedInboundTurn<T> {
   sessionKey: string;
   senderId: string;
   commMessage: Message;
+  queuedFeedbackMessages: Message[];
   textParts: string[];
   enqueuedAt: number;
   lastEnqueuedAt: number;
@@ -86,6 +87,8 @@ export class InboundTurnQueue {
         tail.lastEnqueuedAt = now;
         tail.commMessage = commMessage;
         tail.run = run;
+        this.activityEmitter.emitQueuedStart(commMessage, sessionKey);
+        tail.queuedFeedbackMessages.push(commMessage);
         void this.pump(sessionKey);
         return tail.promise;
       }
@@ -102,6 +105,7 @@ export class InboundTurnQueue {
       sessionKey,
       senderId,
       commMessage,
+      queuedFeedbackMessages: [],
       textParts: content ? [content] : [],
       enqueuedAt: now,
       lastEnqueuedAt: now,
@@ -125,6 +129,7 @@ export class InboundTurnQueue {
     const shouldShowPending = this.inFlight.has(sessionKey) || queue.length > 1;
     if (shouldShowPending) {
       this.activityEmitter.emitQueuedStart(commMessage, sessionKey);
+      entry.queuedFeedbackMessages.push(commMessage);
     }
 
     void this.pump(sessionKey);
@@ -135,7 +140,7 @@ export class InboundTurnQueue {
     for (const queue of this.queues.values()) {
       for (const entry of queue) {
         entry.disposeAbortListener?.();
-        this.activityEmitter.emitQueuedClear(entry.commMessage, entry.sessionKey);
+        this.clearQueuedFeedback(entry);
         entry.reject(new Error('InboundTurnQueue disposed'));
       }
     }
@@ -155,7 +160,7 @@ export class InboundTurnQueue {
     while (queue.length > 0 && this.isExpired(queue[0]!, now)) {
       const expired = queue.shift()!;
       expired.disposeAbortListener?.();
-      this.activityEmitter.emitQueuedClear(expired.commMessage, sessionKey);
+      this.clearQueuedFeedback(expired);
       expired.reject(new InboundTurnExpiredError(sessionKey));
     }
 
@@ -181,7 +186,7 @@ export class InboundTurnQueue {
           this.queues.delete(sessionKey);
         }
 
-        this.activityEmitter.emitQueuedClear(entry.commMessage, sessionKey);
+        this.clearQueuedFeedback(entry);
         entry.started = true;
 
         try {
@@ -214,8 +219,15 @@ export class InboundTurnQueue {
     queue.splice(index, 1);
     if (queue.length === 0) this.queues.delete(entry.sessionKey);
     entry.disposeAbortListener?.();
-    this.activityEmitter.emitQueuedClear(entry.commMessage, entry.sessionKey);
+    this.clearQueuedFeedback(entry);
     entry.reject(inboundAbortReason(entry.sessionKey, entry.signal?.reason));
+  }
+
+  private clearQueuedFeedback(entry: QueuedInboundTurn<unknown>): void {
+    for (const commMessage of entry.queuedFeedbackMessages) {
+      this.activityEmitter.emitQueuedClear(commMessage, entry.sessionKey);
+    }
+    entry.queuedFeedbackMessages.length = 0;
   }
 }
 

--- a/packages/im/agent/src/turn/turn-pipeline.ts
+++ b/packages/im/agent/src/turn/turn-pipeline.ts
@@ -26,12 +26,13 @@ import type {
   OutputElement,
   Tool,
 } from '../internal/agent-host.js';
-import type { Message } from '@zhin.js/core';
+import { resolveIMSessionIdFromMessage, type Message } from '@zhin.js/core';
 import {
   turnMediaFromMessage,
   turnContextViewFromMessage,
 } from '../context/im-turn-context-adapter.js';
 import { createClassicToolExecutionAuthority } from '../tool/classic-tool-execution-authority.js';
+import { createTurnActivityProjector } from '../activity-feedback/turn-event-projector.js';
 
 function requireSessionSystem(host: ZhinAgentPrivate): SessionSystem {
   if (!host.sessionSystem) {
@@ -75,6 +76,36 @@ export async function processTextTurn(
   onChunk?: OnChunkCallback,
   extras?: ProcessTextTurnOptions,
 ): Promise<OutputElement[]> {
+  try {
+    return await processTextTurnInner(host, content, commMessage, externalTools, onChunk, extras);
+  } catch (error) {
+    const sessionId = resolveIMSessionIdFromMessage(commMessage);
+    const payload = host.emitter.createPayload(sessionId, commMessage, 'text', {
+      content,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    try {
+      await host.emitter.dispatch('ai.processing.error', payload);
+    } catch {
+      // Activity observers cannot replace the original turn failure.
+    }
+    try {
+      await host.emitter.dispatch('ai.typing.stop', { ...payload, reason: 'processing_error' });
+    } catch {
+      // Activity observers cannot replace the original turn failure.
+    }
+    throw error;
+  }
+}
+
+async function processTextTurnInner(
+  host: ZhinAgentPrivate,
+  content: string,
+  commMessage: Message,
+  externalTools: Tool[] = [],
+  onChunk?: OnChunkCallback,
+  extras?: ProcessTextTurnOptions,
+): Promise<OutputElement[]> {
     const t0 = now();
     const sessionSystem = requireSessionSystem(host);
     const prep = await sessionSystem.prepareTextTurn(host, commMessage, content, {
@@ -89,9 +120,16 @@ export async function processTextTurn(
       }, { sessionId });
     }
 
-    await host.emitter.dispatch('ai.processing.start', host.emitter.createPayload(sessionId, commMessage, 'text', {
+    const activityPayload = host.emitter.createPayload(sessionId, commMessage, 'text', {
       content,
-    }));
+    });
+    await host.emitter.dispatch('ai.processing.start', activityPayload);
+    const projectActivity = createTurnActivityProjector({
+      payload: activityPayload,
+      publish: (event, payload) => host.emitter.emit(event, payload),
+      thinkingPreview: host.config.thinkingPreview === true,
+      thinkingMaxLength: host.config.thinkingPreviewMaxLength ?? 200,
+    });
     logPhase(host.phaseConfig, 'turn.start', sessionId, {
       mode: 'text',
       provider: host.getTurnProvider().name,
@@ -218,7 +256,10 @@ export async function processTextTurn(
           toolCatalog: toolsPrep.catalog,
           toolLoading: toolsPrep.resolved.deferred ? 'deferred' : 'direct',
           conversationPersistence: 'session',
-          onTurnEvent: extras?.onTurnEvent,
+          onTurnEvent: (event) => {
+            extras?.onTurnEvent?.(event);
+            projectActivity(event);
+          },
           journal: extras?.journal,
           generation: extras?.generation,
           });

--- a/packages/im/agent/src/typing-indicator/index.ts
+++ b/packages/im/agent/src/typing-indicator/index.ts
@@ -145,9 +145,11 @@ export class ReactionTypingIndicator implements TypingIndicator {
     this.active = false;
     this.reactionId = null;
 
-    void Promise.resolve(this.removeReaction(messageId, reactionId)).catch((error) => {
+    try {
+      await this.removeReaction(messageId, reactionId);
+    } catch (error) {
       logger.warn('Failed to remove reaction:', error);
-    });
+    }
   }
 
   isActive(): boolean {

--- a/packages/im/agent/src/typing-indicator/index.ts
+++ b/packages/im/agent/src/typing-indicator/index.ts
@@ -243,6 +243,8 @@ export class MessageTypingIndicator implements TypingIndicator {
 export class NativeTypingIndicator implements TypingIndicator {
   private active = false;
   private keepaliveTimer?: ReturnType<typeof setInterval>;
+  private keepaliveTail: Promise<void> = Promise.resolve();
+  private stopping?: Promise<void>;
 
   constructor(
     private options: TypingIndicatorOptions,
@@ -252,6 +254,7 @@ export class NativeTypingIndicator implements TypingIndicator {
   ) {}
 
   async start(): Promise<void> {
+    if (this.stopping) await this.stopping;
     if (this.active || !hasTypingSendTarget(this.options)) {
       return;
     }
@@ -261,9 +264,14 @@ export class NativeTypingIndicator implements TypingIndicator {
       const raw = this.config.platformConfig?.keepaliveIntervalMs;
       const intervalMs = typeof raw === 'number' && raw > 0 ? raw : 5_000;
       this.keepaliveTimer = setInterval(() => {
-        void this.startTyping(this.options).catch((error) => {
-          logger.error('keepalive failed:', error);
-        });
+        this.keepaliveTail = this.keepaliveTail
+          .catch(() => undefined)
+          .then(async () => {
+            if (this.active) await this.startTyping(this.options);
+          })
+          .catch((error) => {
+            logger.error('keepalive failed:', error);
+          });
       }, intervalMs);
     } catch (error) {
       this.active = false;
@@ -276,20 +284,28 @@ export class NativeTypingIndicator implements TypingIndicator {
   }
 
   async stop(): Promise<void> {
+    if (this.stopping) return this.stopping;
     if (!this.active) {
       return;
     }
+    this.active = false;
     if (this.keepaliveTimer) {
       clearInterval(this.keepaliveTimer);
       this.keepaliveTimer = undefined;
     }
-    try {
-      await this.stopTyping(this.options);
-    } catch (error) {
-      logger.error('Failed to stop native typing:', error);
-    } finally {
-      this.active = false;
-    }
+    this.stopping = (async () => {
+      try {
+        // A keepalive may already be inside the platform call. Wait for it so
+        // stopTyping is the last wire operation and cannot be overwritten.
+        await this.keepaliveTail.catch(() => undefined);
+        await this.stopTyping(this.options);
+      } catch (error) {
+        logger.error('Failed to stop native typing:', error);
+      } finally {
+        this.stopping = undefined;
+      }
+    })();
+    return this.stopping;
   }
 
   isActive(): boolean {
@@ -312,6 +328,8 @@ export class NoneTypingIndicator implements TypingIndicator {
 export class TypingIndicatorManager {
   private adapters: Map<string, TypingIndicatorAdapter> = new Map();
   private activeIndicators: Map<string, TypingIndicator> = new Map();
+  private pendingStarts: Map<string, Promise<TypingIndicator>> = new Map();
+  private pendingStops: Map<string, Promise<void>> = new Map();
   private defaultConfig: TypingIndicatorConfig;
 
   constructor(defaultConfig: Partial<TypingIndicatorConfig> = {}) {
@@ -371,21 +389,35 @@ export class TypingIndicatorManager {
     config?: Partial<TypingIndicatorConfig>,
   ): Promise<TypingIndicator> {
     const key = this.getIndicatorKey(options);
+    const stopping = this.pendingStops.get(key);
+    if (stopping) await stopping;
     const existing = this.activeIndicators.get(key);
     if (existing) {
+      const pending = this.pendingStarts.get(key);
+      if (pending) return pending;
       return existing;
     }
 
     const indicator = this.createIndicator(options, config);
     this.activeIndicators.set(key, indicator);
+    const starting = (async () => {
+      try {
+        await indicator.start();
+        if (!indicator.isActive() && this.activeIndicators.get(key) === indicator) {
+          this.activeIndicators.delete(key);
+        }
+        return indicator;
+      } catch (error) {
+        if (this.activeIndicators.get(key) === indicator) this.activeIndicators.delete(key);
+        throw error;
+      }
+    })();
+    this.pendingStarts.set(key, starting);
     try {
-      await indicator.start();
-    } catch (error) {
-      this.activeIndicators.delete(key);
-      throw error;
+      return await starting;
+    } finally {
+      if (this.pendingStarts.get(key) === starting) this.pendingStarts.delete(key);
     }
-
-    return indicator;
   }
 
   /**
@@ -393,11 +425,26 @@ export class TypingIndicatorManager {
    */
   async stop(options: TypingIndicatorOptions): Promise<void> {
     const key = this.getIndicatorKey(options);
-    const indicator = this.activeIndicators.get(key);
-
-    if (indicator) {
-      await indicator.stop();
-      this.activeIndicators.delete(key);
+    const existingStop = this.pendingStops.get(key);
+    if (existingStop) return existingStop;
+    // Publish the shared stop before waiting for start. Otherwise two callers
+    // can both cross the await and independently stop the same indicator.
+    const stopping = (async () => {
+      await this.pendingStarts.get(key)?.catch(() => undefined);
+      const indicator = this.activeIndicators.get(key);
+      if (indicator) {
+        try {
+          await indicator.stop();
+        } finally {
+          if (this.activeIndicators.get(key) === indicator) this.activeIndicators.delete(key);
+        }
+      }
+    })();
+    this.pendingStops.set(key, stopping);
+    try {
+      await stopping;
+    } finally {
+      if (this.pendingStops.get(key) === stopping) this.pendingStops.delete(key);
     }
   }
 
@@ -405,6 +452,8 @@ export class TypingIndicatorManager {
    * 停止所有提示
    */
   async stopAll(): Promise<void> {
+    await Promise.allSettled(this.pendingStarts.values());
+    await Promise.allSettled(this.pendingStops.values());
     for (const [key, indicator] of this.activeIndicators.entries()) {
       try {
         await indicator.stop();
@@ -413,6 +462,8 @@ export class TypingIndicatorManager {
       }
     }
     this.activeIndicators.clear();
+    this.pendingStarts.clear();
+    this.pendingStops.clear();
   }
 
   /**
@@ -427,7 +478,11 @@ export class TypingIndicatorManager {
    * 生成指示器键
    */
   private getIndicatorKey(options: TypingIndicatorOptions): string {
-    return `${options.platform}:${options.endpointKey}:${options.sessionId || options.messageId}`;
+    return JSON.stringify([
+      options.platform,
+      options.endpointKey,
+      options.sessionId || options.messageId || null,
+    ]);
   }
 
   async dispose(): Promise<void> {
@@ -574,7 +629,7 @@ export function provideTypingIndicatorManager(
 ): TypingIndicatorManager {
   const manager = new TypingIndicatorManager(defaultConfig);
   typingStore.provide(context, manager);
-  context.lifecycle.add(() => void manager.dispose());
+  context.lifecycle.add(() => manager.dispose());
   return manager;
 }
 

--- a/packages/im/agent/src/utils/keyed-mutex.ts
+++ b/packages/im/agent/src/utils/keyed-mutex.ts
@@ -31,12 +31,24 @@ export class KeyedMutex {
     return this.chains.size;
   }
 
-  async drain(timeoutMs: number): Promise<void> {
-    const deadline = Date.now() + timeoutMs;
-    while (this.chains.size > 0 && Date.now() < deadline) {
-      await Promise.allSettled([...this.chains.values()]);
+  async drain(timeoutMs?: number): Promise<void> {
+    const pending = Promise.allSettled([...this.chains.values()]).then(() => undefined);
+    if (timeoutMs === undefined) {
+      await pending;
+      return;
     }
-    this.chains.clear();
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    try {
+      await Promise.race([
+        pending,
+        new Promise<void>((resolve) => {
+          timer = setTimeout(resolve, Math.max(0, timeoutMs));
+          timer.unref?.();
+        }),
+      ]);
+    } finally {
+      if (timer) clearTimeout(timer);
+    }
   }
 }
 

--- a/packages/im/agent/src/zhin-agent/index.ts
+++ b/packages/im/agent/src/zhin-agent/index.ts
@@ -164,6 +164,7 @@ export class ZhinAgent implements IAgentTurnProcessor, IAgentSessionManager, IAg
   lastTurnMetrics: ZhinAgentTurnMetrics | null = null;
   private readonly inboundQueueConfig: ResolvedInboundQueueConfig;
   readonly inboundTurnQueue: InboundTurnQueue;
+  private disposal?: Promise<void>;
   readonly turnContextState: TurnContextBridgeState = {
     alwaysSkillsBaseline: '',
   };
@@ -524,13 +525,17 @@ export class ZhinAgent implements IAgentTurnProcessor, IAgentSessionManager, IAg
     return true;
   }
 
-  dispose(): void {
-    disposeZhinAgentResources(this);
-    this.subagentSystem = null;
-    this.lastTurnMetrics = null;
-     
-    this.provider = null!;
-    this.providerResolver = null;
-    clearZhinAgentRuntimeModules(this.runtimeModules);
+  dispose(): Promise<void> {
+    if (this.disposal) return this.disposal;
+    this.disposal = (async () => {
+      await disposeZhinAgentResources(this);
+      this.subagentSystem = null;
+      this.lastTurnMetrics = null;
+
+      this.provider = null!;
+      this.providerResolver = null;
+      clearZhinAgentRuntimeModules(this.runtimeModules);
+    })();
+    return this.disposal;
   }
 }

--- a/packages/im/agent/tests/activity-feedback/manager.test.ts
+++ b/packages/im/agent/tests/activity-feedback/manager.test.ts
@@ -36,11 +36,33 @@ describe('ActivityFeedbackManager', () => {
     await manager.start('active', base, { type: 'reaction', emoji: '60' });
 
     expect(created).toHaveLength(2);
-    expect(created[0]!.sessionId).toBe('group:123:456::phase:queued');
-    expect(created[1]!.sessionId).toBe('group:123:456::phase:active');
+    expect(created[0]!.sessionId).toBe('group:123:456::phase:queued::message:msg1');
+    expect(created[1]!.sessionId).toBe('group:123:456::phase:active::message:msg1');
 
     expect(manager.getActiveIndicator('queued', base)).toBeDefined();
     expect(manager.getActiveIndicator('active', base)).toBeDefined();
+  });
+
+  it('keys reactions by message while leaving message feedback session-scoped', async () => {
+    const created: TypingIndicatorOptions[] = [];
+    const manager = new ActivityFeedbackManager();
+    manager.registerAdapter(mockAdapter((options) => created.push({ ...options })));
+    const base = {
+      platform: 'test',
+      endpointKey: 'ep1',
+      sessionId: 'group:123:456',
+      sceneType: 'group' as const,
+    };
+
+    await manager.start('queued', { ...base, messageId: 'msg1' }, { type: 'reaction' });
+    await manager.start('queued', { ...base, messageId: 'msg2' }, { type: 'reaction' });
+    await manager.start('thinking', { ...base, messageId: 'msg1' }, { type: 'message' });
+
+    expect(created.map((options) => options.sessionId)).toEqual([
+      'group:123:456::phase:queued::message:msg1',
+      'group:123:456::phase:queued::message:msg2',
+      'group:123:456::phase:thinking',
+    ]);
   });
 
   it('stops only the requested phase', async () => {

--- a/packages/im/agent/tests/ai-event-subscriber.test.ts
+++ b/packages/im/agent/tests/ai-event-subscriber.test.ts
@@ -123,4 +123,55 @@ describe('ai-event-subscriber', () => {
 
     expect(received).toEqual(['runtime-dispatch-1']);
   });
+
+  it('dispatch awaits async Runtime handlers', async () => {
+    activityFeedbackAiBus.clear();
+    const received: string[] = [];
+    const dispose = subscribeAIEventsOnTarget(activityFeedbackAiBus, {
+      onProcessingStart: async () => {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        received.push('start');
+      },
+    });
+
+    await activityFeedbackAiBus.dispatch('ai.processing.start', {
+      sessionId: 'ordered-session',
+      source: 'zhin-agent',
+    });
+
+    expect(received).toEqual(['start']);
+    dispose();
+    activityFeedbackAiBus.clear();
+  });
+
+  it('does not deliver an in-flight event to a listener added by the next generation', async () => {
+    activityFeedbackAiBus.clear();
+    const received: string[] = [];
+    let releaseOld!: () => void;
+    const oldPending = new Promise<void>((resolve) => {
+      releaseOld = resolve;
+    });
+    const oldListener = async () => {
+      received.push('old:start');
+      await oldPending;
+      received.push('old:finish');
+    };
+    const nextListener = () => {
+      received.push('next');
+    };
+    activityFeedbackAiBus.on('ai.processing.start', oldListener);
+
+    const dispatch = activityFeedbackAiBus.dispatch('ai.processing.start', {
+      sessionId: 'hmr-session',
+      source: 'zhin-agent',
+    });
+    await Promise.resolve();
+    activityFeedbackAiBus.off('ai.processing.start', oldListener);
+    activityFeedbackAiBus.on('ai.processing.start', nextListener);
+    releaseOld();
+    await dispatch;
+
+    expect(received).toEqual(['old:start', 'old:finish']);
+    activityFeedbackAiBus.clear();
+  });
 });

--- a/packages/im/agent/tests/ai/subagent.test.ts
+++ b/packages/im/agent/tests/ai/subagent.test.ts
@@ -103,11 +103,58 @@ describe('SubagentRuntime', () => {
     });
   });
 
-  afterEach(() => {
-    manager.dispose();
+  afterEach(async () => {
+    await manager.dispose();
   });
 
   describe('spawn', () => {
+    it('dispose during async enrichment must fail closed before starting work', async () => {
+      let releaseMeta!: () => void;
+      const enrichment = new Promise<void>((resolve) => { releaseMeta = resolve; });
+      const guarded = new SubagentRuntime({
+        provider: provider as any,
+        workspace: '/tmp/test-workspace',
+        createTools: () => mockTools,
+        resolveAgentMeta: async () => {
+          await enrichment;
+          return null;
+        },
+      });
+
+      const spawning = guarded.spawn({ task: 'late', agent: 'worker', origin: baseOrigin });
+      await Promise.resolve();
+      const disposal = guarded.dispose();
+      releaseMeta();
+
+      await disposal;
+      await expect(spawning).rejects.toThrow(/disposed|retired|aborted/i);
+      expect(llm.calls).toHaveLength(0);
+    });
+
+    it('dispose during spawn observer must abort before entering agent loop', async () => {
+      let releaseSpawn!: () => void;
+      let spawnObserved!: () => void;
+      const observed = new Promise<void>((resolve) => { spawnObserved = resolve; });
+      const guarded = new SubagentRuntime({
+        provider: provider as any,
+        workspace: '/tmp/test-workspace',
+        createTools: () => mockTools,
+        onEvent: async (event) => {
+          if (event.phase !== 'spawn') return;
+          spawnObserved();
+          await new Promise<void>((resolve) => { releaseSpawn = resolve; });
+        },
+      });
+
+      const spawning = guarded.spawn({ task: 'late', origin: baseOrigin });
+      await observed;
+      const disposal = guarded.dispose();
+      releaseSpawn();
+
+      await disposal;
+      await expect(spawning).rejects.toThrow(/disposed|retired|aborted/i);
+      expect(llm.calls).toHaveLength(0);
+    });
     it('应返回确认文本并包含任务标签', async () => {
       const result = await manager.spawn({
         task: '分析项目结构',
@@ -158,6 +205,7 @@ describe('SubagentRuntime', () => {
       expect(onEvent).toHaveBeenCalledWith(expect.objectContaining({ phase: 'spawn', label: 'README分析' }));
       expect(onEvent).toHaveBeenCalledWith(expect.objectContaining({ phase: 'start', label: 'README分析' }));
       expect(onEvent).toHaveBeenCalledWith(expect.objectContaining({ phase: 'finish', label: 'README分析', status: 'ok' }));
+      expect(onEvent.mock.calls.map(([event]) => event.phase)).toEqual(['spawn', 'start', 'finish']);
 
       eventManager.dispose();
     });
@@ -304,12 +352,149 @@ describe('SubagentRuntime', () => {
 
       expect(manager.getRunningCount()).toBe(0);
     });
+
+    it('cancel 应中断挂起的 agent loop 并产生错误终态', async () => {
+      llm.hang();
+      const dispatched: string[] = [];
+      const emitted: string[] = [];
+      const emitter = {
+        createPayload: (_sid: string, _ctx: unknown, _mode: string, extra: Record<string, unknown> = {}) => ({
+          sessionId: 'test-session', messageId: 'msg-1', ...extra,
+        }),
+        dispatch: vi.fn(async (name: string) => { dispatched.push(name); }),
+        emit: vi.fn((name: string) => { emitted.push(name); }),
+      } as unknown as ZhinAgentEventEmitter;
+      manager.setEventEmitter(emitter);
+
+      const confirmation = await manager.spawn({ task: '挂起任务', origin: baseOrigin });
+      const taskId = confirmation.match(/id: ([^)]+)/)?.[1];
+      expect(taskId).toBeTruthy();
+      await vi.waitFor(() => expect(llm.calls).toHaveLength(1));
+      expect(manager.cancel(taskId!)).toBe(true);
+
+      await vi.waitFor(() => expect(onSubagentComplete).toHaveBeenCalledTimes(1));
+      expect(onSubagentComplete.mock.calls[0]![0].status).toBe('error');
+      expect(dispatched).toContain('ai.processing.error');
+      expect(emitted).toContain('ai.typing.stop');
+      expect(manager.getRunningCount()).toBe(0);
+    });
   });
 
   describe('dispose', () => {
     it('应清空 runningTasks', () => {
       manager.dispose();
       expect(manager.getRunningCount()).toBe(0);
+    });
+
+    it('dispose 中断子任务时只发终态清理，不再投递旧 generation 结果', async () => {
+      llm.hang();
+      const dispatched: string[] = [];
+      const emitter = {
+        createPayload: (_sid: string, _ctx: unknown, _mode: string, extra: Record<string, unknown> = {}) => ({
+          sessionId: 'test-session', messageId: 'msg-1', ...extra,
+        }),
+        dispatch: vi.fn(async (name: string) => { dispatched.push(name); }),
+        emit: vi.fn(),
+      } as unknown as ZhinAgentEventEmitter;
+      manager.setEventEmitter(emitter);
+      await manager.spawn({ task: '退役时挂起', origin: baseOrigin });
+      await vi.waitFor(() => expect(llm.calls).toHaveLength(1));
+
+      manager.dispose();
+      await vi.waitFor(() => expect(dispatched).toContain('ai.processing.error'));
+
+      expect(onSubagentComplete).not.toHaveBeenCalled();
+      expect(manager.getRunningCount()).toBe(0);
+    });
+
+    it('dispose 应等待已跟踪任务的 terminal observer 完成', async () => {
+      llm.hang();
+      let finishEntered!: () => void;
+      let releaseFinish!: () => void;
+      const entered = new Promise<void>((resolve) => { finishEntered = resolve; });
+      const guarded = new SubagentRuntime({
+        provider: provider as any,
+        workspace: '/tmp/test-workspace',
+        createTools: () => mockTools,
+        onEvent: async (event) => {
+          if (event.phase !== 'finish') return;
+          finishEntered();
+          await new Promise<void>((resolve) => { releaseFinish = resolve; });
+        },
+      });
+      await guarded.spawn({ task: 'tracked', origin: baseOrigin });
+      await vi.waitFor(() => expect(llm.calls).toHaveLength(1));
+
+      let settled = false;
+      const disposal = Promise.resolve(guarded.dispose()).then(() => { settled = true; });
+      await entered;
+      expect(settled).toBe(false);
+      releaseFinish();
+      await disposal;
+      expect(settled).toBe(true);
+    });
+
+    it('processingStart observer 内 dispose 不 self-wait，但外部 dispose 仍等 terminal', async () => {
+      const holder: { current?: SubagentRuntime } = {};
+      let finishEntered!: () => void;
+      let releaseFinish!: () => void;
+      const entered = new Promise<void>((resolve) => { finishEntered = resolve; });
+      let observerDisposeReturned = false;
+      const emitter = {
+        createPayload: (_sid: string, _ctx: unknown, _mode: string, extra: Record<string, unknown> = {}) => ({
+          sessionId: 'test-session', messageId: 'msg-1', ...extra,
+        }),
+        dispatch: vi.fn(async (name: string) => {
+          if (name === 'ai.processing.start') {
+            await holder.current!.dispose();
+            observerDisposeReturned = true;
+          }
+        }),
+        emit: vi.fn(),
+      } as unknown as ZhinAgentEventEmitter;
+      const guarded = new SubagentRuntime({
+        provider: provider as any,
+        workspace: '/tmp/test-workspace',
+        createTools: () => mockTools,
+        eventEmitter: emitter,
+        onEvent: async (event) => {
+          if (event.phase !== 'finish') return;
+          finishEntered();
+          await new Promise<void>((resolve) => { releaseFinish = resolve; });
+        },
+      });
+      holder.current = guarded;
+
+      await guarded.spawn({ task: 'dispose-from-processing-start', origin: baseOrigin });
+      await entered;
+      expect(observerDisposeReturned).toBe(true);
+      let externalSettled = false;
+      const external = guarded.dispose().then(() => { externalSettled = true; });
+      await Promise.resolve();
+      expect(externalSettled).toBe(false);
+      releaseFinish();
+      await external;
+    });
+
+    it('finish observer 内 dispose 排除当前 task，不与自身 settlement 死锁', async () => {
+      const holder: { current?: SubagentRuntime } = {};
+      let finishDisposeReturned = false;
+      const guarded = new SubagentRuntime({
+        provider: provider as any,
+        workspace: '/tmp/test-workspace',
+        createTools: () => mockTools,
+        onEvent: async (event) => {
+          if (event.phase !== 'finish') return;
+          await holder.current!.dispose();
+          finishDisposeReturned = true;
+        },
+      });
+      holder.current = guarded;
+
+      await guarded.spawn({ task: 'dispose-from-finish', origin: baseOrigin });
+      await vi.waitFor(() => expect(finishDisposeReturned).toBe(true));
+      await guarded.dispose();
+      expect(guarded.getRunningCount()).toBe(0);
     });
 
     it('应上报与主 agent 同类的 AI 处理事件（source=subagent）', async () => {

--- a/packages/im/agent/tests/ai/zhin-agent.test.ts
+++ b/packages/im/agent/tests/ai/zhin-agent.test.ts
@@ -300,5 +300,22 @@ describe('ZhinAgent', () => {
     it('应正常清理资源', () => {
       expect(() => agent.dispose()).not.toThrow();
     });
+
+    it('并发 dispose 应共享同一关闭完成', async () => {
+      let release!: () => void;
+      const dispose = vi.fn(() => new Promise<void>((resolve) => { release = resolve; }));
+      agent.subagentSystem = { dispose } as unknown as import('../../src/subagent/subagent-system.js').SubagentSystem;
+
+      const first = agent.dispose();
+      let secondSettled = false;
+      const repeated = agent.dispose();
+      expect(repeated).toBe(first);
+      const second = repeated.then(() => { secondSettled = true; });
+      await Promise.resolve();
+      expect(secondSettled).toBe(false);
+      expect(dispose).toHaveBeenCalledTimes(1);
+      release();
+      await Promise.all([first, second]);
+    });
   });
 });

--- a/packages/im/agent/tests/plugin-runtime/full-agent-turn-engine.test.ts
+++ b/packages/im/agent/tests/plugin-runtime/full-agent-turn-engine.test.ts
@@ -82,6 +82,19 @@ describe('FullAgentTurnEngine', () => {
       runText(input: Record<string, unknown>) {
         coreInput = input;
         return (async function* () {
+          yield {
+            type: 'tool_call' as const,
+            toolName: 'web_search',
+            args: { query: 'zhin' },
+            toolUseId: 'tool-1',
+          };
+          yield {
+            type: 'tool_result' as const,
+            toolName: 'web_search',
+            output: 'done',
+            durationMs: 12,
+            toolUseId: 'tool-1',
+          };
           yield { type: 'chunk' as const, text: 'done', accumulated: 'done' };
           yield {
             type: 'turn_end' as const,
@@ -133,7 +146,11 @@ describe('FullAgentTurnEngine', () => {
     const events: string[] = [];
     const started: Array<Record<string, unknown>> = [];
     const finished: Array<Record<string, unknown>> = [];
+    const toolCalls: Array<Record<string, unknown>> = [];
+    const toolResults: Array<Record<string, unknown>> = [];
     activityFeedbackAiBus.on('ai.processing.start', (payload) => started.push(payload as never));
+    activityFeedbackAiBus.on('ai.tool.call', (payload) => toolCalls.push(payload as never));
+    activityFeedbackAiBus.on('ai.tool.result', (payload) => toolResults.push(payload as never));
     activityFeedbackAiBus.on('ai.processing.finish', (payload) => {
       order.push('finish');
       finished.push(payload as never);
@@ -149,7 +166,7 @@ describe('FullAgentTurnEngine', () => {
       if (step.value.type === 'turn_end') order.push('terminal');
     }
 
-    expect(events).toEqual(['chunk', 'turn_end']);
+    expect(events).toEqual(['tool_call', 'tool_result', 'chunk', 'turn_end']);
     expect(order).toEqual(['context-read', 'terminal', 'reply', 'touch', 'context-commit:9', 'finalize', 'finish']);
     expect(started).toHaveLength(1);
     expect(started[0]).toMatchObject({
@@ -161,6 +178,8 @@ describe('FullAgentTurnEngine', () => {
       hookContext: { activityFeedbackEligible: true },
     });
     expect(finished).toHaveLength(1);
+    expect(toolCalls).toEqual([expect.objectContaining({ toolName: 'web_search' })]);
+    expect(toolResults).toEqual([expect.objectContaining({ toolName: 'web_search' })]);
     expect(coreInput).toMatchObject({
       toolLoading: 'deferred',
       generation: 7,

--- a/packages/im/agent/tests/subagent/subagent-system.test.ts
+++ b/packages/im/agent/tests/subagent/subagent-system.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { SubagentSystem } from '../../src/subagent/subagent-system.js';
 import { ImResultSink } from '../../src/subagent/im-result-sink.js';
 
@@ -30,5 +30,25 @@ describe('SubagentSystem', () => {
       { text: 'done', taskId: 'task-42', status: 'error' },
     );
     expect(delivered).toEqual([{ taskId: 'task-42', status: 'failed', result: 'done' }]);
+  });
+
+  it('shares concurrent disposal completion', async () => {
+    let release!: () => void;
+    const runtimeDispose = vi.fn(() => new Promise<void>((resolve) => { release = resolve; }));
+    const system = new SubagentSystem({});
+    (system as unknown as { runtime: { dispose(): Promise<void> } }).runtime = {
+      dispose: runtimeDispose,
+    };
+
+    const first = system.dispose();
+    let secondSettled = false;
+    const repeated = system.dispose();
+    expect(repeated).toBe(first);
+    const second = repeated.then(() => { secondSettled = true; });
+    await Promise.resolve();
+    expect(secondSettled).toBe(false);
+    expect(runtimeDispose).toHaveBeenCalledTimes(1);
+    release();
+    await Promise.all([first, second]);
   });
 });

--- a/packages/im/agent/tests/task-executor.test.ts
+++ b/packages/im/agent/tests/task-executor.test.ts
@@ -75,6 +75,127 @@ describe('task executor outbound seam', () => {
     expect(publish).toHaveBeenNthCalledWith(2, expect.objectContaining({ phase: 'finish' }));
   });
 
+  it('serializes schedule activity terminals with execution for the same scene', async () => {
+    let releaseFirst!: () => void;
+    const phases: string[] = [];
+    const execute = vi.fn(async () => {
+      if (execute.mock.calls.length === 1) {
+        await new Promise<void>((resolve) => { releaseFirst = resolve; });
+      }
+      return domainResult();
+    });
+    const scheduled = { ...job({ channel: 'silent' }), activityFeedback: true };
+    const executor = createTaskExecutor({
+      activity: { publish: (event) => { phases.push(event.phase); } },
+      domain: { execute },
+      resolveAdapter: () => undefined,
+    });
+
+    const first = executor.execute(scheduled);
+    await vi.waitFor(() => expect(execute).toHaveBeenCalledTimes(1));
+    const second = executor.execute(scheduled);
+    await Promise.resolve();
+    expect(phases).toEqual(['start']);
+    releaseFirst();
+    await Promise.all([first, second]);
+
+    expect(phases).toEqual(['start', 'finish', 'start', 'finish']);
+  });
+
+  it('does not serialize independent executor generations through module state', async () => {
+    let releaseFirst!: () => void;
+    const firstDomain = vi.fn(async () => {
+      await new Promise<void>((resolve) => { releaseFirst = resolve; });
+      return domainResult('first');
+    });
+    const secondDomain = vi.fn(async () => domainResult('second'));
+    const notify = { channel: 'silent' as const };
+    const firstExecutor = createTaskExecutor({ domain: { execute: firstDomain }, resolveAdapter: () => undefined });
+    const secondExecutor = createTaskExecutor({ domain: { execute: secondDomain }, resolveAdapter: () => undefined });
+
+    const first = firstExecutor.execute(job(notify));
+    await vi.waitFor(() => expect(firstDomain).toHaveBeenCalledTimes(1));
+    const second = secondExecutor.execute(job(notify));
+    await vi.waitFor(() => expect(secondDomain).toHaveBeenCalledTimes(1));
+    await expect(second).resolves.toMatchObject({ responseText: 'second' });
+    releaseFirst();
+    await first;
+  });
+
+  it('dispose waits for admitted execution and rejects new work', async () => {
+    let release!: () => void;
+    const executor = createTaskExecutor({
+      domain: { execute: vi.fn(async () => {
+        await new Promise<void>((resolve) => { release = resolve; });
+        return domainResult();
+      }) },
+      resolveAdapter: () => undefined,
+    });
+    const running = executor.execute(job({ channel: 'silent' }));
+    await vi.waitFor(() => expect(release).toBeTypeOf('function'));
+    let settled = false;
+    const disposal = executor.dispose().then(() => { settled = true; });
+    await Promise.resolve();
+    expect(settled).toBe(false);
+    await expect(executor.execute(job({ channel: 'silent' }))).rejects.toThrow(/disposed/i);
+    release();
+    await running;
+    await disposal;
+  });
+
+  it('concurrent dispose callers share completion instead of returning early', async () => {
+    let release!: () => void;
+    const executor = createTaskExecutor({
+      domain: { execute: vi.fn(async () => {
+        await new Promise<void>((resolve) => { release = resolve; });
+        return domainResult();
+      }) },
+      resolveAdapter: () => undefined,
+    });
+    const running = executor.execute(job({ channel: 'silent' }));
+    await vi.waitFor(() => expect(release).toBeTypeOf('function'));
+
+    const first = executor.dispose();
+    let secondSettled = false;
+    const repeated = executor.dispose();
+    expect(repeated).toBe(first);
+    const second = repeated.then(() => { secondSettled = true; });
+    await Promise.resolve();
+    expect(secondSettled).toBe(false);
+    release();
+    await Promise.all([running, first, second]);
+  });
+
+  it('legacy global drain fails explicitly instead of reporting a false successful drain', async () => {
+    const { drainTaskExecutorLocks } = await import('../src/task-executor.js');
+    await expect(drainTaskExecutorLocks(10)).rejects.toThrow(/executor\.dispose/i);
+  });
+
+  it('fails fast when an injected execution callback awaits its own executor disposal', async () => {
+    const holder: { executor?: ReturnType<typeof createTaskExecutor> } = {};
+    const executor = createTaskExecutor({
+      domain: {
+        execute: vi.fn(async () => {
+          await holder.executor!.dispose();
+          return domainResult();
+        }),
+      },
+      resolveAdapter: () => undefined,
+    });
+    holder.executor = executor;
+
+    const verdict = Promise.race([
+      executor.execute(job({ channel: 'silent' })),
+      new Promise<never>((_resolve, reject) => {
+        const timer = setTimeout(() => reject(new Error('self-dispose timed out')), 100);
+        timer.unref?.();
+      }),
+    ]);
+
+    await expect(verdict).rejects.toThrow(/cannot dispose.*inside|execution callback/i);
+    await executor.dispose();
+  });
+
   it('cancels scene-lock admission without entering the domain', async () => {
     let releaseFirst!: () => void;
     const execute = vi.fn(async () => {

--- a/packages/im/agent/tests/typing-feedback-probe.test.ts
+++ b/packages/im/agent/tests/typing-feedback-probe.test.ts
@@ -1,9 +1,13 @@
 import { describe, expect, it, vi, afterEach } from 'vitest';
-import { createSyntheticMessage } from '@zhin.js/core';
+import { createSyntheticMessage, type Tool } from '@zhin.js/core';
 import { resetLlmApiRegistryForTests } from '@zhin.js/ai';
 import { ZhinAgent } from '../src/zhin-agent/index.js';
 import { activityFeedbackAiBus } from '../src/activity-feedback/ai-bus.js';
-import { wireMockLlmApi, assistantTextReply } from './helpers/mock-llm-api.js';
+import {
+  wireMockLlmApi,
+  assistantTextReply,
+  assistantToolCallReply,
+} from './helpers/mock-llm-api.js';
 
 describe('typing 反馈事件链探针', () => {
   afterEach(() => {
@@ -38,5 +42,65 @@ describe('typing 反馈事件链探针', () => {
     expect((payload.hookContext as Record<string, unknown> | undefined)?.activityFeedbackEligible).toBe(true);
     agent.dispose();
     activityFeedbackAiBus.off('ai.processing.start', listener);
+  });
+
+  it('processTurn failure emits an awaited terminal error and typing stop', async () => {
+    resetLlmApiRegistryForTests();
+    const llm = wireMockLlmApi();
+    const agent = new ZhinAgent(llm.provider as never, { maxIterations: 2 });
+    const received: string[] = [];
+    const onError = () => { received.push('error'); };
+    const onStop = () => { received.push('stop'); };
+    activityFeedbackAiBus.on('ai.processing.error', onError);
+    activityFeedbackAiBus.on('ai.typing.stop', onStop);
+    const commMessage = createSyntheticMessage({
+      adapter: 'sandbox', endpoint: 'bot', id: 'm-error', sender: { id: 'u1' },
+    });
+
+    await expect(agent.processTurn({
+      content: 'fail',
+      message: commMessage,
+      activityFeedbackEligible: true,
+    })).rejects.toThrow('IM Turn context requires');
+
+    expect(received).toEqual(['error', 'stop']);
+    agent.dispose();
+  });
+
+  it('processTurn projects tool and iteration events to the shared activity bus', async () => {
+    resetLlmApiRegistryForTests();
+    let call = 0;
+    const llm = wireMockLlmApi({
+      responder: () => call++ === 0
+        ? assistantToolCallReply([{ id: 'call-1', name: 'status_probe', arguments: {} }])
+        : assistantTextReply('done'),
+    });
+    const agent = new ZhinAgent(llm.provider as never, { maxIterations: 3 });
+    const received: string[] = [];
+    activityFeedbackAiBus.on('ai.tool.call', () => { received.push('tool.call'); });
+    activityFeedbackAiBus.on('ai.tool.result', () => { received.push('tool.result'); });
+    activityFeedbackAiBus.on('ai.processing.start', (payload) => {
+      if (payload.iterations === 2) received.push('iteration.2');
+    });
+    const tool: Tool = {
+      name: 'status_probe',
+      description: 'status probe',
+      parameters: { type: 'object', properties: {} },
+      execute: vi.fn(async () => 'ok'),
+    };
+    const commMessage = createSyntheticMessage({
+      adapter: 'sandbox', endpoint: 'bot', id: 'm-tool', sender: { id: 'u1' },
+      channel: { type: 'private', id: 'u1' },
+    });
+
+    await agent.processTurn({
+      content: '请调用 status_probe',
+      message: commMessage,
+      tools: [tool],
+      activityFeedbackEligible: true,
+    });
+
+    expect(received).toEqual(expect.arrayContaining(['tool.call', 'tool.result', 'iteration.2']));
+    agent.dispose();
   });
 });

--- a/packages/im/agent/tests/typing-indicator/index.test.ts
+++ b/packages/im/agent/tests/typing-indicator/index.test.ts
@@ -3,6 +3,7 @@ import {
   TypingIndicatorManager,
   ReactionTypingIndicator,
   MessageTypingIndicator,
+  NativeTypingIndicator,
   NoneTypingIndicator,
   ReactionTypingIndicatorAdapter,
   GenericTypingIndicatorAdapter,
@@ -12,6 +13,7 @@ import {
   stopTypingIndicator,
 } from '../../src/typing-indicator/index.js';
 import { DisposeStack } from '@zhin.js/plugin-runtime';
+import { AdapterActivityFeedbackManager } from '../../src/activity-feedback/adapter-integration.js';
 
 describe('TypingIndicatorManager', () => {
   let manager: TypingIndicatorManager;
@@ -187,7 +189,7 @@ describe('TypingIndicatorManager', () => {
       const mockIndicator = {
         start: vi.fn().mockResolvedValue(undefined),
         stop: vi.fn().mockResolvedValue(undefined),
-        isActive: vi.fn().mockReturnValue(false),
+        isActive: vi.fn().mockReturnValue(true),
       };
 
       const adapter: ICQQTypingIndicatorAdapter = {
@@ -219,13 +221,13 @@ describe('TypingIndicatorManager', () => {
       const mockIndicator1 = {
         start: vi.fn().mockResolvedValue(undefined),
         stop: vi.fn().mockResolvedValue(undefined),
-        isActive: vi.fn().mockReturnValue(false),
+        isActive: vi.fn().mockReturnValue(true),
       };
 
       const mockIndicator2 = {
         start: vi.fn().mockResolvedValue(undefined),
         stop: vi.fn().mockResolvedValue(undefined),
-        isActive: vi.fn().mockReturnValue(false),
+        isActive: vi.fn().mockReturnValue(true),
       };
 
       const adapter: ICQQTypingIndicatorAdapter = {
@@ -257,6 +259,156 @@ describe('TypingIndicatorManager', () => {
       expect(mockIndicator1.stop).toHaveBeenCalled();
       expect(mockIndicator2.stop).toHaveBeenCalled();
     });
+
+    it('启动未激活时应释放会话占位以便后续重试', async () => {
+      const inactive = {
+        start: vi.fn().mockResolvedValue(undefined),
+        stop: vi.fn().mockResolvedValue(undefined),
+        isActive: vi.fn().mockReturnValue(false),
+      };
+      const active = {
+        start: vi.fn().mockResolvedValue(undefined),
+        stop: vi.fn().mockResolvedValue(undefined),
+        isActive: vi.fn().mockReturnValue(true),
+      };
+      const adapter: ICQQTypingIndicatorAdapter = {
+        platform: 'icqq',
+        supportedTypes: ['reaction'],
+        createIndicator: vi.fn()
+          .mockReturnValueOnce(inactive)
+          .mockReturnValueOnce(active),
+      };
+      manager.registerAdapter(adapter);
+      const options = {
+        platform: 'icqq', endpointKey: 'bot', sessionId: 'group:1',
+        messageId: 'message-1', sceneType: 'group' as const,
+      };
+
+      expect((await manager.start(options)).isActive()).toBe(false);
+      expect((await manager.start(options)).isActive()).toBe(true);
+      expect(adapter.createIndicator).toHaveBeenCalledTimes(2);
+    });
+
+    it('并发 start 应共享启动结果且不在 indicator 激活前返回', async () => {
+      let releaseStart!: () => void;
+      let active = false;
+      const indicator = {
+        start: vi.fn().mockImplementation(async () => {
+          await new Promise<void>((resolve) => { releaseStart = resolve; });
+          active = true;
+        }),
+        stop: vi.fn().mockResolvedValue(undefined),
+        isActive: vi.fn(() => active),
+      };
+      manager.registerAdapter({
+        platform: 'icqq', supportedTypes: ['reaction'],
+        createIndicator: vi.fn().mockReturnValue(indicator),
+      });
+      const options = {
+        platform: 'icqq', endpointKey: 'bot', sessionId: 'group:1',
+        messageId: 'message-1', sceneType: 'group' as const,
+      };
+
+      const first = manager.start(options);
+      let secondSettled = false;
+      const second = manager.start(options).then((value) => {
+        secondSettled = true;
+        return value;
+      });
+      await Promise.resolve();
+      expect(secondSettled).toBe(false);
+      releaseStart();
+      expect(await second).toBe(await first);
+      expect(indicator.start).toHaveBeenCalledTimes(1);
+    });
+
+    it('启动未完成时的并发 stop 应共享同一清理', async () => {
+      let releaseStart!: () => void;
+      const indicator = {
+        start: vi.fn().mockImplementation(() => new Promise<void>((resolve) => {
+          releaseStart = resolve;
+        })),
+        stop: vi.fn().mockResolvedValue(undefined),
+        isActive: vi.fn().mockReturnValue(true),
+      };
+      manager.registerAdapter({
+        platform: 'test', supportedTypes: ['reaction'],
+        createIndicator: vi.fn().mockReturnValue(indicator),
+      });
+      const options = {
+        platform: 'test', endpointKey: 'bot', sessionId: 'group:1', sceneType: 'group' as const,
+      };
+
+      const starting = manager.start(options);
+      const firstStop = manager.stop(options);
+      const secondStop = manager.stop(options);
+      releaseStart();
+      await Promise.all([starting, firstStop, secondStop]);
+
+      expect(indicator.stop).toHaveBeenCalledTimes(1);
+    });
+
+    it('不应将分隔符组合不同的 endpoint 键串成同一指示器', async () => {
+      const first = {
+        start: vi.fn().mockResolvedValue(undefined), stop: vi.fn(),
+        isActive: vi.fn().mockReturnValue(true),
+      };
+      const second = {
+        start: vi.fn().mockResolvedValue(undefined), stop: vi.fn(),
+        isActive: vi.fn().mockReturnValue(true),
+      };
+      manager.registerAdapter({
+        platform: 'a:b', supportedTypes: ['reaction'],
+        createIndicator: vi.fn().mockReturnValue(first),
+      });
+      manager.registerAdapter({
+        platform: 'a', supportedTypes: ['reaction'],
+        createIndicator: vi.fn().mockReturnValue(second),
+      });
+
+      await manager.start({
+        platform: 'a:b', endpointKey: 'c', sessionId: 'd', sceneType: 'private',
+      });
+      await manager.start({
+        platform: 'a', endpointKey: 'b:c', sessionId: 'd', sceneType: 'private',
+      });
+
+      expect(first.start).toHaveBeenCalledTimes(1);
+      expect(second.start).toHaveBeenCalledTimes(1);
+    });
+  });
+});
+
+describe('NativeTypingIndicator', () => {
+  it('停止时应等待已在途的 keepalive，再发送 stopTyping', async () => {
+    vi.useFakeTimers();
+    let releaseKeepalive!: () => void;
+    const startTyping = vi.fn()
+      .mockResolvedValueOnce(undefined)
+      .mockImplementationOnce(() => new Promise<void>((resolve) => {
+        releaseKeepalive = resolve;
+      }));
+    const stopTyping = vi.fn().mockResolvedValue(undefined);
+    const indicator = new NativeTypingIndicator(
+      {
+        platform: 'test', endpointKey: 'bot', sessionId: 'private:1',
+        userId: '1', sceneType: 'private',
+      },
+      { type: 'typing', platformConfig: { keepaliveIntervalMs: 10 } },
+      startTyping,
+      stopTyping,
+    );
+
+    await indicator.start();
+    await vi.advanceTimersByTimeAsync(10);
+    expect(startTyping).toHaveBeenCalledTimes(2);
+    const stopping = indicator.stop();
+    await Promise.resolve();
+    expect(stopTyping).not.toHaveBeenCalled();
+    releaseKeepalive();
+    await stopping;
+    expect(stopTyping).toHaveBeenCalledTimes(1);
+    vi.useRealTimers();
   });
 });
 
@@ -535,6 +687,33 @@ describe('NoneTypingIndicator', () => {
   });
 });
 
+describe('Endpoint activity feedback capability boundary', () => {
+  it('does not use legacy $updateMessage without explicit endpoint edit control', async () => {
+    const legacyUpdate = vi.fn().mockResolvedValue(undefined);
+    const manager = new AdapterActivityFeedbackManager();
+    const endpoint = {
+      $id: 'bot',
+      control: { recall: vi.fn().mockResolvedValue(undefined) },
+      $updateMessage: legacyUpdate,
+    };
+    const feedback = manager.enableForEndpoint(endpoint as never, 'test', {
+      sendMessage: vi.fn().mockResolvedValue('status-1'),
+    } as never);
+    const options = {
+      platform: 'test', endpointKey: 'bot', sessionId: 'group:1',
+      groupId: '1', sceneType: 'group' as const,
+    };
+
+    const indicator = await feedback.start('active', options, {
+      type: 'message', message: 'processing',
+    });
+    await indicator.update?.('next');
+
+    expect(legacyUpdate).not.toHaveBeenCalled();
+    await feedback.stop('active', options);
+  });
+});
+
 describe('ReactionTypingIndicatorAdapter', () => {
   it('应该创建适配器', () => {
     const adapter = new ReactionTypingIndicatorAdapter(
@@ -676,6 +855,34 @@ describe('全局实例', () => {
     expect(instance).toBeDefined();
     void lifecycle.dispose();
   });
+
+  it('generation dispose 应等待活跃提示完成清理', async () => {
+    const lifecycle = new DisposeStack();
+    const manager = provideTypingIndicatorManager({ lifecycle });
+    let releaseStop!: () => void;
+    const indicator = {
+      start: vi.fn().mockResolvedValue(undefined),
+      stop: vi.fn().mockImplementation(() => new Promise<void>((resolve) => {
+        releaseStop = resolve;
+      })),
+      isActive: vi.fn().mockReturnValue(true),
+    };
+    manager.registerAdapter({
+      platform: 'test', supportedTypes: ['reaction'],
+      createIndicator: vi.fn().mockReturnValue(indicator),
+    });
+    await manager.start({
+      platform: 'test', endpointKey: 'bot', sessionId: 'private:1', sceneType: 'private',
+    });
+
+    let disposed = false;
+    const disposing = lifecycle.dispose().then(() => { disposed = true; });
+    await vi.waitFor(() => expect(indicator.stop).toHaveBeenCalledTimes(1));
+    expect(disposed).toBe(false);
+    releaseStop();
+    await disposing;
+    expect(indicator.stop).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe('便捷函数', () => {
@@ -714,7 +921,7 @@ describe('便捷函数', () => {
     const mockIndicator = {
       start: vi.fn().mockResolvedValue(undefined),
       stop: vi.fn().mockResolvedValue(undefined),
-      isActive: vi.fn().mockReturnValue(false),
+      isActive: vi.fn().mockReturnValue(true),
     };
 
     const adapter: ICQQTypingIndicatorAdapter = {

--- a/packages/im/agent/tests/typing-indicator/index.test.ts
+++ b/packages/im/agent/tests/typing-indicator/index.test.ts
@@ -335,7 +335,7 @@ describe('ReactionTypingIndicator', () => {
     expect(indicator.isActive()).toBe(false);
   });
 
-  it('stop 不等待 removeReaction 完成', async () => {
+  it('stop 等待 removeReaction 完成', async () => {
     const addReaction = vi.fn().mockResolvedValue('reaction-123');
     let resolveRemove!: () => void;
     const removeReaction = vi.fn().mockImplementation(
@@ -355,10 +355,15 @@ describe('ReactionTypingIndicator', () => {
     );
 
     await indicator.start();
-    await expect(indicator.stop()).resolves.toBeUndefined();
+    let settled = false;
+    const stopping = indicator.stop().then(() => { settled = true; });
+    await Promise.resolve();
     expect(removeReaction).toHaveBeenCalledTimes(1);
     expect(indicator.isActive()).toBe(false);
+    expect(settled).toBe(false);
     resolveRemove();
+    await stopping;
+    expect(settled).toBe(true);
   });
 
   it('并发 stop 只应 remove 一次', async () => {

--- a/packages/im/agent/tests/zhin-agent/inbound-turn-queue.test.ts
+++ b/packages/im/agent/tests/zhin-agent/inbound-turn-queue.test.ts
@@ -104,6 +104,44 @@ describe('InboundTurnQueue', () => {
     expect(result).toEqual(['hello\nworld']);
   });
 
+  it('acknowledges and clears every coalesced message while another turn is active', async () => {
+    const queue = new InboundTurnQueue(fifoConfig, emitter);
+    const sessionKey = 'sandbox:b1:group:g1';
+    let releaseFirst!: () => void;
+    const firstGate = new Promise<void>((resolve) => { releaseFirst = resolve; });
+
+    const first = queue.schedule({
+      sessionKey,
+      commMessage: messageWithId({ scope: 'group', sceneId: 'g1', senderId: 'u1', messageId: 'm1' }),
+      content: 'busy',
+      run: async () => {
+        await firstGate;
+        return ['busy'];
+      },
+    });
+    await new Promise((resolve) => setTimeout(resolve, 5));
+
+    const second = queue.schedule({
+      sessionKey,
+      commMessage: messageWithId({ scope: 'group', sceneId: 'g1', senderId: 'u2', messageId: 'm2' }),
+      content: 'hello',
+      run: async (merged) => [merged],
+    });
+    const third = queue.schedule({
+      sessionKey,
+      commMessage: messageWithId({ scope: 'group', sceneId: 'g1', senderId: 'u2', messageId: 'm3' }),
+      content: 'world',
+      run: async (merged) => [merged],
+    });
+
+    expect(second).toBe(third);
+    expect(emitter.starts.map((event) => event.messageId)).toEqual(['m2', 'm3']);
+
+    releaseFirst();
+    await Promise.all([first, second]);
+    expect(emitter.clears.map((event) => event.messageId)).toEqual(['m2', 'm3']);
+  });
+
   it('drops expired queue items and clears queued feedback', async () => {
     vi.useFakeTimers();
     const queue = new InboundTurnQueue(

--- a/packages/im/core/src/plugin-runtime/im/im-runtime.ts
+++ b/packages/im/core/src/plugin-runtime/im/im-runtime.ts
@@ -11,6 +11,7 @@ import {
   type SnapshotLease,
   type SnapshotReader,
 } from '@zhin.js/plugin-runtime';
+import { AsyncLocalStorage } from 'node:async_hooks';
 import { createPermissionHost, permissionHostToken } from '@zhin.js/permission';
 import { MessageBus, messageBusToken } from './message-bus.js';
 import {
@@ -205,6 +206,7 @@ export class ImRuntime implements MessageGateway {
     readonly admission?: GenerationAdmissionGate;
   }> = [];
   readonly #interactionClaims = new Map<string, UserInteractionClaim>();
+  readonly #operationSnapshot = new AsyncLocalStorage<SnapshotLease>();
   #snapshots?: SnapshotReader;
   readonly #inboundClaim?: ImRuntimeOptions['inboundClaim'];
   readonly #enrichSender?: ImRuntimeOptions['enrichSender'];
@@ -225,6 +227,19 @@ export class ImRuntime implements MessageGateway {
   /** Process composition replaces the bootstrap memory store after required DB activation. */
   replaceConversationEventStore(store: ConversationEventStore): void {
     this.conversationEvents = store;
+  }
+
+  /** Pins all nested IM operations to the snapshot current at operation ingress. */
+  async runWithSnapshotView<T>(operation: () => Promise<T>): Promise<T> {
+    const inherited = this.#operationSnapshot.getStore();
+    if (inherited?.active) return operation();
+    if (!this.#snapshots) throw new Error('ImRuntime is not attached to a Root');
+    const lease = this.#snapshots.acquire();
+    try {
+      return await this.#operationSnapshot.run(lease, operation);
+    } finally {
+      lease.release();
+    }
   }
 
   async resolveConversationReference(
@@ -666,7 +681,7 @@ export class ImRuntime implements MessageGateway {
       return result;
     } finally {
       active = false;
-      lease.release();
+      this.#release(lease);
     }
   }
 
@@ -675,7 +690,7 @@ export class ImRuntime implements MessageGateway {
     try {
       return await this.#sendWithSnapshot(request, lease.value);
     } finally {
-      lease.release();
+      this.#release(lease);
     }
   }
 
@@ -731,7 +746,7 @@ export class ImRuntime implements MessageGateway {
     try {
       await this.#runHandlers(lease.value, event, [payload]);
     } finally {
-      lease.release();
+      this.#release(lease);
     }
   }
 
@@ -824,7 +839,7 @@ export class ImRuntime implements MessageGateway {
           managementCapabilities: row.managementCapabilities,
         }));
       } finally {
-        lease.release();
+        this.#release(lease);
       }
     } catch {
       return Object.freeze([]);
@@ -843,7 +858,7 @@ export class ImRuntime implements MessageGateway {
         const id = index.resolve(input.adapter, input.endpointKey);
         return id ? index.capabilities(id) : undefined;
       } finally {
-        lease.release();
+        this.#release(lease);
       }
     } catch {
       return undefined;
@@ -872,7 +887,7 @@ export class ImRuntime implements MessageGateway {
           }),
         });
       } finally {
-        lease.release();
+        this.#release(lease);
       }
     } catch {
       return Object.freeze({
@@ -911,7 +926,7 @@ export class ImRuntime implements MessageGateway {
           managementCapabilities: row.managementCapabilities,
         });
       } finally {
-        lease.release();
+        this.#release(lease);
       }
     } catch {
       return null;
@@ -942,7 +957,7 @@ export class ImRuntime implements MessageGateway {
       }, lease.value);
       return { messageId: result.message?.id ?? '' };
     } finally {
-      lease.release();
+      this.#release(lease);
     }
   }
 
@@ -1025,7 +1040,7 @@ export class ImRuntime implements MessageGateway {
       const control = id ? index.control(id, operation) : undefined;
       return control ? await run(control) : fallback;
     } finally {
-      lease.release();
+      this.#release(lease);
     }
   }
 
@@ -1046,7 +1061,7 @@ export class ImRuntime implements MessageGateway {
       if (!endpoint) return null;
       return await run(resolveEndpointManagement(endpoint) ?? Object.freeze({}));
     } finally {
-      lease.release();
+      this.#release(lease);
     }
   }
 
@@ -1149,9 +1164,16 @@ export class ImRuntime implements MessageGateway {
     return receipt ?? failedReceipt('outbound_delivery_incomplete');
   }
 
-  #acquire() {
+  #acquire(): SnapshotLease {
+    const inherited = this.#operationSnapshot.getStore();
+    if (inherited?.active) return inherited;
     if (!this.#snapshots) throw new Error('ImRuntime is not attached to a Root');
     return this.#snapshots.acquire();
+  }
+
+  #release(lease: SnapshotLease): void {
+    if (this.#operationSnapshot.getStore() === lease) return;
+    lease.release();
   }
 
   /**

--- a/packages/im/core/src/plugin-runtime/im/im-runtime.ts
+++ b/packages/im/core/src/plugin-runtime/im/im-runtime.ts
@@ -37,6 +37,7 @@ import {
   type ConversationResolution,
   type ConversationRef,
   type DeliveryReceipt,
+  type EndpointCapabilities,
   type MessageRef,
 } from '@zhin.js/im-contract';
 import { segmentsToPlainText } from '../../built/segment-contract/text.js';
@@ -827,6 +828,25 @@ export class ImRuntime implements MessageGateway {
       }
     } catch {
       return Object.freeze([]);
+    }
+  }
+
+  /** Exact operation capabilities for one concrete live Endpoint. */
+  endpointCapabilities(input: {
+    readonly adapter: string;
+    readonly endpointKey: string;
+  }): EndpointCapabilities | undefined {
+    try {
+      const lease = this.#acquire();
+      try {
+        const index = requireAdapters(lease.value);
+        const id = index.resolve(input.adapter, input.endpointKey);
+        return id ? index.capabilities(id) : undefined;
+      } finally {
+        lease.release();
+      }
+    } catch {
+      return undefined;
     }
   }
 

--- a/packages/im/core/tests/plugin-runtime/im-runtime.test.ts
+++ b/packages/im/core/tests/plugin-runtime/im-runtime.test.ts
@@ -948,6 +948,13 @@ describe('IM Runtime', () => {
     };
     const message = { conversation, id: 'message-1' };
 
+    expect(fixture.im.endpointCapabilities({ adapter: 'memory', endpointKey: 'memory' }))
+      .toEqual({
+        inbound: true,
+        outbound: true,
+        operations: { recall: true, edit: true, reaction: true, typing: true },
+      });
+
     await fixture.im.recallEndpointMessage({ adapter: 'memory', endpointKey: 'memory', message });
     await expect(fixture.im.editEndpointMessage({
       adapter: 'memory', endpointKey: 'memory', message, content: 'updated',

--- a/packages/im/core/tests/plugin-runtime/im-runtime.test.ts
+++ b/packages/im/core/tests/plugin-runtime/im-runtime.test.ts
@@ -1026,6 +1026,43 @@ describe('IM Runtime', () => {
     await fixture.store.close();
   });
 
+  it('pins delayed outbound operations to the snapshot captured at ingress', async () => {
+    const calls: string[] = [];
+    const fixture = await createFixture([], [], undefined, undefined, undefined, {
+      endpointControl: { recall: async () => { calls.push('old:recall'); } },
+      adapterOperations: ['recall'],
+    });
+    let release!: () => void;
+    const pending = new Promise<void>((resolve) => { release = resolve; });
+    const message = {
+      conversation: {
+        endpoint: { id: String(fixture.adapter.id), adapter: String(rootPluginId()) },
+        kind: 'private' as const,
+        id: 'room-1',
+      },
+      id: 'message-1',
+    };
+
+    const operation = fixture.im.runWithSnapshotView(async () => {
+      await pending;
+      await fixture.im.recallEndpointMessage({
+        adapter: 'memory', endpointKey: 'memory', message,
+      });
+    });
+    await Promise.resolve();
+    const current = fixture.store.current;
+    fixture.store.commit(current.generation, {
+      snapshot: { ...snapshotState(current), projections: new Map() },
+      dispose: () => undefined,
+    });
+    release();
+    await operation;
+
+    expect(calls).toEqual(['old:recall']);
+    await fixture.adapters.stop();
+    await fixture.store.close();
+  });
+
   it('does not execute control methods added outside the declared capability set', async () => {
     const calls: string[] = [];
     const control: EndpointControl = {};

--- a/packages/im/plugin-runtime/src/outbound-host.ts
+++ b/packages/im/plugin-runtime/src/outbound-host.ts
@@ -80,6 +80,8 @@ export interface OutboundMessage {
 }
 
 export interface OutboundHost {
+  /** Runs related operations against one IM Runtime snapshot captured at ingress. */
+  runWithView?<T>(operation: () => Promise<T>): Promise<T>;
   /** Exact operations declared by one live Endpoint. */
   capabilities?(input: OutboundEndpointInput): OutboundEndpointCapabilities | undefined;
   /** Returns platform message id when available (activity-feedback needs it). */

--- a/packages/im/plugin-runtime/src/outbound-host.ts
+++ b/packages/im/plugin-runtime/src/outbound-host.ts
@@ -49,6 +49,27 @@ export interface OutboundRecallInput {
   readonly message: OutboundMessage;
 }
 
+export type OutboundEndpointOperation = 'recall' | 'edit' | 'reaction' | 'typing';
+
+export interface OutboundEndpointInput {
+  readonly adapter: string;
+  readonly endpointKey: string;
+}
+
+export interface OutboundEndpointCapabilities {
+  readonly operations: readonly OutboundEndpointOperation[];
+}
+
+export interface OutboundEditInput extends OutboundEndpointInput {
+  readonly message: OutboundMessage;
+  readonly content: unknown;
+}
+
+export interface OutboundTypingInput extends OutboundEndpointInput {
+  readonly conversation: OutboundMessage['conversation'];
+  readonly active?: boolean;
+}
+
 
 /** Structured message identity; structurally compatible with IM MessageRef. */
 export interface OutboundMessage {
@@ -59,6 +80,8 @@ export interface OutboundMessage {
 }
 
 export interface OutboundHost {
+  /** Exact operations declared by one live Endpoint. */
+  capabilities?(input: OutboundEndpointInput): OutboundEndpointCapabilities | undefined;
   /** Returns platform message id when available (activity-feedback needs it). */
   send(input: OutboundSendInput): Promise<string | null>;
   /** Optional: platform message reactions (icqq group emoji, etc.). */
@@ -66,6 +89,10 @@ export interface OutboundHost {
   removeReaction?(input: OutboundRemoveReactionInput): Promise<void>;
   /** Optional: recall/delete a status message (activity-feedback autoRemove). */
   recall?(input: OutboundRecallInput): Promise<void>;
+  /** Optional: update a previously sent status message. */
+  edit?(input: OutboundEditInput): Promise<string | null>;
+  /** Optional: toggle the platform-native typing indicator. */
+  typing?(input: OutboundTypingInput): Promise<void>;
 }
 
 export const outboundHostToken = createToken<OutboundHost>(

--- a/plugins/adapters/email/src/endpoint.ts
+++ b/plugins/adapters/email/src/endpoint.ts
@@ -220,20 +220,23 @@ export class EmailEndpoint implements EndpointInstance {
     imap.on('error', (error) => {
       this.#logger.error('IMAP error:', error);
       // imap 通常在 error 后紧跟 end；两处都调度，靠已有定时器去重
-      this.#scheduleImapReconnect();
+      this.#scheduleImapReconnect(imap);
     });
     imap.on('end', () => {
       this.#logger.debug(formatCompact({
           op: 'disconnect',
         mode: 'imap',
       }));
-      this.#scheduleImapReconnect();
+      this.#scheduleImapReconnect(imap);
     });
   }
 
   /** IMAP 断线后按指数退避重建连接并恢复监听（基数 reconnectInterval，封顶 5 分钟）。 */
-  #scheduleImapReconnect(): void {
-    if (!this.#started || this.#reconnectTimer) return;
+  #scheduleImapReconnect(source?: EmailImapTransport): void {
+    // A replaced transport may emit a late `end` after its earlier `error`
+    // already caused a successful reconnect. Only the currently owned IMAP
+    // connection may arm the next generation's reconnect timer.
+    if (!this.#started || this.#reconnectTimer || (source && this.#imap !== source)) return;
     const base = this.#options.config.imap.reconnectInterval;
     const delay = Math.min(base * 2 ** this.#reconnectAttempts, 300_000);
     this.#reconnectAttempts += 1;
@@ -250,15 +253,17 @@ export class EmailEndpoint implements EndpointInstance {
 
   async #reconnectImap(): Promise<void> {
     if (!this.#started) return;
+    let imap: EmailImapTransport | undefined;
     try {
-      const imap = this.#options.createImap?.(this.#options.config.imap)
+      const nextImap = this.#options.createImap?.(this.#options.config.imap)
         ?? defaultCreateImap(this.#options.config.imap);
-      this.#imap = imap;
-      this.#setupImapListeners(imap);
+      imap = nextImap;
+      this.#imap = nextImap;
+      this.#setupImapListeners(nextImap);
       await new Promise<void>((resolve, reject) => {
-        imap.once('ready', () => resolve());
-        imap.once('error', (error) => reject(error));
-        imap.connect();
+        nextImap.once('ready', () => resolve());
+        nextImap.once('error', (error) => reject(error));
+        nextImap.connect();
       });
       this.#reconnectAttempts = 0;
       this.#logger.info(formatCompact({
@@ -274,7 +279,7 @@ export class EmailEndpoint implements EndpointInstance {
         ok: false,
         error: error instanceof Error ? error.message : String(error),
       }));
-      this.#scheduleImapReconnect();
+      this.#scheduleImapReconnect(imap);
     }
   }
 

--- a/plugins/adapters/email/tests/email-runtime.test.ts
+++ b/plugins/adapters/email/tests/email-runtime.test.ts
@@ -513,6 +513,35 @@ describe('email plugin runtime adapter', () => {
     expect(imaps).toHaveLength(2);
   });
 
+  it('ignores a stale end from the replaced IMAP transport after reconnect', async () => {
+    vi.useFakeTimers();
+    const imaps: Array<ReturnType<typeof createMockImap>> = [];
+    const endpoint = new EmailEndpoint({
+      id: capabilityId(rootPluginId(), adapterFeature, 'email'),
+      gateway: { receive: vi.fn(async () => Object.freeze({ matched: false })), send: vi.fn(async () => 'sent') },
+      config: {
+        ...baseConfig,
+        imap: { ...baseConfig.imap, reconnectInterval: 50 },
+      },
+      createSmtp: () => createMockSmtp(),
+      createImap: () => {
+        const imap = createMockImap();
+        imaps.push(imap);
+        return imap;
+      },
+    });
+
+    await endpoint.start();
+    imaps[0]!.emitError(new Error('socket reset'));
+    await vi.advanceTimersByTimeAsync(50);
+    expect(imaps).toHaveLength(2);
+
+    imaps[0]!.emit('end');
+    await vi.advanceTimersByTimeAsync(50);
+    expect(imaps).toHaveLength(2);
+    await endpoint.stop();
+  });
+
   it('disarms pending reconnect when stop runs before the backoff fires', async () => {
     const imaps: Array<ReturnType<typeof createMockImap>> = [];
     const endpoint = new EmailEndpoint({

--- a/plugins/adapters/icqq/src/endpoint.ts
+++ b/plugins/adapters/icqq/src/endpoint.ts
@@ -8,6 +8,7 @@ import {
   type VideoElem,
 } from '@icqqjs/icqq';
 import { inspect } from 'node:util';
+import { AsyncLocalStorage } from 'node:async_hooks';
 import type {
   EndpointControl,
   EndpointInstance,
@@ -102,10 +103,13 @@ export class IcqqEndpoint extends Client implements EndpointInstance {
   #open = false;
   #retiring = false;
   #started = false;
+  #retirementEpoch = 0;
+  #retirementArmed = false;
   #resolveStartOnline?: () => void;
   #heldInbound: IcqqInboundMessage[] = [];
   #unregisterAgent?: () => void;
   readonly #inflightInbound = new Set<Promise<void>>();
+  readonly #inboundOwner = new AsyncLocalStorage<symbol>();
   readonly #messageContent = new Map<string, ConversationMessage>();
 
   readonly content: EndpointContentPort = Object.freeze({
@@ -282,6 +286,12 @@ export class IcqqEndpoint extends Client implements EndpointInstance {
   async start(signal: AbortSignal): Promise<void> {
     if (this.#started) return;
     signal.throwIfAborted();
+    // Invalidate a guard left by a prior lifecycle epoch before admitting a
+    // new login attempt on this endpoint instance.
+    this.#retirementEpoch += 1;
+    this.#retirementArmed = false;
+    this.#retiring = false;
+    this.off('system.online');
     this.#started = true;
     let resolveOnline!: () => void;
     const onlineReady = new Promise<void>((resolve) => {
@@ -312,31 +322,47 @@ export class IcqqEndpoint extends Client implements EndpointInstance {
   }
 
   open(): void {
+    if (this.#retirementArmed) {
+      this.#retirementEpoch += 1;
+      this.#retirementArmed = false;
+      this.off('system.online');
+      this.#bindSystemOnlineEvent();
+    }
     this.#retiring = false;
     this.#open = true;
     const held = this.#heldInbound.splice(0);
-    for (const msg of held) this.admit(msg);
+    for (const msg of held) {
+      void this.admit(msg).catch((error) => {
+        this.#logInboundHandlerFailure('held', error);
+      });
+    }
   }
 
   async close(): Promise<void> {
-    this.#retiring = true;
-    this.#open = false;
+    this.#assertExternalLifecycle('close');
+    this.#armRetirementFence();
     await Promise.allSettled([...this.#inflightInbound]);
   }
 
   async stop(): Promise<void> {
-    this.#retiring = true;
-    this.#open = false;
+    this.#assertExternalLifecycle('stop');
+    this.#armRetirementFence();
     await Promise.allSettled([...this.#inflightInbound]);
     this.#resolveStartOnline?.();
     this.#options.loginAssist.cancelOwned(this.#loginAssistOwner, 'endpoint_stopped');
     this.#heldInbound.length = 0;
     this.#unregisterAgent?.();
     this.#unregisterAgent = undefined;
-    for (const event of BOUND_EVENTS) this.off(event);
-    try {
-      await this.logout?.();
-    } catch { /* ignore */ }
+    for (const event of BOUND_EVENTS) {
+      // The retirement guard owns this matcher until a late login handshake
+      // has finished. start()/open() replace it with the normal listener.
+      if (event !== 'system.online') this.off(event);
+    }
+    // `Client.logout()` sends an account-level unregister packet before it
+    // closes this transport. During config HMR the replacement endpoint for
+    // the same UIN is already online, so unregistering the retiring generation
+    // also closes the replacement session. Endpoint ownership is transport
+    // scoped: retire only this Client's TCP connection.
     try {
       this.terminate();
     } catch { /* ignore */ }
@@ -345,6 +371,31 @@ export class IcqqEndpoint extends Client implements EndpointInstance {
     this.#guildCatalog.clear();
     this.#started = false;
     this.#logger.debug(formatCompact({ op: 'disconnect' }));
+  }
+
+  #armRetirementFence(): void {
+    this.#retiring = true;
+    this.#open = false;
+    if (this.#retirementArmed) return;
+    this.#retirementArmed = true;
+    const retirementEpoch = ++this.#retirementEpoch;
+    // ICQQ owns reconnect through this per-Client timer. Clear it before any
+    // asynchronous drain so a queued callback cannot enter while close waits.
+    if (this.login_timer) {
+      clearTimeout(this.login_timer);
+      this.login_timer = null;
+    }
+    // A login callback may already be inside the SDK handshake, which has no
+    // abort API. Replace the normal online listener with an epoch-owned guard
+    // before draining inbound work. Transport termination is account-local;
+    // logout would also unregister an HMR replacement using the same UIN.
+    this.off('system.online');
+    this.on('system.online', () => {
+      if (this.#retirementEpoch !== retirementEpoch || !this.#retiring) return;
+      try {
+        this.terminate();
+      } catch { /* already closed */ }
+    });
   }
 
   async send({ conversation, payload }: EndpointSendRequest): Promise<string> {
@@ -410,7 +461,37 @@ export class IcqqEndpoint extends Client implements EndpointInstance {
     }
   }
 
-  admit(msg: IcqqInboundMessage, admittedBeforeRetire = false): void {
+  admit(msg: IcqqInboundMessage): Promise<void> {
+    return this.#trackInbound(() => this.#deliverInbound(msg));
+  }
+
+  #trackInbound(run: () => Promise<void>): Promise<void> {
+    const owner = Symbol('icqq-inbound');
+    let settle!: () => void;
+    const settlement = new Promise<void>((resolve) => { settle = resolve; });
+    this.#inflightInbound.add(settlement);
+    let operation: Promise<void>;
+    try {
+      operation = this.#inboundOwner.run(owner, run);
+    } catch (error) {
+      this.#inflightInbound.delete(settlement);
+      settle();
+      return Promise.reject(error);
+    }
+    return operation.finally(() => {
+      this.#inflightInbound.delete(settlement);
+      settle();
+    });
+  }
+
+  #assertExternalLifecycle(operation: 'close' | 'stop'): void {
+    if (!this.#inboundOwner.getStore()) return;
+    throw new Error(
+      `ICQQ endpoint ${operation} cannot run inside its own inbound receive; invoke it from the owning lifecycle`,
+    );
+  }
+
+  async #deliverInbound(msg: IcqqInboundMessage, admittedBeforeRetire = false): Promise<void> {
     const conversation = msg.conversation;
     if (!this.#open && !admittedBeforeRetire) {
       if (this.#retiring) return;
@@ -445,7 +526,7 @@ export class IcqqEndpoint extends Client implements EndpointInstance {
       + (mentioned ? ' (mentioned)' : '')
       + ` | ${truncatePreview(msg.content, 80)}`,
     );
-    void this.#options.gateway.receive({
+    await this.#options.gateway.receive({
       conversation,
       message: { conversation, id: msg.id },
       content: msg.content,
@@ -484,16 +565,16 @@ export class IcqqEndpoint extends Client implements EndpointInstance {
     };
     this.on('message.private', (event) => this.#startMessageEvent('message.private', event));
     this.on('message.group', (event) => this.#startMessageEvent('message.group', event));
-    this.on('message.guild', (event) => safe('message.guild', () => this.#handleGuildEvent(event)));
+    this.on('message.guild', (event) => {
+      void this.#handleGuildEvent(event).catch((error) => {
+        this.#logInboundHandlerFailure('message.guild', error);
+      });
+    });
     this.on('request.friend', (event) => safe('request.friend', () => this.#onRequestEvent(serializeIcqqEvent(event))));
     this.on('request.group', (event) => safe('request.group', () => this.#onRequestEvent(serializeIcqqEvent(event))));
     this.on('notice.friend', (event) => safe('notice.friend', () => this.#onNoticeEvent(serializeIcqqEvent(event))));
     this.on('notice.group', (event) => safe('notice.group', () => this.#onNoticeEvent(serializeIcqqEvent(event))));
-    this.on('system.online', (event) => safe('system.online', () => {
-      this.#resolveStartOnline?.();
-      this.#options.loginAssist.cancelOwned(this.#loginAssistOwner, 'online');
-      this.#logSystemEvent('online', event);
-    }));
+    this.#bindSystemOnlineEvent();
     this.on('system.offline', (event) => this.#logSystemEvent('offline', event));
     this.on('system.offline.network', (event) => this.#logSystemEvent('offline.network', event));
     this.on('system.offline.kickoff', (event) => this.#logSystemEvent('offline.kickoff', event));
@@ -508,6 +589,24 @@ export class IcqqEndpoint extends Client implements EndpointInstance {
       this.#logSystemEvent('login.error', event);
     });
     this.on('system.login.auth', (event) => this.#handleLoginChallenge('auth', event));
+  }
+
+  #bindSystemOnlineEvent(): void {
+    this.on('system.online', (event) => {
+      if (this.#retiring) return;
+      try {
+        this.#resolveStartOnline?.();
+        this.#options.loginAssist.cancelOwned(this.#loginAssistOwner, 'online');
+        this.#logSystemEvent('online', event);
+      } catch (error) {
+        this.#logger.warn(formatCompact({
+          op: 'icqq_event_handler',
+          endpoint: this.endpointName,
+          event: 'system.online',
+          error: error instanceof Error ? error.message : String(error),
+        }));
+      }
+    });
   }
 
   #handleLoginChallenge(
@@ -660,7 +759,7 @@ export class IcqqEndpoint extends Client implements EndpointInstance {
         timestamp: quoted.time ? quoted.time * (quoted.time < 1e12 ? 1000 : 1) : Date.now(),
       }));
     }
-    this.admit({
+    await this.#deliverInbound({
       id: normalized.messageId,
       conversation,
       content: formatInboundContent(normalized.rawMessage),
@@ -680,12 +779,9 @@ export class IcqqEndpoint extends Client implements EndpointInstance {
   }
 
   #startMessageEvent(eventName: 'message.private' | 'message.group', event: unknown): void {
-    const operation = this.#handleMessageEvent(eventName, event);
-    this.#inflightInbound.add(operation);
+    const operation = this.#trackInbound(() => this.#handleMessageEvent(eventName, event));
     void operation.catch((error) => {
       this.#logInboundHandlerFailure(eventName, error);
-    }).finally(() => {
-      this.#inflightInbound.delete(operation);
     });
   }
 
@@ -712,7 +808,7 @@ export class IcqqEndpoint extends Client implements EndpointInstance {
     }));
   }
 
-  #handleGuildEvent(event: unknown): void {
+  async #handleGuildEvent(event: unknown): Promise<void> {
     const payload = serializeIcqqEvent(event);
     if (!payload || typeof payload !== 'object') return;
     const normalized = normalizeIcqqGuildInboundMessage(
@@ -736,7 +832,7 @@ export class IcqqEndpoint extends Client implements EndpointInstance {
       }));
       return;
     }
-    this.admit({
+    await this.admit({
       id: normalized.messageId,
       conversation: icqqInboundConversation(String(this.#options.id), {
         channelType: 'channel',

--- a/plugins/adapters/icqq/tests/_icqq-mock.ts
+++ b/plugins/adapters/icqq/tests/_icqq-mock.ts
@@ -26,6 +26,13 @@ export function createIcqqTestPorts(): {
  * to simulate icqq events, and vi.mocked(endpoint.method) to assert calls.
  */
 export class Client {
+  static readonly activeClients = new Map<number, Set<Client>>();
+  protected login_timer: ReturnType<typeof setTimeout> | null = null;
+  private nextLoginGate?: {
+    entered: () => void;
+    wait: Promise<void>;
+  };
+
   uin: number;
   fl = new Map<number, unknown>();
   gl = new Map<number, unknown>();
@@ -65,9 +72,27 @@ export class Client {
     return true;
   }
 
-  login = vi.fn(async (_password?: string) => { this.emit('system.online'); });
-  logout = vi.fn(async () => {});
-  terminate = vi.fn();
+  login = vi.fn(async (_password?: string) => {
+    const gate = this.nextLoginGate;
+    this.nextLoginGate = undefined;
+    if (gate) {
+      gate.entered();
+      await gate.wait;
+    }
+    if (!Client.activeClients.has(this.uin)) Client.activeClients.set(this.uin, new Set());
+    Client.activeClients.get(this.uin)!.add(this);
+    this.emit('system.online');
+  });
+  logout = vi.fn(async () => {
+    // ICQQ logout sends an account-level unregister packet. Model the observed
+    // effect during same-account HMR: every TCP session for that UIN is closed.
+    Client.activeClients.delete(this.uin);
+  });
+  terminate = vi.fn(() => {
+    const clients = Client.activeClients.get(this.uin);
+    clients?.delete(this);
+    if (clients?.size === 0) Client.activeClients.delete(this.uin);
+  });
   submitSlider = vi.fn(async (_ticket?: string) => {});
   sendSmsCode = vi.fn(async () => {});
   submitSmsCode = vi.fn(async (_code?: string) => {});
@@ -107,6 +132,33 @@ export class Client {
     setReaction: this.setReaction,
     delReaction: this.delReaction,
   }));
+}
+
+export function isMockIcqqClientConnected(client: Client): boolean {
+  return Client.activeClients.get(client.uin)?.has(client) ?? false;
+}
+
+export function scheduleMockIcqqReconnect(client: Client, delayMs: number): void {
+  const state = client as unknown as { login_timer: ReturnType<typeof setTimeout> | null };
+  state.login_timer = setTimeout(() => {
+    state.login_timer = null;
+    void client.login();
+  }, delayMs);
+}
+
+export function hangNextMockIcqqLogin(client: Client): {
+  readonly entered: Promise<void>;
+  readonly release: () => void;
+} {
+  let markEntered!: () => void;
+  let release!: () => void;
+  const entered = new Promise<void>((resolve) => { markEntered = resolve; });
+  const wait = new Promise<void>((resolve) => { release = resolve; });
+  const state = client as unknown as {
+    nextLoginGate?: { entered: () => void; wait: Promise<void> };
+  };
+  state.nextLoginGate = { entered: markEntered, wait };
+  return { entered, release };
 }
 
 export function parseGroupMessageId(msgid: string): {

--- a/plugins/adapters/icqq/tests/icqq-runtime.test.ts
+++ b/plugins/adapters/icqq/tests/icqq-runtime.test.ts
@@ -13,7 +13,12 @@ import {
   resolveIcqqConfig,
 } from '../src/protocol.js';
 import { getIcqqAgentDeps, setIcqqAgentDeps } from '../src/icqq-agent-deps.js';
-import { createIcqqTestPorts } from './_icqq-mock.js';
+import {
+  createIcqqTestPorts,
+  hangNextMockIcqqLogin,
+  isMockIcqqClientConnected,
+  scheduleMockIcqqReconnect,
+} from './_icqq-mock.js';
 
 const adapterFeature = featureId('zhin.adapter');
 
@@ -27,13 +32,14 @@ function createEndpoint(overrides: {
   gateway?: MessageGateway;
   friends?: Map<number, unknown>;
   groups?: Map<number, unknown>;
+  config?: ReturnType<typeof resolveIcqqConfig>;
 } = {}): IcqqEndpoint {
   const receive = overrides.receive ?? vi.fn(async () => Object.freeze({ matched: true, value: 'ok' }));
   const gateway = overrides.gateway ?? { receive, send: vi.fn(async () => 'sent') };
   const endpoint = new IcqqEndpoint({
     id: capabilityId(rootPluginId(), adapterFeature, 'icqq'),
     gateway,
-    config: baseConfig,
+    config: overrides.config ?? baseConfig,
     ...createIcqqTestPorts(),
   });
   const friends = overrides.friends ?? new Map([[2, { user_id: 2, nickname: 'bob', sex: 'unknown', age: 0 }]]);
@@ -44,6 +50,7 @@ function createEndpoint(overrides: {
 }
 
 afterEach(() => {
+  vi.useRealTimers();
   setIcqqAgentDeps(null);
 });
 
@@ -116,6 +123,244 @@ describe('icqq protocol helpers', () => {
 });
 
 describe('icqq plugin runtime adapter', () => {
+  it('keeps the replacement TCP session alive when config HMR retires the old endpoint', async () => {
+    const reconnectingConfig = resolveIcqqConfig({ id: '10001', autoReconnect: true });
+    const previous = createEndpoint({ config: reconnectingConfig });
+    await previous.start(new AbortController().signal);
+    previous.open();
+
+    const replacement = createEndpoint({ config: reconnectingConfig });
+    await replacement.start(new AbortController().signal);
+    replacement.open();
+
+    await previous.close();
+    await previous.stop();
+
+    expect(previous.logout).not.toHaveBeenCalled();
+    expect(previous.terminate).toHaveBeenCalledOnce();
+    expect(isMockIcqqClientConnected(replacement)).toBe(true);
+    await replacement.stop();
+  });
+
+  it('cancels the retiring SDK reconnect timer before it can revive the old generation', async () => {
+    vi.useFakeTimers();
+    const reconnectingConfig = resolveIcqqConfig({ id: '10001', autoReconnect: true });
+    const previous = createEndpoint({ config: reconnectingConfig });
+    const replacement = createEndpoint({ config: reconnectingConfig });
+    await previous.start(new AbortController().signal);
+    previous.open();
+    await replacement.start(new AbortController().signal);
+    replacement.open();
+
+    scheduleMockIcqqReconnect(previous, 50);
+    await previous.close();
+    await previous.stop();
+    await vi.advanceTimersByTimeAsync(50);
+
+    expect(previous.login).toHaveBeenCalledTimes(1);
+    expect(isMockIcqqClientConnected(previous)).toBe(false);
+    expect(isMockIcqqClientConnected(replacement)).toBe(true);
+    await replacement.stop();
+  });
+
+  it('retires an SDK reconnect whose login handshake already entered before stop', async () => {
+    vi.useFakeTimers();
+    const reconnectingConfig = resolveIcqqConfig({ id: '10001', autoReconnect: true });
+    const previous = createEndpoint({ config: reconnectingConfig });
+    const replacement = createEndpoint({ config: reconnectingConfig });
+    await previous.start(new AbortController().signal);
+    previous.open();
+    await replacement.start(new AbortController().signal);
+    replacement.open();
+
+    const handshake = hangNextMockIcqqLogin(previous);
+    scheduleMockIcqqReconnect(previous, 50);
+    await vi.advanceTimersByTimeAsync(50);
+    await handshake.entered;
+
+    await previous.close();
+    await previous.stop();
+    handshake.release();
+    await vi.runAllTimersAsync();
+
+    expect(previous.login).toHaveBeenCalledTimes(2);
+    expect(isMockIcqqClientConnected(previous)).toBe(false);
+    expect(isMockIcqqClientConnected(replacement)).toBe(true);
+    await replacement.stop();
+  });
+
+  it('arms reconnect retirement before waiting for in-flight inbound drain', async () => {
+    vi.useFakeTimers();
+    let releaseInbound!: () => void;
+    const inboundGate = new Promise<void>((resolve) => { releaseInbound = resolve; });
+    const receive = vi.fn(async () => {
+      await inboundGate;
+      return Object.freeze({ matched: true, value: 'ok' });
+    });
+    const reconnectingConfig = resolveIcqqConfig({ id: '10001', autoReconnect: true });
+    const previous = createEndpoint({ config: reconnectingConfig, receive });
+    const replacement = createEndpoint({ config: reconnectingConfig });
+    await previous.start(new AbortController().signal);
+    previous.open();
+    await replacement.start(new AbortController().signal);
+    replacement.open();
+
+    previous.emit('message.group.normal', {
+      post_type: 'message',
+      message_type: 'group',
+      group_id: 100,
+      user_id: 2,
+      message_id: 'inflight-before-stop',
+      raw_message: 'hold inbound drain',
+      time: 1_700_000_000,
+      sender: { user_id: 2, nickname: 'bob', role: 'member' },
+    });
+    await vi.waitFor(() => expect(receive).toHaveBeenCalledOnce());
+
+    const handshake = hangNextMockIcqqLogin(previous);
+    scheduleMockIcqqReconnect(previous, 50);
+    await vi.advanceTimersByTimeAsync(50);
+    await handshake.entered;
+
+    let closeSettled = false;
+    const closing = previous.close().then(() => { closeSettled = true; });
+    let stopSettled = false;
+    const stopping = previous.stop().then(() => { stopSettled = true; });
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(closeSettled).toBe(false);
+    expect(stopSettled).toBe(false);
+    expect(previous.terminate).not.toHaveBeenCalled();
+    handshake.release();
+    await vi.runAllTimersAsync();
+
+    expect(isMockIcqqClientConnected(previous)).toBe(false);
+    expect(isMockIcqqClientConnected(replacement)).toBe(true);
+
+    releaseInbound();
+    await Promise.all([closing, stopping]);
+    await replacement.stop();
+  });
+
+  it('close waits for an in-flight guild message receive', async () => {
+    let releaseInbound!: () => void;
+    const inboundGate = new Promise<void>((resolve) => { releaseInbound = resolve; });
+    const receive = vi.fn(async () => {
+      await inboundGate;
+      return Object.freeze({ matched: true, value: 'ok' });
+    });
+    const endpoint = createEndpoint({ receive });
+    await endpoint.start(new AbortController().signal);
+    endpoint.open();
+
+    endpoint.emit('message.guild.normal', {
+      type: 'guild',
+      guild_id: 'g1',
+      guild_name: 'Guild One',
+      channel_id: 'c1',
+      channel_name: 'general',
+      tiny_id: 'u1',
+      nickname: 'alice',
+      message_id: 'guild-inflight',
+      raw_message: 'hold guild receive',
+      time: 1_700_000_000,
+    });
+    await vi.waitFor(() => expect(receive).toHaveBeenCalledOnce());
+
+    let closeSettled = false;
+    const closing = endpoint.close().then(() => { closeSettled = true; });
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    expect(closeSettled).toBe(false);
+
+    releaseInbound();
+    await closing;
+    await endpoint.stop();
+  });
+
+  it('stop waits for a held message receive flushed by open', async () => {
+    let releaseInbound!: () => void;
+    const inboundGate = new Promise<void>((resolve) => { releaseInbound = resolve; });
+    const receive = vi.fn(async () => {
+      await inboundGate;
+      return Object.freeze({ matched: true, value: 'ok' });
+    });
+    const endpoint = createEndpoint({ receive });
+    await endpoint.start(new AbortController().signal);
+
+    endpoint.emit('message.group.normal', {
+      post_type: 'message',
+      message_type: 'group',
+      group_id: 100,
+      user_id: 2,
+      message_id: 'held-inflight',
+      raw_message: 'hold until open',
+      time: 1_700_000_000,
+      sender: { user_id: 2, nickname: 'bob', role: 'member' },
+    });
+    await Promise.resolve();
+    expect(receive).not.toHaveBeenCalled();
+
+    endpoint.open();
+    await vi.waitFor(() => expect(receive).toHaveBeenCalledOnce());
+    let stopSettled = false;
+    const stopping = endpoint.stop().then(() => { stopSettled = true; });
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    expect(stopSettled).toBe(false);
+
+    releaseInbound();
+    await stopping;
+  });
+
+  it.each(['close', 'stop'] as const)(
+    'fails fast when gateway.receive synchronously awaits endpoint.%s, while external lifecycle still drains',
+    async (method) => {
+      let releaseInbound!: () => void;
+      const inboundGate = new Promise<void>((resolve) => { releaseInbound = resolve; });
+      let markLifecycleAttempted!: () => void;
+      const lifecycleAttempted = new Promise<void>((resolve) => { markLifecycleAttempted = resolve; });
+      let internalError: unknown;
+      const holder: { endpoint?: IcqqEndpoint } = {};
+      const receive = vi.fn(async () => {
+        try {
+          await holder.endpoint![method]();
+        } catch (error) {
+          internalError = error;
+        } finally {
+          markLifecycleAttempted();
+        }
+        await inboundGate;
+        return Object.freeze({ matched: true, value: 'ok' });
+      });
+      const endpoint = createEndpoint({ receive });
+      holder.endpoint = endpoint;
+      await endpoint.start(new AbortController().signal);
+      endpoint.open();
+
+      endpoint.emit('message.group.normal', {
+        post_type: 'message',
+        message_type: 'group',
+        group_id: 100,
+        user_id: 2,
+        message_id: `self-${method}`,
+        raw_message: `self ${method}`,
+        time: 1_700_000_000,
+        sender: { user_id: 2, nickname: 'bob', role: 'member' },
+      });
+      await lifecycleAttempted;
+      expect(internalError).toBeInstanceOf(Error);
+      expect(String(internalError)).toMatch(/inbound|receive|lifecycle/i);
+
+      let externalSettled = false;
+      const external = endpoint[method]().then(() => { externalSettled = true; });
+      await new Promise<void>((resolve) => setTimeout(resolve, 0));
+      expect(externalSettled).toBe(false);
+
+      releaseInbound();
+      await external;
+      if (method === 'close') await endpoint.stop();
+    },
+  );
+
   it('admits message events via MessageGateway when open', async () => {
     const receive = vi.fn(async () => Object.freeze({ matched: true, value: 'ok' }));
     const endpoint = createEndpoint({ receive });

--- a/plugins/adapters/sandbox/src/endpoint.ts
+++ b/plugins/adapters/sandbox/src/endpoint.ts
@@ -24,7 +24,12 @@ import {
  * 首个占用 `/sandbox`（保持 Console 默认兼容），其余退到 `/sandbox/<name>`。
  * 认领记录按 HttpHost 隔离，endpoint stop() 时必须 release。
  */
-const claimedWsPaths = new WeakMap<HttpHost, Map<string, string>>();
+interface SandboxWsPathClaim {
+  readonly name: string;
+  readonly owners: Set<symbol>;
+}
+
+const claimedWsPaths = new WeakMap<HttpHost, Map<string, SandboxWsPathClaim>>();
 
 function claimSandboxWsPath(
   http: HttpHost,
@@ -37,7 +42,7 @@ function claimSandboxWsPath(
   }
   const candidates = ['/sandbox', `/sandbox/${encodeURIComponent(name)}`];
   let path = candidates.find(
-    (candidate) => !claims!.has(candidate) || claims!.get(candidate) === name,
+    (candidate) => !claims!.has(candidate) || claims!.get(candidate)?.name === name,
   );
   if (!path) {
     let index = 2;
@@ -47,13 +52,19 @@ function claimSandboxWsPath(
       path = `/sandbox/${encodeURIComponent(name)}-${index}`;
     }
   }
-  claims.set(path, name);
+  const owner = Symbol(name);
+  const claim = claims.get(path) ?? { name, owners: new Set<symbol>() };
+  claim.owners.add(owner);
+  claims.set(path, claim);
   const claimed = path;
   const registry = claims;
   return {
     path: claimed,
     release: () => {
-      if (registry.get(claimed) === name) registry.delete(claimed);
+      claim.owners.delete(owner);
+      if (claim.owners.size === 0 && registry.get(claimed) === claim) {
+        registry.delete(claimed);
+      }
     },
   };
 }

--- a/plugins/adapters/sandbox/tests/sandbox-runtime.test.ts
+++ b/plugins/adapters/sandbox/tests/sandbox-runtime.test.ts
@@ -31,6 +31,39 @@ afterEach(async () => {
 });
 
 describe('sandbox plugin runtime adapter', () => {
+  it('keeps the replacement path claim when the previous HMR endpoint stops', () => {
+    const http = createHttpHost({ host: '127.0.0.1', port: 0 });
+    hosts.push(http);
+    const ws = vi.spyOn(http, 'ws');
+    const gateway: MessageGateway = {
+      receive: vi.fn(async () => Object.freeze({ matched: false })),
+      send: vi.fn(async () => 'sent'),
+    };
+    const createEndpoint = (id: string) => new SandboxWsEndpoint({
+      id: capabilityId(rootPluginId(), adapterFeature, `sandbox-${id}`),
+      gateway,
+      http,
+      defaults: resolveSandboxEndpoint({ id, owner: 'sandbox-user' }),
+    });
+
+    const previous = createEndpoint('demo-bot');
+    const replacement = createEndpoint('demo-bot');
+    previous.start();
+    replacement.start();
+    previous.stop();
+
+    const other = createEndpoint('other-bot');
+    other.start();
+    expect(ws.mock.calls.map(([path]) => path)).toEqual([
+      '/sandbox',
+      '/sandbox',
+      '/sandbox/other-bot',
+    ]);
+
+    replacement.stop();
+    other.stop();
+  });
+
   it('shares a delayed readiness probe and lets callers suppress stale delivery', async () => {
     let resolveProbe: ((status: {
       available: boolean;

--- a/plugins/services/activity-feedback/README.md
+++ b/plugins/services/activity-feedback/README.md
@@ -26,7 +26,7 @@ activityFeedbackAiBus ──► ai-event-binder（薄） ──► ActivityFeedb
 
 同一 IM 会话的异步状态事件按产生顺序串行投影，主 Agent、工具迭代、子 Agent
 以及 Schedule 的开始/完成/失败不会互相抢写。Endpoint 未声明某项操作时会按实际
-能力降级为状态消息，不按平台名称猜测隐藏方法。
+能力降级为可安全清理的 reaction、typing、message 或 none，不按平台名称猜测隐藏方法。
 
 ## 安装
 

--- a/plugins/services/activity-feedback/README.md
+++ b/plugins/services/activity-feedback/README.md
@@ -1,6 +1,6 @@
 # @zhin.js/service-activity-feedback
 
-可选服务插件：订阅 AI 生命周期事件，按**顶层** `activityFeedback` 配置驱动各适配器能力。
+可选服务插件：订阅 AI 生命周期事件，按插件实例配置驱动各适配器能力。
 
 ## 模块结构
 
@@ -18,11 +18,15 @@ activityFeedbackAiBus ──► ai-event-binder（薄） ──► ActivityFeedb
 
 - **Orchestrator**：对外 `startPhase` / `stopPhase` / `updateThinkingText`
 - **Policy**：根级 `activityFeedback` 合并与 phase 解析
-- **Executor**：隐藏 platform 自管 manager 与 generic manager 双路径
+- **Executor**：隐藏 platform 自管 manager 与 generic manager 双路径，并按 Endpoint 声明能力选择 reaction / typing / message
 - **Adapter**：仅提供 `$activityFeedback` IO 能力
-- **Runtime slice-2**：`plugin.ts` setup 经 `activityFeedbackAiBus` 订阅（无 `usePlugin`）；
-  endpoint access 暂为 noop（phase 在 resolve 失败时静默跳过）。
-  **TODO**：注入真实 Adapter/endpoint access，使 typing/reaction 真正出站。
+- **Runtime**：`plugin.ts` setup 经 `activityFeedbackAiBus` 订阅（无 `usePlugin`），
+  通过 generation-owned `outboundHostToken` 访问当前 Endpoint；发送、撤回、编辑、
+  reaction 与原生 typing 均走统一 IM Runtime 控制链路。
+
+同一 IM 会话的异步状态事件按产生顺序串行投影，主 Agent、工具迭代、子 Agent
+以及 Schedule 的开始/完成/失败不会互相抢写。Endpoint 未声明某项操作时会按实际
+能力降级为状态消息，不按平台名称猜测隐藏方法。
 
 ## 安装
 
@@ -30,19 +34,32 @@ activityFeedbackAiBus ──► ai-event-binder（薄） ──► ActivityFeedb
 pnpm add @zhin.js/service-activity-feedback @zhin.js/agent
 ```
 
+随后在项目 `package.json#zhin.plugins` 挂载插件：
+
+```json
+{
+  "zhin": {
+    "plugins": [
+      {
+        "package": "@zhin.js/service-activity-feedback",
+        "instanceKey": "activity-feedback"
+      }
+    ]
+  }
+}
+```
+
 ## 启用
 
 ```yaml
 plugins:
-  - "@zhin.js/service-activity-feedback"
-
-activityFeedback:
-  enabled: true
-  platforms:
-    icqq:
-      phases:
-        active:
-          group: { type: reaction, emoji: "60" }
+  activity-feedback:
+    enabled: true
+    platforms:
+      icqq:
+        phases:
+          active:
+            group: { type: reaction, emoji: "60" }
 ```
 
 详见 [Activity Feedback](../../../docs/advanced/activity-feedback.md)、[ADR 0034](../../../docs/adr/0034-activity-feedback-service-plugin.md)。

--- a/plugins/services/activity-feedback/plugin.ts
+++ b/plugins/services/activity-feedback/plugin.ts
@@ -1,4 +1,10 @@
-import { definePlugin, outboundHostToken } from 'zhin.js';
+import {
+  createGenerationAdmissionGate,
+  createToken,
+  definePlugin,
+  outboundHostToken,
+  type GenerationAdmissionGate,
+} from 'zhin.js';
 import { getLogger } from '@zhin.js/logger';
 import {
   loadActivityFeedbackServiceConfig,
@@ -9,11 +15,13 @@ import {
   createActivityFeedbackOrchestratorForRuntime,
 } from './src/ai-event-binder.js';
 import {
-  createNoopEndpointAccess,
   createOutboundEndpointAccess,
 } from './src/executor.js';
 
 const logger = getLogger('activity-feedback');
+const activityFeedbackAdmissionToken = createToken<GenerationAdmissionGate>(
+  'zhin.activity-feedback.generation-admission',
+);
 
 /**
  * Activity Feedback service — Plugin Runtime entry.
@@ -33,20 +41,32 @@ export default definePlugin<ActivityFeedbackServiceConfig>({
       return;
     }
 
-    const access = context.resources.has(outboundHostToken)
-      ? createOutboundEndpointAccess(context.resources.use(outboundHostToken), logger)
-      : createNoopEndpointAccess();
+    const outbound = context.resources.has(outboundHostToken)
+      ? context.resources.use(outboundHostToken)
+      : undefined;
+    if (!outbound || typeof outbound.runWithView !== 'function') {
+      logger.debug(
+        '[ActivityFeedback] disabled: OutboundHost with generation-bound runWithView is required',
+      );
+      return;
+    }
+    const access = createOutboundEndpointAccess(outbound, logger);
 
     const orchestrator = createActivityFeedbackOrchestratorForRuntime(
       serviceConfig,
       logger,
       access,
     );
-    const dispose = bindActivityFeedbackToAIEventBus(orchestrator);
+    const admission = createGenerationAdmissionGate();
+    context.resources.provide(activityFeedbackAdmissionToken, admission);
+    const dispose = bindActivityFeedbackToAIEventBus(
+      orchestrator,
+      admission,
+      outbound.runWithView.bind(outbound),
+    );
     context.lifecycle.add(async () => {
       logger.debug('[ActivityFeedback] Disposing Runtime AI event binder');
       await dispose();
-      await orchestrator.dispose();
     });
   },
 });

--- a/plugins/services/activity-feedback/plugin.ts
+++ b/plugins/services/activity-feedback/plugin.ts
@@ -43,9 +43,10 @@ export default definePlugin<ActivityFeedbackServiceConfig>({
       access,
     );
     const dispose = bindActivityFeedbackToAIEventBus(orchestrator);
-    context.lifecycle.add(() => {
+    context.lifecycle.add(async () => {
       logger.debug('[ActivityFeedback] Disposing Runtime AI event binder');
-      dispose();
+      await dispose();
+      await orchestrator.dispose();
     });
   },
 });

--- a/plugins/services/activity-feedback/src/ai-event-binder.ts
+++ b/plugins/services/activity-feedback/src/ai-event-binder.ts
@@ -7,6 +7,7 @@ import {
   type AIEventTarget,
 } from '@zhin.js/agent';
 import { loadActivityFeedbackServiceConfig, type ActivityFeedbackServiceConfig } from './config.js';
+import type { GenerationAdmissionGate } from 'zhin.js';
 import {
   ActivityFeedbackExecutor,
   createNoopEndpointAccess,
@@ -55,9 +56,10 @@ export function createActivityFeedbackAIEventHandlers(
       await orchestrator.stopPhase(payload, 'active', 'processing.error');
     },
 
-    onTypingStop: (payload) => {
+    onTypingStop: async (payload) => {
       if (!isActivityFeedbackEnabled(payload, 'active')) return;
-      return orchestrator.stopPhase(payload, 'active', 'typing.stop');
+      await orchestrator.stopPhase(payload, 'thinking', 'typing.stop');
+      await orchestrator.stopPhase(payload, 'active', 'typing.stop');
     },
 
     onThinking: async (payload) => {
@@ -120,20 +122,53 @@ export function createActivityFeedbackAIEventHandlers(
  */
 export function bindActivityFeedbackToAIEventBus(
   orchestrator: ActivityFeedbackOrchestrator,
+  admission: GenerationAdmissionGate,
+  runWithView: <T>(operation: () => Promise<T>) => Promise<T>,
 ): () => Promise<void> {
-  const serialized = createGenerationSerializedTarget(activityFeedbackAiBus);
+  let stopWatchingRetirement: (() => void) | undefined;
+  let close!: () => Promise<void>;
+  const watchRetirement = () => {
+    if (stopWatchingRetirement) return;
+    stopWatchingRetirement = admission.onDeactivate(() => {
+      void close();
+    });
+  };
+  const serialized = createGenerationSerializedTarget(
+    activityFeedbackAiBus,
+    admission,
+    runWithView,
+    watchRetirement,
+  );
   const unsubscribe = subscribeAIEventsOnTarget(
     serialized.target,
     createActivityFeedbackAIEventHandlers(orchestrator),
   );
+  let shutdown: Promise<void> | undefined;
+  close = (): Promise<void> => {
+    if (shutdown) return shutdown;
+    // Retirement is published before SnapshotStore changes its current pointer.
+    // Enter the IM view synchronously here so timers, native-typing keepalives,
+    // and final reaction/message cleanup all remain on this generation's Endpoint.
+    shutdown = runWithView(async () => {
+      unsubscribe();
+      await serialized.close();
+      await orchestrator.dispose();
+    });
+    return shutdown;
+  };
   return async () => {
-    unsubscribe();
-    await serialized.close();
+    stopWatchingRetirement?.();
+    await close();
   };
 }
 
 /** Generation-local ordering: one queue per IM session, no module-level runtime state. */
-function createGenerationSerializedTarget(source: AIEventTarget): {
+function createGenerationSerializedTarget(
+  source: AIEventTarget,
+  admission: GenerationAdmissionGate,
+  runWithView: <T>(operation: () => Promise<T>) => Promise<T>,
+  onAdmitted: () => void,
+): {
   target: AIEventTarget;
   close(): Promise<void>;
 } {
@@ -144,19 +179,28 @@ function createGenerationSerializedTarget(source: AIEventTarget): {
   const target: AIEventTarget = {
     on(event, listener) {
       const wrapped = async (payload: AIEventPayload) => {
-        const key = payload.sessionId || '__global__';
-        const previous = tails.get(key);
-        const run = async () => {
-          if (!closed) await listener(payload);
-        };
-        const current = previous
-          ? previous.catch(() => undefined).then(run)
-          : run();
-        tails.set(key, current);
+        const release = admission.acquire();
+        if (!release) return;
+        onAdmitted();
         try {
-          await current;
+          await runWithView(async () => {
+            const key = payload.sessionId || '__global__';
+            const previous = tails.get(key);
+            const run = async () => {
+              if (!closed) await listener(payload);
+            };
+            const current = previous
+              ? previous.catch(() => undefined).then(run)
+              : run();
+            tails.set(key, current);
+            try {
+              await current;
+            } finally {
+              if (tails.get(key) === current) tails.delete(key);
+            }
+          });
         } finally {
-          if (tails.get(key) === current) tails.delete(key);
+          release();
         }
       };
       wrappers.set(listener, wrapped);

--- a/plugins/services/activity-feedback/src/ai-event-binder.ts
+++ b/plugins/services/activity-feedback/src/ai-event-binder.ts
@@ -99,9 +99,12 @@ export function createActivityFeedbackAIEventHandlers(
     },
 
     onSubagentFinish: async (payload) => {
-      if (!isActivityFeedbackEnabled(payload, 'active')) return;
-      await orchestrator.stopPhase(payload, 'thinking', 'subagent.finish');
-      await orchestrator.stopPhase(payload, 'active', 'subagent.finish');
+      if (isActivityFeedbackEnabled(payload, 'thinking')) {
+        await orchestrator.stopPhase(payload, 'thinking', 'subagent.finish');
+      }
+      if (isActivityFeedbackEnabled(payload, 'active')) {
+        await orchestrator.stopPhase(payload, 'active', 'subagent.finish');
+      }
     },
 
     onScheduleStart: (payload) => orchestrator.startPhase(payload, 'schedule_start', 'schedule.start'),
@@ -126,7 +129,6 @@ export function bindActivityFeedbackToAIEventBus(
   runWithView: <T>(operation: () => Promise<T>) => Promise<T>,
 ): () => Promise<void> {
   let stopWatchingRetirement: (() => void) | undefined;
-  let close!: () => Promise<void>;
   const watchRetirement = () => {
     if (stopWatchingRetirement) return;
     stopWatchingRetirement = admission.onDeactivate(() => {
@@ -144,7 +146,7 @@ export function bindActivityFeedbackToAIEventBus(
     createActivityFeedbackAIEventHandlers(orchestrator),
   );
   let shutdown: Promise<void> | undefined;
-  close = (): Promise<void> => {
+  function close(): Promise<void> {
     if (shutdown) return shutdown;
     // Retirement is published before SnapshotStore changes its current pointer.
     // Enter the IM view synchronously here so timers, native-typing keepalives,
@@ -155,7 +157,7 @@ export function bindActivityFeedbackToAIEventBus(
       await orchestrator.dispose();
     });
     return shutdown;
-  };
+  }
   return async () => {
     stopWatchingRetirement?.();
     await close();

--- a/plugins/services/activity-feedback/src/ai-event-binder.ts
+++ b/plugins/services/activity-feedback/src/ai-event-binder.ts
@@ -3,6 +3,8 @@ import {
   activityFeedbackAiBus,
   isActivityFeedbackEnabled,
   type AIEventHandlers,
+  type AIEventPayload,
+  type AIEventTarget,
 } from '@zhin.js/agent';
 import { loadActivityFeedbackServiceConfig, type ActivityFeedbackServiceConfig } from './config.js';
 import {
@@ -29,7 +31,13 @@ export function createActivityFeedbackAIEventHandlers(
     onProcessingStart: async (payload) => {
       if (!isActivityFeedbackEnabled(payload, 'active')) return;
       await orchestrator.stopPhase(payload, 'queued', 'processing.start');
+      if (typeof payload.iterations === 'number' && payload.iterations > 1) {
+        await orchestrator.stopPhase(payload, 'thinking', 'processing.iteration');
+      }
       await orchestrator.startPhase(payload, 'active', 'processing.start');
+      if (typeof payload.iterations === 'number' && payload.iterations > 1 && payload.content?.trim()) {
+        await orchestrator.updatePhaseText(payload, 'active', payload.content.trim());
+      }
     },
 
     onTypingStart: async () => {},
@@ -60,9 +68,26 @@ export function createActivityFeedbackAIEventHandlers(
       await orchestrator.updateThinkingText(payload, payload.thinking);
     },
 
+    onToolCall: async (payload) => {
+      if (!isActivityFeedbackEnabled(payload, 'active') || !payload.toolName?.trim()) return;
+      const text = `调用工具：${payload.toolName.trim()}…`;
+      await orchestrator.updatePhaseText(payload, 'thinking', text);
+      await orchestrator.updatePhaseText(payload, 'active', text);
+    },
+
+    onToolResult: async (payload) => {
+      if (!isActivityFeedbackEnabled(payload, 'active') || !payload.toolName?.trim()) return;
+      const outcome = payload.status === 'error' || payload.error ? '未完成' : '已完成';
+      const text = `工具 ${payload.toolName.trim()} ${outcome}，继续处理…`;
+      await orchestrator.updatePhaseText(payload, 'thinking', text);
+      await orchestrator.updatePhaseText(payload, 'active', text);
+    },
+
     onSubagentStart: async (payload) => {
       if (!isActivityFeedbackEnabled(payload, 'thinking')) return;
-      // Do not stop the parent turn's active indicator — subagent uses an isolated session key.
+      // The subagent has an isolated session key; remove its own active placeholder
+      // before switching to the richer thinking state.
+      await orchestrator.stopPhase(payload, 'active', 'subagent.start');
       await orchestrator.startPhase(payload, 'thinking', 'subagent.start');
       const tag = payload.agentId?.trim() || 'subagent';
       const label = payload.label?.trim()
@@ -74,14 +99,17 @@ export function createActivityFeedbackAIEventHandlers(
     onSubagentFinish: async (payload) => {
       if (!isActivityFeedbackEnabled(payload, 'active')) return;
       await orchestrator.stopPhase(payload, 'thinking', 'subagent.finish');
-      await orchestrator.startPhase(payload, 'active', 'subagent.finish');
+      await orchestrator.stopPhase(payload, 'active', 'subagent.finish');
     },
 
     onScheduleStart: (payload) => orchestrator.startPhase(payload, 'schedule_start', 'schedule.start'),
-    onScheduleFinish: (payload) => orchestrator.stopPhase(payload, 'schedule_start', 'schedule.finish'),
+    onScheduleFinish: async (payload) => {
+      await orchestrator.stopPhase(payload, 'schedule_start', 'schedule.finish');
+      await orchestrator.showTransientPhase(payload, 'schedule_finish', 'schedule.finish');
+    },
     onScheduleError: async (payload) => {
       await orchestrator.stopPhase(payload, 'schedule_start', 'schedule.error');
-      await orchestrator.startPhase(payload, 'schedule_error', 'schedule.error');
+      await orchestrator.showTransientPhase(payload, 'schedule_error', 'schedule.error');
     },
   };
 }
@@ -92,11 +120,65 @@ export function createActivityFeedbackAIEventHandlers(
  */
 export function bindActivityFeedbackToAIEventBus(
   orchestrator: ActivityFeedbackOrchestrator,
-): () => void {
-  return subscribeAIEventsOnTarget(
-    activityFeedbackAiBus,
+): () => Promise<void> {
+  const serialized = createGenerationSerializedTarget(activityFeedbackAiBus);
+  const unsubscribe = subscribeAIEventsOnTarget(
+    serialized.target,
     createActivityFeedbackAIEventHandlers(orchestrator),
   );
+  return async () => {
+    unsubscribe();
+    await serialized.close();
+  };
+}
+
+/** Generation-local ordering: one queue per IM session, no module-level runtime state. */
+function createGenerationSerializedTarget(source: AIEventTarget): {
+  target: AIEventTarget;
+  close(): Promise<void>;
+} {
+  const tails = new Map<string, Promise<void>>();
+  const wrappers = new Map<(payload: AIEventPayload) => void | Promise<void>,
+    (payload: AIEventPayload) => Promise<void>>();
+  let closed = false;
+  const target: AIEventTarget = {
+    on(event, listener) {
+      const wrapped = async (payload: AIEventPayload) => {
+        const key = payload.sessionId || '__global__';
+        const previous = tails.get(key);
+        const run = async () => {
+          if (!closed) await listener(payload);
+        };
+        const current = previous
+          ? previous.catch(() => undefined).then(run)
+          : run();
+        tails.set(key, current);
+        try {
+          await current;
+        } finally {
+          if (tails.get(key) === current) tails.delete(key);
+        }
+      };
+      wrappers.set(listener, wrapped);
+      return source.on(event, wrapped);
+    },
+    off(event, listener) {
+      const wrapped = wrappers.get(listener);
+      if (!wrapped) return source.off(event, listener);
+      wrappers.delete(listener);
+      return source.off(event, wrapped);
+    },
+  };
+  return {
+    target,
+    async close() {
+      closed = true;
+      const pending = [...tails.values()];
+      await Promise.allSettled(pending);
+      tails.clear();
+      wrappers.clear();
+    },
+  };
 }
 
 export type ActivityFeedbackLogger = {

--- a/plugins/services/activity-feedback/src/config.ts
+++ b/plugins/services/activity-feedback/src/config.ts
@@ -1,6 +1,6 @@
 import type { ActivityFeedbackConfig } from '@zhin.js/agent';
 
-/** 顶层 `activityFeedback` 配置（zhin.config.yml，与 endpoints 解耦） */
+/** Plugin Runtime 实例配置（`plugins.<instanceKey>`，与 Adapter endpoint 配置解耦）。 */
 export interface ActivityFeedbackServiceConfig {
   enabled?: boolean;
   defaults?: ActivityFeedbackConfig;

--- a/plugins/services/activity-feedback/src/executor.ts
+++ b/plugins/services/activity-feedback/src/executor.ts
@@ -56,13 +56,18 @@ export function createOutboundEndpointAccess(
       const key = `${platform}:${endpointKey}`;
       const cached = cache.get(key);
       if (cached) return cached;
+      const declared = outbound.capabilities?.({ adapter: platform, endpointKey })?.operations;
+      const supports = (operation: 'recall' | 'edit' | 'reaction' | 'typing') =>
+        declared?.includes(operation) === true;
       const recall = outbound.recall;
+      const edit = outbound.edit;
       const addReaction = outbound.addReaction;
       const removeReaction = outbound.removeReaction;
+      const typing = outbound.typing;
       const endpoint = {
         $id: endpointKey,
         control: {
-          ...(recall ? {
+          ...(recall && supports('recall') ? {
             recall: async (message: Parameters<typeof recall>[0]['message']) => {
               try {
                 await recall({ adapter: platform, endpointKey, message });
@@ -74,7 +79,23 @@ export function createOutboundEndpointAccess(
               }
             },
           } : {}),
-          ...(addReaction ? {
+          ...(edit && supports('edit') ? {
+            edit: async (
+              message: Parameters<typeof edit>[0]['message'],
+              content: unknown,
+            ) => {
+              try {
+                return await edit({ adapter: platform, endpointKey, message, content });
+              } catch (error) {
+                logger?.debug(
+                  `[ActivityFeedback] outbound edit failed (${key}):`,
+                  error instanceof Error ? error.message : String(error),
+                );
+                return null;
+              }
+            },
+          } : {}),
+          ...(addReaction && supports('reaction') ? {
             addReaction: async (
               message: Parameters<typeof addReaction>[0]['message'],
               emoji: string,
@@ -98,7 +119,7 @@ export function createOutboundEndpointAccess(
               }
             },
           } : {}),
-          ...(removeReaction ? {
+          ...(removeReaction && supports('reaction') ? {
             removeReaction: async (
               message: Parameters<typeof removeReaction>[0]['message'],
               reactionId: string,
@@ -111,6 +132,21 @@ export function createOutboundEndpointAccess(
                   error instanceof Error ? error.message : String(error),
                 );
               });
+            },
+          } : {}),
+          ...(typing && supports('typing') ? {
+            typing: async (
+              conversation: Parameters<typeof typing>[0]['conversation'],
+              active?: boolean,
+            ) => {
+              try {
+                await typing({ adapter: platform, endpointKey, conversation, active });
+              } catch (error) {
+                logger?.debug(
+                  `[ActivityFeedback] outbound typing failed (${key}):`,
+                  error instanceof Error ? error.message : String(error),
+                );
+              }
             },
           } : {}),
         },
@@ -281,10 +317,24 @@ export class ActivityFeedbackExecutor {
     await driver.stop(ctx, phase);
   }
 
-  async updateThinkingText(ctx: ActivityFeedbackEventContext, text: string): Promise<void> {
+  async updateText(
+    ctx: ActivityFeedbackEventContext,
+    phase: ActivityFeedbackPhase,
+    text: string,
+  ): Promise<void> {
     const resolved = this.access.resolve(ctx.platform, ctx.endpointKey);
     if (!resolved) return;
     const driver = createPhaseDriver(resolved.endpoint, ctx.platform, resolved.adapter);
-    await driver.updateThinkingText(ctx, text);
+    const manager = resolved.endpoint.$activityFeedback;
+    if (!manager || !isGenericActivityFeedbackManager(manager)) {
+      if (phase === 'thinking') await driver.updateThinkingText(ctx, text);
+      return;
+    }
+    const indicator = manager.getActiveIndicator(phase, ctx.options);
+    if (indicator?.update) await indicator.update(text);
+  }
+
+  async updateThinkingText(ctx: ActivityFeedbackEventContext, text: string): Promise<void> {
+    await this.updateText(ctx, 'thinking', text);
   }
 }

--- a/plugins/services/activity-feedback/src/executor.ts
+++ b/plugins/services/activity-feedback/src/executor.ts
@@ -53,7 +53,7 @@ export function createOutboundEndpointAccess(
   const cache = new Map<string, { endpoint: EndpointWithActivityFeedback; adapter: Adapter }>();
   return {
     resolve(platform, endpointKey) {
-      const key = `${platform}:${endpointKey}`;
+      const key = JSON.stringify([platform, endpointKey]);
       const cached = cache.get(key);
       if (cached) return cached;
       const declared = outbound.capabilities?.({ adapter: platform, endpointKey })?.operations;
@@ -124,14 +124,14 @@ export function createOutboundEndpointAccess(
               message: Parameters<typeof removeReaction>[0]['message'],
               reactionId: string,
             ) => {
-              void Promise.resolve(
-                removeReaction({ adapter: platform, endpointKey, message, reactionId }),
-              ).catch((error) => {
+              try {
+                await removeReaction({ adapter: platform, endpointKey, message, reactionId });
+              } catch (error) {
                 logger?.debug(
                   `[ActivityFeedback] outbound removeReaction failed (${key}):`,
                   error instanceof Error ? error.message : String(error),
                 );
-              });
+              }
             },
           } : {}),
           ...(typing && supports('typing') ? {
@@ -169,9 +169,7 @@ export function createOutboundEndpointAccess(
               },
               content: text,
             });
-            // Prefer real id; fall back to a sentinel so MessageTypingIndicator
-            // keeps the phase active until stop (recall is a no-op here).
-            return messageId || `outbound:${Date.now()}`;
+            return messageId || null;
           } catch (error) {
             logger?.debug(
               `[ActivityFeedback] outbound send failed (${key}):`,

--- a/plugins/services/activity-feedback/src/orchestrator.ts
+++ b/plugins/services/activity-feedback/src/orchestrator.ts
@@ -12,6 +12,16 @@ import { ActivityFeedbackPolicy } from './policy.js';
 type Logger = { debug: (msg: string, ...args: unknown[]) => void; error: (msg: string, ...args: unknown[]) => void };
 
 export class ActivityFeedbackOrchestrator {
+  private readonly active = new Map<string, {
+    ctx: NonNullable<ReturnType<typeof toActivityFeedbackEventContext>>;
+    phase: ActivityFeedbackPhase;
+  }>();
+  private readonly transient = new Map<string, {
+    timer: ReturnType<typeof setTimeout>;
+    ctx: NonNullable<ReturnType<typeof toActivityFeedbackEventContext>>;
+    phase: ActivityFeedbackPhase;
+  }>();
+
   constructor(
     private readonly policy: ActivityFeedbackPolicy,
     private readonly executor: ActivityFeedbackExecutor,
@@ -49,6 +59,7 @@ export class ActivityFeedbackOrchestrator {
       const config = applySubagentActivityPrefixToConfig(resolution.config, payload);
       this.log.debug(`[ActivityFeedback] start ${phase} (${reason}) session=${ctx.sessionId}`);
       await this.executor.start(ctx, phase, config);
+      this.active.set(this.phaseKey(ctx, phase), { ctx, phase });
     } catch (error) {
       this.log.error(`[ActivityFeedback] start ${phase} failed (${reason}):`, error);
     }
@@ -57,6 +68,9 @@ export class ActivityFeedbackOrchestrator {
   async stopPhase(payload: AIEventPayload, phase: ActivityFeedbackPhase, reason: string): Promise<void> {
     const ctx = toActivityFeedbackEventContext(payload);
     if (!ctx) return;
+    const key = this.phaseKey(ctx, phase);
+    this.clearTransient(key);
+    this.active.delete(key);
 
     try {
       this.log.debug(`[ActivityFeedback] stop ${phase} (${reason}) session=${ctx.sessionId}`);
@@ -67,13 +81,68 @@ export class ActivityFeedbackOrchestrator {
   }
 
   async updateThinkingText(payload: AIEventPayload, text: string): Promise<void> {
+    await this.updatePhaseText(payload, 'thinking', text);
+  }
+
+  async updatePhaseText(
+    payload: AIEventPayload,
+    phase: ActivityFeedbackPhase,
+    text: string,
+  ): Promise<void> {
     const ctx = toActivityFeedbackEventContext(payload);
     if (!ctx || !text) return;
 
     try {
-      await this.executor.updateThinkingText(ctx, withSubagentActivityPrefix(text, payload));
+      await this.executor.updateText(ctx, phase, withSubagentActivityPrefix(text, payload));
     } catch (error) {
-      this.log.error('[ActivityFeedback] thinking update failed:', error);
+      this.log.error(`[ActivityFeedback] ${phase} update failed:`, error);
     }
+  }
+
+  async showTransientPhase(
+    payload: AIEventPayload,
+    phase: ActivityFeedbackPhase,
+    reason: string,
+  ): Promise<void> {
+    await this.startPhase(payload, phase, reason);
+    const ctx = toActivityFeedbackEventContext(payload);
+    if (!ctx) return;
+    const resolution = this.policy.resolvePhase(ctx.platform, ctx.endpointKey, phase, ctx.sceneType);
+    if (resolution.kind !== 'active') return;
+    const delay = resolution.config.removeDelay ?? 3_000;
+    const key = this.phaseKey(ctx, phase);
+    this.clearTransient(key);
+    const timer = setTimeout(() => {
+      this.transient.delete(key);
+      this.active.delete(key);
+      void this.executor.stop(ctx, phase).catch((error) => {
+        this.log.error(`[ActivityFeedback] transient ${phase} cleanup failed:`, error);
+      });
+    }, Math.max(0, delay));
+    timer.unref?.();
+    this.transient.set(key, { timer, ctx, phase });
+  }
+
+  async dispose(): Promise<void> {
+    const pending = [...this.active.values()];
+    const timers = [...this.transient.values()];
+    this.active.clear();
+    this.transient.clear();
+    for (const item of timers) clearTimeout(item.timer);
+    await Promise.allSettled(pending.map((item) => this.executor.stop(item.ctx, item.phase)));
+  }
+
+  private phaseKey(
+    ctx: NonNullable<ReturnType<typeof toActivityFeedbackEventContext>>,
+    phase: ActivityFeedbackPhase,
+  ): string {
+    return `${ctx.platform}:${ctx.endpointKey}:${ctx.sessionId}:${phase}`;
+  }
+
+  private clearTransient(key: string): void {
+    const current = this.transient.get(key);
+    if (!current) return;
+    clearTimeout(current.timer);
+    this.transient.delete(key);
   }
 }

--- a/plugins/services/activity-feedback/src/orchestrator.ts
+++ b/plugins/services/activity-feedback/src/orchestrator.ts
@@ -21,6 +21,7 @@ export class ActivityFeedbackOrchestrator {
     ctx: NonNullable<ReturnType<typeof toActivityFeedbackEventContext>>;
     phase: ActivityFeedbackPhase;
   }>();
+  private readonly pendingCleanup = new Set<Promise<void>>();
 
   constructor(
     private readonly policy: ActivityFeedbackPolicy,
@@ -115,9 +116,14 @@ export class ActivityFeedbackOrchestrator {
     const timer = setTimeout(() => {
       this.transient.delete(key);
       this.active.delete(key);
-      void this.executor.stop(ctx, phase).catch((error) => {
-        this.log.error(`[ActivityFeedback] transient ${phase} cleanup failed:`, error);
-      });
+      const cleanup = this.executor.stop(ctx, phase)
+        .catch((error) => {
+          this.log.error(`[ActivityFeedback] transient ${phase} cleanup failed:`, error);
+        })
+        .finally(() => {
+          this.pendingCleanup.delete(cleanup);
+        });
+      this.pendingCleanup.add(cleanup);
     }, Math.max(0, delay));
     timer.unref?.();
     this.transient.set(key, { timer, ctx, phase });
@@ -129,14 +135,17 @@ export class ActivityFeedbackOrchestrator {
     this.active.clear();
     this.transient.clear();
     for (const item of timers) clearTimeout(item.timer);
-    await Promise.allSettled(pending.map((item) => this.executor.stop(item.ctx, item.phase)));
+    await Promise.allSettled([
+      ...pending.map((item) => this.executor.stop(item.ctx, item.phase)),
+      ...this.pendingCleanup,
+    ]);
   }
 
   private phaseKey(
     ctx: NonNullable<ReturnType<typeof toActivityFeedbackEventContext>>,
     phase: ActivityFeedbackPhase,
   ): string {
-    return JSON.stringify([ctx.platform, ctx.endpointKey, ctx.sessionId, phase]);
+    return JSON.stringify([ctx.platform, ctx.endpointKey, ctx.sessionId, phase, ctx.messageId]);
   }
 
   private clearTransient(key: string): void {

--- a/plugins/services/activity-feedback/src/orchestrator.ts
+++ b/plugins/services/activity-feedback/src/orchestrator.ts
@@ -136,7 +136,7 @@ export class ActivityFeedbackOrchestrator {
     ctx: NonNullable<ReturnType<typeof toActivityFeedbackEventContext>>,
     phase: ActivityFeedbackPhase,
   ): string {
-    return `${ctx.platform}:${ctx.endpointKey}:${ctx.sessionId}:${phase}`;
+    return JSON.stringify([ctx.platform, ctx.endpointKey, ctx.sessionId, phase]);
   }
 
   private clearTransient(key: string): void {

--- a/plugins/services/activity-feedback/src/policy.ts
+++ b/plugins/services/activity-feedback/src/policy.ts
@@ -35,6 +35,7 @@ export class ActivityFeedbackPolicy {
       this.service.defaults,
       this.service.platforms?.[platform],
       this.service.endpoints?.[`${platform}:${endpointKey}`],
+      schedulePhaseLayer(this.service, phase),
     );
 
     if (policy?.enabled === false) {
@@ -48,4 +49,19 @@ export class ActivityFeedbackPolicy {
 
     return { kind: 'active', config };
   }
+}
+
+function schedulePhaseLayer(
+  service: ActivityFeedbackServiceConfig,
+  phase: ActivityFeedbackPhase,
+): import('@zhin.js/agent').ActivityFeedbackConfig | undefined {
+  const scheduleKey = phase === 'schedule_start'
+    ? 'start'
+    : phase === 'schedule_finish'
+      ? 'finish'
+      : phase === 'schedule_error'
+        ? 'error'
+        : undefined;
+  const scenes = scheduleKey ? service.schedule?.phases?.[scheduleKey] : undefined;
+  return scenes ? { phases: { [phase]: scenes } } : undefined;
 }

--- a/plugins/services/activity-feedback/tests/activity-feedback-runtime.test.ts
+++ b/plugins/services/activity-feedback/tests/activity-feedback-runtime.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
-import { DisposeStack } from 'zhin.js';
+import { DisposeStack, type GenerationAdmissionGate } from 'zhin.js';
 import { activityFeedbackAiBus } from '@zhin.js/agent';
 import plugin from '../plugin.ts';
 import { loadActivityFeedbackServiceConfig } from '../src/config.js';
@@ -8,6 +8,36 @@ import {
   createActivityFeedbackAIEventHandlers,
   createActivityFeedbackOrchestratorForRuntime,
 } from '../src/ai-event-binder.js';
+
+function mutableAdmission(initial: boolean): {
+  gate: GenerationAdmissionGate;
+  setActive(active: boolean): void;
+} {
+  let active = initial;
+  const deactivationListeners = new Set<() => void>();
+  return {
+    gate: {
+      acquire: () => active ? () => undefined : undefined,
+      onDeactivate(listener: () => void) {
+        if (!active) {
+          listener();
+          return () => undefined;
+        }
+        deactivationListeners.add(listener);
+        return () => { deactivationListeners.delete(listener); };
+      },
+    } as GenerationAdmissionGate,
+    setActive(next) {
+      const wasActive = active;
+      active = next;
+      if (wasActive && !next) {
+        for (const listener of [...deactivationListeners]) listener();
+      }
+    },
+  };
+}
+
+const runWithView = <T>(operation: () => Promise<T>): Promise<T> => operation();
 
 describe('@zhin.js/service-activity-feedback runtime', () => {
   beforeEach(() => {
@@ -31,6 +61,7 @@ describe('@zhin.js/service-activity-feedback runtime', () => {
     const lifecycle = new DisposeStack();
     const resources = {
       has: () => false,
+      provide: vi.fn(),
       use: () => {
         throw new Error('missing resource');
       },
@@ -86,6 +117,7 @@ describe('@zhin.js/service-activity-feedback runtime', () => {
       config: { get: () => ({ enabled: false }) },
       resources: {
         has: () => false,
+        provide: vi.fn(),
         use: () => {
           throw new Error('missing resource');
         },
@@ -103,7 +135,8 @@ describe('@zhin.js/service-activity-feedback runtime', () => {
       startPhase,
       stopPhase: vi.fn(),
       updateThinkingText: vi.fn(),
-    } as never);
+      dispose: vi.fn().mockResolvedValue(undefined),
+    } as never, mutableAdmission(true).gate, runWithView);
 
     dispose();
 
@@ -198,6 +231,29 @@ describe('@zhin.js/service-activity-feedback runtime', () => {
     );
   });
 
+  it('typing.stop clears both active and thinking states', async () => {
+    const orchestrator = {
+      stopPhase: vi.fn().mockResolvedValue(undefined),
+    };
+    const handlers = createActivityFeedbackAIEventHandlers(orchestrator as never);
+    const payload = {
+      sessionId: 'cancelled',
+      source: 'zhin-agent',
+      platform: 'sandbox',
+      endpointKey: 'bot',
+      hookContext: { activityFeedbackEligible: true },
+    } as never;
+
+    await handlers.onTypingStop?.(payload);
+
+    expect(orchestrator.stopPhase).toHaveBeenNthCalledWith(
+      1, payload, 'thinking', 'typing.stop',
+    );
+    expect(orchestrator.stopPhase).toHaveBeenNthCalledWith(
+      2, payload, 'active', 'typing.stop',
+    );
+  });
+
   it('serializes start/finish handlers inside one plugin generation', async () => {
     const order: string[] = [];
     let finished!: () => void;
@@ -216,8 +272,13 @@ describe('@zhin.js/service-activity-feedback runtime', () => {
       updatePhaseText: vi.fn(),
       updateThinkingText: vi.fn(),
       showTransientPhase: vi.fn(),
+      dispose: vi.fn().mockResolvedValue(undefined),
     };
-    const dispose = bindActivityFeedbackToAIEventBus(orchestrator as never);
+    const dispose = bindActivityFeedbackToAIEventBus(
+      orchestrator as never,
+      mutableAdmission(true).gate,
+      runWithView,
+    );
     const payload = {
       sessionId: 'ordered',
       source: 'zhin-agent',
@@ -232,5 +293,85 @@ describe('@zhin.js/service-activity-feedback runtime', () => {
 
     expect(order).toEqual(['start', 'finish']);
     dispose();
+  });
+
+  it('admits an event only to the generation active when dispatch begins', async () => {
+    const previous = mutableAdmission(true);
+    const candidate = mutableAdmission(false);
+    let releasePrevious!: () => void;
+    const pendingPrevious = new Promise<void>((resolve) => { releasePrevious = resolve; });
+    const previousStart = vi.fn(() => pendingPrevious);
+    const candidateStart = vi.fn().mockResolvedValue(undefined);
+    const previousDispose = bindActivityFeedbackToAIEventBus({
+      startPhase: previousStart,
+      stopPhase: vi.fn(),
+      dispose: vi.fn().mockResolvedValue(undefined),
+    } as never, previous.gate, runWithView);
+    const candidateDispose = bindActivityFeedbackToAIEventBus({
+      startPhase: candidateStart,
+      stopPhase: vi.fn(),
+      dispose: vi.fn().mockResolvedValue(undefined),
+    } as never, candidate.gate, runWithView);
+    const payload = {
+      sessionId: 'hmr-event',
+      source: 'zhin-agent',
+      platform: 'sandbox',
+      endpointKey: 'bot',
+      hookContext: { activityFeedbackEligible: true },
+    } as never;
+
+    const dispatch = activityFeedbackAiBus.dispatch('ai.processing.start', payload);
+    await Promise.resolve();
+    previous.setActive(false);
+    candidate.setActive(true);
+    releasePrevious();
+    await dispatch;
+
+    expect(previousStart).toHaveBeenCalledOnce();
+    expect(candidateStart).not.toHaveBeenCalled();
+    await activityFeedbackAiBus.dispatch('ai.processing.start', payload);
+    expect(previousStart).toHaveBeenCalledOnce();
+    expect(candidateStart).toHaveBeenCalledOnce();
+    await previousDispose();
+    await candidateDispose();
+  });
+
+  it('starts full state cleanup in the retiring generation view', async () => {
+    const admission = mutableAdmission(true);
+    let currentView = 'old';
+    const enteredViews: string[] = [];
+    let releaseHandler!: () => void;
+    const handlerPending = new Promise<void>((resolve) => { releaseHandler = resolve; });
+    const orchestrator = {
+      startPhase: vi.fn(() => handlerPending),
+      stopPhase: vi.fn(),
+      dispose: vi.fn().mockResolvedValue(undefined),
+    };
+    const dispose = bindActivityFeedbackToAIEventBus(
+      orchestrator as never,
+      admission.gate,
+      async (operation) => {
+        enteredViews.push(currentView);
+        return operation();
+      },
+    );
+    const dispatch = activityFeedbackAiBus.dispatch('ai.processing.start', {
+      sessionId: 'retiring-state',
+      source: 'zhin-agent',
+      platform: 'sandbox',
+      endpointKey: 'bot',
+      hookContext: { activityFeedbackEligible: true },
+    } as never);
+    await Promise.resolve();
+
+    admission.setActive(false);
+    currentView = 'new';
+    expect(enteredViews).toEqual(['old', 'old']);
+    expect(orchestrator.dispose).not.toHaveBeenCalled();
+
+    releaseHandler();
+    await dispatch;
+    await dispose();
+    expect(orchestrator.dispose).toHaveBeenCalledOnce();
   });
 });

--- a/plugins/services/activity-feedback/tests/activity-feedback-runtime.test.ts
+++ b/plugins/services/activity-feedback/tests/activity-feedback-runtime.test.ts
@@ -254,6 +254,30 @@ describe('@zhin.js/service-activity-feedback runtime', () => {
     );
   });
 
+  it('subagent finish independently clears thinking and active phases', async () => {
+    const orchestrator = {
+      stopPhase: vi.fn().mockResolvedValue(undefined),
+    };
+    const handlers = createActivityFeedbackAIEventHandlers(orchestrator as never);
+    const payload = {
+      sessionId: 'subagent:thinking-only',
+      source: 'subagent',
+      agentId: 'researcher',
+      hookContext: {
+        activityFeedbackEligible: true,
+      },
+    } as never;
+
+    await handlers.onSubagentFinish?.(payload);
+
+    expect(orchestrator.stopPhase).toHaveBeenCalledWith(
+      payload, 'thinking', 'subagent.finish',
+    );
+    expect(orchestrator.stopPhase).toHaveBeenCalledWith(
+      payload, 'active', 'subagent.finish',
+    );
+  });
+
   it('serializes start/finish handlers inside one plugin generation', async () => {
     const order: string[] = [];
     let finished!: () => void;

--- a/plugins/services/activity-feedback/tests/activity-feedback-runtime.test.ts
+++ b/plugins/services/activity-feedback/tests/activity-feedback-runtime.test.ts
@@ -5,6 +5,7 @@ import plugin from '../plugin.ts';
 import { loadActivityFeedbackServiceConfig } from '../src/config.js';
 import {
   bindActivityFeedbackToAIEventBus,
+  createActivityFeedbackAIEventHandlers,
   createActivityFeedbackOrchestratorForRuntime,
 } from '../src/ai-event-binder.js';
 
@@ -56,7 +57,7 @@ describe('@zhin.js/service-activity-feedback runtime', () => {
     };
     activityFeedbackAiBus.on('ai.processing.start', probe as never);
 
-    activityFeedbackAiBus.emit('ai.processing.start', {
+    await activityFeedbackAiBus.dispatch('ai.processing.start', {
       sessionId: 's1',
       source: 'zhin-agent',
     } as never);
@@ -65,7 +66,7 @@ describe('@zhin.js/service-activity-feedback runtime', () => {
     await lifecycle.dispose();
 
     received.length = 0;
-    activityFeedbackAiBus.emit('ai.processing.start', {
+    await activityFeedbackAiBus.dispatch('ai.processing.start', {
       sessionId: 's2',
       source: 'zhin-agent',
     } as never);
@@ -138,5 +139,98 @@ describe('@zhin.js/service-activity-feedback runtime', () => {
         'test',
       ),
     ).resolves.toBeUndefined();
+  });
+
+  it('updates task/tool progress and shows transient schedule terminal states', async () => {
+    const orchestrator = {
+      startPhase: vi.fn().mockResolvedValue(undefined),
+      stopPhase: vi.fn().mockResolvedValue(undefined),
+      updatePhaseText: vi.fn().mockResolvedValue(undefined),
+      showTransientPhase: vi.fn().mockResolvedValue(undefined),
+    };
+    const handlers = createActivityFeedbackAIEventHandlers(orchestrator as never);
+    const payload = {
+      sessionId: 's1',
+      source: 'zhin-agent',
+      platform: 'sandbox',
+      endpointKey: 'bot',
+      hookContext: { activityFeedbackEligible: true },
+    } as never;
+
+    await handlers.onProcessingStart?.({ ...payload, iterations: 2, content: '处理中 [2/15]...' });
+    await handlers.onToolCall?.({ ...payload, toolName: 'web_search' });
+    await handlers.onToolResult?.({ ...payload, toolName: 'web_search' });
+    await handlers.onToolResult?.({
+      ...payload,
+      toolName: 'shell',
+      status: 'error',
+      error: 'denied',
+    });
+
+    expect(orchestrator.updatePhaseText).toHaveBeenCalledWith(
+      expect.anything(), 'active', '处理中 [2/15]...',
+    );
+    expect(orchestrator.stopPhase).toHaveBeenCalledWith(
+      expect.anything(), 'thinking', 'processing.iteration',
+    );
+    expect(orchestrator.updatePhaseText).toHaveBeenCalledWith(
+      expect.anything(), 'active', '调用工具：web_search…',
+    );
+    expect(orchestrator.updatePhaseText).toHaveBeenCalledWith(
+      expect.anything(), 'active', '工具 web_search 已完成，继续处理…',
+    );
+    expect(orchestrator.updatePhaseText).toHaveBeenCalledWith(
+      expect.anything(), 'active', '工具 shell 未完成，继续处理…',
+    );
+
+    const schedulePayload = {
+      ...payload,
+      sessionId: 'schedule:job-1',
+      hookContext: { scheduleJobId: 'job-1', scheduleActivityFeedback: true },
+    } as never;
+    await handlers.onScheduleFinish?.(schedulePayload);
+    await handlers.onScheduleError?.(schedulePayload);
+    expect(orchestrator.showTransientPhase).toHaveBeenCalledWith(
+      schedulePayload, 'schedule_finish', 'schedule.finish',
+    );
+    expect(orchestrator.showTransientPhase).toHaveBeenCalledWith(
+      schedulePayload, 'schedule_error', 'schedule.error',
+    );
+  });
+
+  it('serializes start/finish handlers inside one plugin generation', async () => {
+    const order: string[] = [];
+    let finished!: () => void;
+    const done = new Promise<void>((resolve) => { finished = resolve; });
+    const orchestrator = {
+      startPhase: vi.fn(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        order.push('start');
+      }),
+      stopPhase: vi.fn(async (_payload, phase: string) => {
+        if (phase === 'active') {
+          order.push('finish');
+          finished();
+        }
+      }),
+      updatePhaseText: vi.fn(),
+      updateThinkingText: vi.fn(),
+      showTransientPhase: vi.fn(),
+    };
+    const dispose = bindActivityFeedbackToAIEventBus(orchestrator as never);
+    const payload = {
+      sessionId: 'ordered',
+      source: 'zhin-agent',
+      platform: 'sandbox',
+      endpointKey: 'bot',
+      hookContext: { activityFeedbackEligible: true },
+    } as never;
+
+    activityFeedbackAiBus.emit('ai.processing.start', payload);
+    activityFeedbackAiBus.emit('ai.processing.finish', payload);
+    await done;
+
+    expect(order).toEqual(['start', 'finish']);
+    dispose();
   });
 });

--- a/plugins/services/activity-feedback/tests/executor.test.ts
+++ b/plugins/services/activity-feedback/tests/executor.test.ts
@@ -246,4 +246,51 @@ describe('createOutboundEndpointAccess', () => {
 
     expect(removeReaction).toHaveBeenCalledOnce();
   });
+
+  it('adds queued reaction for each new inbound message in the same busy group session', async () => {
+    const addReaction = vi.fn(async (input: { message: { id: string } }) => input.message.id);
+    const removeReaction = vi.fn().mockResolvedValue(undefined);
+    const access = createOutboundEndpointAccess({
+      capabilities: vi.fn(() => ({ operations: ['reaction'] })),
+      send: vi.fn(),
+      addReaction,
+      removeReaction,
+    });
+    const executor = new ActivityFeedbackExecutor(access);
+    const base = createCtx();
+    const first = {
+      ...base,
+      sceneType: 'group' as const,
+      groupId: 'group-1',
+      messageId: 'inbound-1',
+      options: {
+        ...base.options,
+        sceneType: 'group' as const,
+        groupId: 'group-1',
+        messageId: 'inbound-1',
+      },
+    };
+    const second = {
+      ...first,
+      messageId: 'inbound-2',
+      options: { ...first.options, messageId: 'inbound-2' },
+    };
+    const config = { type: 'reaction' as const, emoji: '⏳', autoRemove: true };
+
+    await executor.start(first, 'queued', config);
+    await executor.start(second, 'queued', config);
+
+    expect(addReaction).toHaveBeenCalledTimes(2);
+    expect(addReaction.mock.calls.map(([input]) => input.message.id)).toEqual([
+      'inbound-1',
+      'inbound-2',
+    ]);
+
+    await executor.stop(first, 'queued');
+    expect(removeReaction).toHaveBeenCalledOnce();
+    expect(removeReaction.mock.calls[0]![0].message.id).toBe('inbound-1');
+    await executor.stop(second, 'queued');
+    expect(removeReaction).toHaveBeenCalledTimes(2);
+    expect(removeReaction.mock.calls[1]![0].message.id).toBe('inbound-2');
+  });
 });

--- a/plugins/services/activity-feedback/tests/executor.test.ts
+++ b/plugins/services/activity-feedback/tests/executor.test.ts
@@ -27,6 +27,7 @@ function createCtx(): ActivityFeedbackEventContext {
 const phaseConfig: ResolvedActivityFeedbackPhaseConfig = {
   type: 'message',
   message: '处理中…',
+  autoRemove: true,
 };
 
 describe('createOutboundEndpointAccess', () => {
@@ -40,10 +41,14 @@ describe('createOutboundEndpointAccess', () => {
 
   it('start→stop 生命周期：指示器会停止，且不抛 TypeError', async () => {
     const sent: OutboundSendInput[] = [];
+    const recall = vi.fn().mockResolvedValue(undefined);
     const outbound: OutboundHost = {
+      capabilities: vi.fn(() => ({ operations: ['recall'] })),
       send: vi.fn(async (input: OutboundSendInput) => {
         sent.push(input);
+        return 'mid-1';
       }),
+      recall,
     };
     const access = createOutboundEndpointAccess(outbound, { debug: vi.fn() });
     const executor = new ActivityFeedbackExecutor(access);
@@ -71,15 +76,14 @@ describe('createOutboundEndpointAccess', () => {
 
     await executor.stop(ctx, 'active');
     expect(manager.getActiveIndicator('active', ctx.options)).toBeUndefined();
-
-    // OutboundHost 未提供 recall 时，control.recall 不存在
-    expect(endpoint.control?.recall).toBeUndefined();
+    expect(recall).toHaveBeenCalledOnce();
   });
 
   it('wires control.recall to OutboundHost.recall when available', async () => {
     const recalled: Array<{ adapter: string; endpointKey: string; message: unknown }> = [];
     const access = createOutboundEndpointAccess({
       send: vi.fn(async () => 'mid-1'),
+      capabilities: vi.fn(() => ({ operations: ['recall'] })),
       recall: vi.fn(async (input) => {
         recalled.push(input);
       }),
@@ -95,5 +99,73 @@ describe('createOutboundEndpointAccess', () => {
     };
     await endpoint.control?.recall?.(message);
     expect(recalled).toEqual([{ adapter: 'sandbox', endpointKey: 'bot1', message }]);
+  });
+
+  it('does not expose controls or temporary messages that the endpoint did not explicitly declare', async () => {
+    const access = createOutboundEndpointAccess({
+      send: vi.fn(),
+      recall: vi.fn(),
+      edit: vi.fn(),
+      addReaction: vi.fn(),
+      removeReaction: vi.fn(),
+      typing: vi.fn(),
+    });
+
+    const control = access.resolve('sandbox', 'bot1')!.endpoint.control;
+    expect(control?.recall).toBeUndefined();
+    expect(control?.edit).toBeUndefined();
+    expect(control?.addReaction).toBeUndefined();
+    expect(control?.removeReaction).toBeUndefined();
+    expect(control?.typing).toBeUndefined();
+    await new ActivityFeedbackExecutor(access).start(createCtx(), 'active', phaseConfig);
+    const manager = access.resolve('sandbox', 'bot1')!.endpoint.$activityFeedback;
+    if (!manager || !isGenericActivityFeedbackManager(manager)) {
+      throw new Error('expected generic activity feedback manager');
+    }
+    expect(manager.getAdapter('sandbox')?.supportedTypes).toEqual(['none']);
+  });
+
+  it('uses declared native typing and stops it for the same conversation', async () => {
+    const typing = vi.fn().mockResolvedValue(undefined);
+    const access = createOutboundEndpointAccess({
+      send: vi.fn(),
+      capabilities: vi.fn(() => ({ operations: ['typing'] })),
+      typing,
+    });
+    const executor = new ActivityFeedbackExecutor(access);
+    const ctx = { ...createCtx(), platform: 'telegram', options: { ...createCtx().options, platform: 'telegram' } };
+
+    await executor.start(ctx, 'active', { type: 'typing' });
+    await executor.stop(ctx, 'active');
+
+    expect(typing).toHaveBeenNthCalledWith(1, expect.objectContaining({
+      adapter: 'telegram',
+      endpointKey: 'bot1',
+      conversation: expect.objectContaining({ kind: 'private', id: 'u1' }),
+      active: true,
+    }));
+    expect(typing).toHaveBeenNthCalledWith(2, expect.objectContaining({ active: false }));
+  });
+
+  it('updates an active status message through declared edit capability', async () => {
+    const edit = vi.fn().mockResolvedValue('mid-1');
+    const access = createOutboundEndpointAccess({
+      send: vi.fn(async () => 'mid-1'),
+      capabilities: vi.fn(() => ({ operations: ['edit', 'recall'] })),
+      edit,
+      recall: vi.fn(),
+    });
+    const executor = new ActivityFeedbackExecutor(access);
+    const ctx = createCtx();
+
+    await executor.start(ctx, 'active', phaseConfig);
+    await executor.updateText(ctx, 'active', '处理中 [2/15]…');
+
+    expect(edit).toHaveBeenCalledWith(expect.objectContaining({
+      adapter: 'sandbox',
+      endpointKey: 'bot1',
+      message: expect.objectContaining({ id: 'mid-1' }),
+      content: '处理中 [2/15]…',
+    }));
   });
 });

--- a/plugins/services/activity-feedback/tests/executor.test.ts
+++ b/plugins/services/activity-feedback/tests/executor.test.ts
@@ -168,4 +168,82 @@ describe('createOutboundEndpointAccess', () => {
       content: '处理中 [2/15]…',
     }));
   });
+
+  it('does not invent a message id or recall when send returns null', async () => {
+    const recall = vi.fn().mockResolvedValue(undefined);
+    const access = createOutboundEndpointAccess({
+      capabilities: vi.fn(() => ({ operations: ['recall'] })),
+      send: vi.fn().mockResolvedValue(null),
+      recall,
+    });
+    const executor = new ActivityFeedbackExecutor(access);
+    const ctx = createCtx();
+
+    await executor.start(ctx, 'active', phaseConfig);
+    await executor.stop(ctx, 'active');
+
+    expect(recall).not.toHaveBeenCalled();
+  });
+
+  it('awaits reaction removal before reporting cleanup complete', async () => {
+    let release!: () => void;
+    const pending = new Promise<void>((resolve) => { release = resolve; });
+    const removeReaction = vi.fn(() => pending);
+    const access = createOutboundEndpointAccess({
+      capabilities: vi.fn(() => ({ operations: ['reaction'] })),
+      send: vi.fn(),
+      removeReaction,
+    });
+    const endpoint = access.resolve('sandbox', 'bot1')!.endpoint;
+    const message = {
+      conversation: {
+        endpoint: { id: 'bot1', adapter: 'sandbox' },
+        kind: 'private' as const,
+        id: 'u1',
+      },
+      id: 'mid-1',
+    };
+    let settled = false;
+
+    const cleanup = endpoint.control!.removeReaction!(message, 'rid-1').then(() => {
+      settled = true;
+    });
+    await Promise.resolve();
+    expect(settled).toBe(false);
+    release();
+    await cleanup;
+
+    expect(removeReaction).toHaveBeenCalledOnce();
+  });
+
+  it('awaits reaction cleanup through executor and activity manager', async () => {
+    let release!: () => void;
+    const pending = new Promise<void>((resolve) => { release = resolve; });
+    const removeReaction = vi.fn(() => pending);
+    const access = createOutboundEndpointAccess({
+      capabilities: vi.fn(() => ({ operations: ['reaction'] })),
+      send: vi.fn(),
+      addReaction: vi.fn().mockResolvedValue('rid-1'),
+      removeReaction,
+    });
+    const executor = new ActivityFeedbackExecutor(access);
+    const base = createCtx();
+    const ctx = {
+      ...base,
+      messageId: 'source-mid',
+      options: { ...base.options, messageId: 'source-mid' },
+    };
+    await executor.start(ctx, 'active', {
+      type: 'reaction', emoji: '⏳', autoRemove: true,
+    });
+    let settled = false;
+
+    const stopping = executor.stop(ctx, 'active').then(() => { settled = true; });
+    await Promise.resolve();
+    expect(settled).toBe(false);
+    release();
+    await stopping;
+
+    expect(removeReaction).toHaveBeenCalledOnce();
+  });
 });

--- a/plugins/services/activity-feedback/tests/index.test.ts
+++ b/plugins/services/activity-feedback/tests/index.test.ts
@@ -191,4 +191,45 @@ describe('ActivityFeedbackOrchestrator', () => {
       'thinking',
     );
   });
+
+  it('tracks delimiter-containing endpoint tuples without phase-key collisions', async () => {
+    const executor = {
+      start: vi.fn(),
+      stop: vi.fn(),
+      updateText: vi.fn(),
+      updateThinkingText: vi.fn(),
+    } satisfies ActivityFeedbackExecutor;
+    const orchestrator = new ActivityFeedbackOrchestrator(
+      new ActivityFeedbackPolicy(loadActivityFeedbackServiceConfig({})),
+      executor,
+      { debug: vi.fn(), error: vi.fn() },
+    );
+    const base = {
+      source: 'zhin-agent',
+      sceneId: 'u1',
+      userId: 'u1',
+      scope: 'private',
+      hookContext: { activityFeedbackEligible: true },
+    } as const;
+    const first = {
+      ...base,
+      platform: 'a:b', endpointKey: 'c', sessionId: 'd',
+    } as AIEventPayload;
+    const second = {
+      ...base,
+      platform: 'a', endpointKey: 'b', sessionId: 'c:d',
+    } as AIEventPayload;
+
+    await orchestrator.startPhase(first, 'active', 'test');
+    await orchestrator.startPhase(second, 'active', 'test');
+    await orchestrator.stopPhase(first, 'active', 'test');
+    executor.stop.mockClear();
+    await orchestrator.dispose();
+
+    expect(executor.stop).toHaveBeenCalledOnce();
+    expect(executor.stop).toHaveBeenCalledWith(
+      expect.objectContaining({ platform: 'a', endpointKey: 'b', sessionId: 'c:d' }),
+      'active',
+    );
+  });
 });

--- a/plugins/services/activity-feedback/tests/index.test.ts
+++ b/plugins/services/activity-feedback/tests/index.test.ts
@@ -38,6 +38,25 @@ describe('activityFeedback config', () => {
     const service = loadActivityFeedbackServiceConfig({ enabled: false });
     expect(resolveActivityFeedbackForTarget(service, 'icqq', 'x')?.enabled).toBe(false);
   });
+
+  it('schedule finish/error 配置覆盖常规平台默认值', () => {
+    const policy = new ActivityFeedbackPolicy(loadActivityFeedbackServiceConfig({
+      schedule: {
+        phases: {
+          finish: {
+            private: { type: 'message', message: '计划完成', removeDelay: 1200 },
+          },
+        },
+      },
+    }));
+
+    expect(policy.resolvePhase('discord', 'bot', 'schedule_finish', 'private')).toEqual({
+      kind: 'active',
+      config: expect.objectContaining({
+        type: 'message', message: '计划完成', removeDelay: 1200,
+      }),
+    });
+  });
 });
 
 describe('ActivityFeedbackOrchestrator', () => {
@@ -45,6 +64,7 @@ describe('ActivityFeedbackOrchestrator', () => {
     const executor = {
       start: vi.fn(),
       stop: vi.fn(),
+      updateText: vi.fn(),
       updateThinkingText: vi.fn(),
     } satisfies ActivityFeedbackExecutor;
 
@@ -84,6 +104,7 @@ describe('ActivityFeedbackOrchestrator', () => {
     const executor = {
       start: vi.fn(),
       stop: vi.fn(),
+      updateText: vi.fn(),
       updateThinkingText: vi.fn(),
     } satisfies ActivityFeedbackExecutor;
 
@@ -132,6 +153,42 @@ describe('ActivityFeedbackOrchestrator', () => {
       expect.anything(),
       'active',
       expect.objectContaining({ message: '[researcher] 正在处理中...' }),
+    );
+  });
+
+  it('dispose 清理所有仍活跃的主/子 Agent phase', async () => {
+    const executor = {
+      start: vi.fn(),
+      stop: vi.fn(),
+      updateText: vi.fn(),
+      updateThinkingText: vi.fn(),
+    } satisfies ActivityFeedbackExecutor;
+    const orchestrator = new ActivityFeedbackOrchestrator(
+      new ActivityFeedbackPolicy(loadActivityFeedbackServiceConfig({})),
+      executor,
+      { debug: vi.fn(), error: vi.fn() },
+    );
+    const base = {
+      platform: 'discord',
+      endpointKey: 'bot',
+      sessionId: 'discord:bot:private:u1',
+      sceneId: 'u1',
+      userId: 'u1',
+      scope: 'private',
+      hookContext: { activityFeedbackEligible: true },
+    } as AIEventPayload;
+    await orchestrator.startPhase(base, 'active', 'test');
+    await orchestrator.startPhase({
+      ...base, source: 'subagent', agentId: 'researcher', taskId: 'task-1',
+    }, 'thinking', 'test');
+
+    await orchestrator.dispose();
+
+    expect(executor.stop).toHaveBeenCalledTimes(2);
+    expect(executor.stop).toHaveBeenCalledWith(expect.anything(), 'active');
+    expect(executor.stop).toHaveBeenCalledWith(
+      expect.objectContaining({ sessionId: expect.stringContaining('::agent:researcher:') }),
+      'thinking',
     );
   });
 });

--- a/plugins/services/activity-feedback/tests/index.test.ts
+++ b/plugins/services/activity-feedback/tests/index.test.ts
@@ -192,6 +192,36 @@ describe('ActivityFeedbackOrchestrator', () => {
     );
   });
 
+  it('dispose 清理同一会话中每条尚未处理消息的 phase', async () => {
+    const executor = {
+      start: vi.fn(),
+      stop: vi.fn(),
+      updateText: vi.fn(),
+      updateThinkingText: vi.fn(),
+    } satisfies ActivityFeedbackExecutor;
+    const orchestrator = new ActivityFeedbackOrchestrator(
+      new ActivityFeedbackPolicy(loadActivityFeedbackServiceConfig({})),
+      executor,
+      { debug: vi.fn(), error: vi.fn() },
+    );
+    const base = {
+      platform: 'discord',
+      endpointKey: 'bot',
+      sessionId: 'discord:bot:group:g1',
+      sceneId: 'g1',
+      userId: 'u1',
+      scope: 'group',
+      hookContext: { activityFeedbackEligible: true },
+    } as AIEventPayload;
+
+    await orchestrator.startPhase({ ...base, messageId: 'm1' }, 'queued', 'test');
+    await orchestrator.startPhase({ ...base, messageId: 'm2' }, 'queued', 'test');
+    await orchestrator.dispose();
+
+    expect(executor.stop).toHaveBeenCalledTimes(2);
+    expect(executor.stop.mock.calls.map(([ctx]) => ctx.messageId)).toEqual(['m1', 'm2']);
+  });
+
   it('tracks delimiter-containing endpoint tuples without phase-key collisions', async () => {
     const executor = {
       start: vi.fn(),
@@ -231,5 +261,45 @@ describe('ActivityFeedbackOrchestrator', () => {
       expect.objectContaining({ platform: 'a', endpointKey: 'b', sessionId: 'c:d' }),
       'active',
     );
+  });
+
+  it('dispose waits for transient cleanup already started by its timer', async () => {
+    vi.useFakeTimers();
+    let releaseStop!: () => void;
+    const stopPending = new Promise<void>((resolve) => { releaseStop = resolve; });
+    const executor = {
+      start: vi.fn().mockResolvedValue(undefined),
+      stop: vi.fn(() => stopPending),
+      updateText: vi.fn(),
+      updateThinkingText: vi.fn(),
+    } satisfies ActivityFeedbackExecutor;
+    const orchestrator = new ActivityFeedbackOrchestrator(
+      new ActivityFeedbackPolicy(loadActivityFeedbackServiceConfig({
+        schedule: {
+          phases: {
+            finish: { group: { type: 'reaction', removeDelay: 10 } },
+          },
+        },
+      })),
+      executor,
+      { debug: vi.fn(), error: vi.fn() },
+    );
+    const payload = {
+      platform: 'icqq', endpointKey: 'bot', sessionId: 'schedule:cleanup',
+      sceneId: 'group:1', groupId: '1', scope: 'group',
+      hookContext: { scheduleActivityFeedback: true, scheduleJobId: 'cleanup' },
+    } as AIEventPayload;
+
+    await orchestrator.showTransientPhase(payload, 'schedule_finish', 'test');
+    await vi.advanceTimersByTimeAsync(10);
+    let disposed = false;
+    const disposal = orchestrator.dispose().then(() => { disposed = true; });
+    await Promise.resolve();
+    expect(disposed).toBe(false);
+
+    releaseStop();
+    await disposal;
+    expect(disposed).toBe(true);
+    vi.useRealTimers();
   });
 });

--- a/plugins/services/activity-feedback/tests/live-chain-probe.test.ts
+++ b/plugins/services/activity-feedback/tests/live-chain-probe.test.ts
@@ -9,14 +9,15 @@ import type { OutboundHost, OutboundSendInput } from 'zhin.js';
 const logger = { debug: vi.fn(), error: vi.fn() };
 
 describe('live chain probe', () => {
-  it('processing.start → typing 文本经 OutboundHost 发出（默认配置）', async () => {
+  it('processing.start → 可撤回状态文本经 OutboundHost 发出', async () => {
     const sent: OutboundSendInput[] = [];
     const outbound: OutboundHost = {
+      capabilities: vi.fn(() => ({ operations: ['recall'] })),
       send: vi.fn(async (input: OutboundSendInput) => {
         sent.push(input);
         return 'mid-1';
       }),
-      addReaction: vi.fn(async () => 'rid-1'),
+      recall: vi.fn(),
     };
     const access = createOutboundEndpointAccess(outbound, logger);
     const orchestrator = createActivityFeedbackOrchestratorForRuntime({}, logger, access);
@@ -41,5 +42,6 @@ describe('live chain probe', () => {
       endpointKey: '8596238',
       conversation: { kind: 'group', id: '1001' },
     });
+    await orchestrator.dispose();
   });
 });


### PR DESCRIPTION
## Summary
- unify exact Endpoint control capability projection across adapters and fix platform recall/reaction behavior
- connect Agent, subagent, tool iteration, task and schedule lifecycle state to IM feedback
- make error, abort, HMR retirement, reconnect, and reaction/message cleanup generation-safe and awaitable
- fix same-account ICQQ HMR retirement/reconnect races, Email late-disconnect reconnect duplication, and Sandbox WS path ownership
- key reaction feedback per inbound message so messages arriving during a pending turn each receive and later clear their own reaction
- harden indicator, subagent, schedule and endpoint admission/disposal against pre-registration, self-wait and concurrent-dispose races

## Compatibility
- `@zhin.js/agent`: major changeset because deprecated `drainTaskExecutorLocks()` now rejects with migration guidance; generation-owned executors must be retained and `await executor.dispose()`

## Validation
- `pnpm check:all` — all 40 harness checks passed, including unit tests, lint, type-check, architecture, install size, Stable smoke and L4-CI
- ICQQ: 137 tests plus package build
- cross-adapter lifecycle matrix: 11 adapter packages / 504 tests
- independent Standards and Spec reviews passed with no actionable findings

## Sourcery 总结

统一 Endpoint 能力处理，并在 Agent 和 Schedule 生命周期中提供具备生成安全性、有序性且完全可等待的 IM 活动反馈。

新功能：
- 通过出站主机透传精确的 Endpoint 控制能力，并支持可编辑状态消息和原生输入反馈。
- 为 Agent 思考、工具执行、迭代、子 Agent、排队中的轮次以及 Schedule 生命周期状态提供有序的 IM 活动反馈。

错误修复：
- 防止不受支持的平台操作、虚构的消息标识符、过期生成的传递以及 HMR 传输所有权导致泄漏或错误清理。
- 修复 Satori 撤回路由，以及过期的 email、ICQQ 和 sandbox 传输生命周期行为。

增强功能：
- 使活动事件、出站操作、生命周期释放和终端清理具备生成感知能力，在必要时进行序列化，并完全支持等待。
- 将 Schedule 锁定移至由执行器负责的生命周期状态，并针对已弃用的全局锁耗尽操作显式失败。

文档：
- 记录 Activity Feedback 的安装与配置、Endpoint 能力要求以及生成安全性保证。
- 新增 ADR 0034，说明与传输无关的活动生命周期如何投射到 IM 中。

测试：
- 扩展对能力投射、基于快照的操作、有序异步活动事件、生成退休、生命周期清理、原生输入、可编辑消息、Schedule 状态以及 HMR 所有权的测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify Endpoint capability handling and deliver generation-safe, ordered, and fully awaitable IM activity feedback across Agent and Schedule lifecycles.

New Features:
- Project exact Endpoint control capabilities through the outbound host and add support for editable status messages and native typing feedback.
- Expose ordered IM activity feedback for Agent thinking, tool execution, iterations, subagents, queued turns, and Schedule lifecycle states.

Bug Fixes:
- Prevent unsupported platform operations, fabricated message identifiers, stale generation deliveries, and HMR transport ownership from causing leaks or incorrect cleanup.
- Fix Satori recall routing and stale email, ICQQ, and sandbox transport lifecycle behavior.

Enhancements:
- Make activity events, outbound operations, lifecycle disposal, and terminal cleanup generation-aware, serialized where required, and fully awaitable.
- Move schedule locking to executor-owned lifecycle state and fail explicitly for deprecated global lock draining.

Documentation:
- Document Activity Feedback installation, configuration, Endpoint capability requirements, and generation-safety guarantees.
- Add ADR 0034 describing transport-independent activity lifecycle projection into IM.

Tests:
- Expand coverage for capability projection, snapshot-bound operations, ordered asynchronous activity events, generation retirement, lifecycle cleanup, native typing, editable messages, Schedule states, and HMR ownership.

</details>