### PR TITLE
chore: keep activity feedback changesets patch-only

### DIFF
--- a/.changeset/calm-agent-lifecycle-boundaries.md
+++ b/.changeset/calm-agent-lifecycle-boundaries.md
@@ -1,5 +1,5 @@
 ---
-"@zhin.js/agent": major
+"@zhin.js/agent": patch
 ---
 
 Close lifecycle races across IM activity indicators, subagent cancellation and schedule feedback: retry inactive starts, serialize native typing keepalives with cleanup, await generation disposal without task-observer self-deadlocks, propagate subagent abort signals without delivering retired-generation results, preserve spawn/start/finish ordering, and make same-scene schedule locks executor-owned and lifecycle-drained. The deprecated global schedule-lock drain remains exported for compatibility but now fails explicitly with migration guidance instead of falsely reporting that generation-owned executors were drained.

--- a/.changeset/smooth-activity-feedback.md
+++ b/.changeset/smooth-activity-feedback.md
@@ -1,6 +1,6 @@
 ---
-"@zhin.js/plugin-runtime": minor
-"@zhin.js/core": minor
+"@zhin.js/plugin-runtime": patch
+"@zhin.js/core": patch
 "@zhin.js/agent": patch
 "@zhin.js/cli": patch
 "@zhin.js/service-activity-feedback": patch


### PR DESCRIPTION
Set every changeset introduced by the activity-feedback/lifecycle work to `patch`.

Validation: `pnpm changeset status` reports no minor or major bumps.

## Sourcery 摘要

增强功能：
- 将与 activity-feedback 和 lifecycle 工作相关的所有变更集设置为补丁级别发布。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Set all changesets associated with the activity-feedback and lifecycle work to patch-level releases.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps activity-feedback/lifecycle changesets patch-only to avoid unintended minor or major releases. Was: `@zhin.js/agent` marked major, `@zhin.js/core` and `@zhin.js/plugin-runtime` minor; now: all are patch with no runtime behavior change.

<sup>Written for commit 9f5efab606337cfd8db029b4db80e41815cebd1c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zhinjs/zhin/pull/629?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

