### PR TITLE
ci: serialize harness checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,7 @@ jobs:
         run: pnpm check:all
         env:
           HARNESS_SKIP_TEST: '1'
+          HARNESS_SEQUENTIAL: '1'
 
       - name: run tests with coverage
         if: matrix.os == 'ubuntu-latest' && matrix.node-version == 24

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,13 @@ jobs:
       # STATUS_DLL_INIT_FAILED when Turbo fans out multiple nested tsc/tsup processes.
       - name: build packages (Windows)
         if: runner.os == 'Windows'
-        run: pnpm build --concurrency=1
+        run: |
+          pnpm build --concurrency=1
+          if ($LASTEXITCODE -eq -1073741502 -or $LASTEXITCODE -eq 3221225794) {
+            Write-Warning 'Windows child process initialization failed; retrying incremental build once.'
+            pnpm build --concurrency=1
+          }
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
       - name: build packages
         if: runner.os != 'Windows'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -62,6 +62,8 @@ jobs:
       # type-check / lint / unit tests 已纳入 pnpm check:all
       - name: run harness checks (incl. type-check, lint, test)
         run: pnpm check:all
+        env:
+          HARNESS_SEQUENTIAL: '1'
 
       # npm 要求包名已存在后才能走可信发布 / changesets；新包需维护者手动首次发包。
       - name: detect packages needing first publish

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -15,6 +15,7 @@ export default tseslint.config(
       '**/*.cjs',
       '**/*.d.ts',
       '.github/skills/**',
+      '.tmp/**',
       'vendor/**',
     ],
   },

--- a/scripts/check-all-harness.mjs
+++ b/scripts/check-all-harness.mjs
@@ -287,11 +287,12 @@ async function runCheck(check) {
       .map((value) => value.trim())
       .filter(Boolean)
       .join('\n');
-    const details = output || [
+    const details = [
+      output,
       error.message,
       `exit code: ${String(error.code ?? 'unknown')}`,
       `signal: ${String(error.signal ?? 'none')}`,
-    ].join('\n');
+    ].filter(Boolean).join('\n');
     console.log(`  ✗ ${check.name} FAILED (${elapsed}s)`);
     return { name: check.name, status: 'FAILED', elapsed, error: details };
   }

--- a/scripts/check-all-harness.mjs
+++ b/scripts/check-all-harness.mjs
@@ -38,6 +38,7 @@ const checks = [
     name: 'Lint',
     command: 'pnpm lint:ci',
     description: 'ESLint（.ts/.tsx）',
+    retries: 1,
   },
   {
     name: 'Type Check',
@@ -256,23 +257,46 @@ const checks = [
   },
 ].filter((c) => !(skipUnitTests && c.name === 'Unit Tests'));
 
-function runCheck(check) {
-  const start = performance.now();
+function executeCheck(check) {
   return new Promise((resolve) => {
     exec(check.command, {
       cwd: repoRoot,
       maxBuffer: 32 * 1024 * 1024,
-    }, (error, _stdout, stderr) => {
-      const elapsed = ((performance.now() - start) / 1000).toFixed(1);
-      if (error) {
-        console.log(`  ✗ ${check.name} FAILED (${elapsed}s)`);
-        resolve({ name: check.name, status: 'FAILED', elapsed, error: stderr || error.message });
-      } else {
-        console.log(`  ✓ ${check.name} (${elapsed}s)`);
-        resolve({ name: check.name, status: 'PASSED', elapsed });
-      }
-    });
+    }, (error, stdout, stderr) => resolve({ error, stdout, stderr }));
   });
+}
+
+async function runCheck(check) {
+  const start = performance.now();
+  const attempts = 1 + (check.retries ?? 0);
+
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    const { error, stdout, stderr } = await executeCheck(check);
+    const elapsed = ((performance.now() - start) / 1000).toFixed(1);
+    if (!error) {
+      console.log(`  ✓ ${check.name} (${elapsed}s)`);
+      return { name: check.name, status: 'PASSED', elapsed };
+    }
+
+    if (attempt < attempts) {
+      console.log(`  ↻ ${check.name} failed; retrying once`);
+      continue;
+    }
+
+    const output = [stdout, stderr]
+      .map((value) => value.trim())
+      .filter(Boolean)
+      .join('\n');
+    const details = output || [
+      error.message,
+      `exit code: ${String(error.code ?? 'unknown')}`,
+      `signal: ${String(error.signal ?? 'none')}`,
+    ].join('\n');
+    console.log(`  ✗ ${check.name} FAILED (${elapsed}s)`);
+    return { name: check.name, status: 'FAILED', elapsed, error: details };
+  }
+
+  throw new Error(`unreachable check state: ${check.name}`);
 }
 
 async function runPool(items, limit) {


### PR DESCRIPTION
## Summary

- run CI harness checks sequentially on the Ubuntu 24 gate
- run release harness checks sequentially before publishing
- avoid intermittent resource-related lint child-process exits

## Evidence

- the failed Linux job contained no ESLint diagnostics
- local sequential CI-equivalent harness passed 45/45 checks
- the full harness passed 46/46 checks before this workflow-only change

## Sourcery 摘要

在 CI 和发布工作流中串行执行 harness 检查，以提高可靠性。

Bug 修复：
- 串行执行 CI 和发布 harness 检查，以减少因资源相关问题导致的 lint 进程间歇性失败。

CI：
- 为 Ubuntu 24 CI gate 以及软件包发布前的检查配置顺序执行 harness。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 生成的摘要

通过串行执行 harness 检查，并对暂时性的构建和 lint 失败进行重试，提高 CI 和发布的可靠性。

错误修复：
- 对 lint 检查重试一次，并在 CI 构建期间对暂时性的 Windows 子进程初始化失败进行重试，以减少间歇性工作流失败。

增强功能：
- 支持在 CI 和发布工作流中顺序执行 harness，并通过捕获输出和退出详情来改进 harness 失败报告。

CI：
- 配置 Ubuntu CI 和发布前的 harness 检查按顺序运行，以提高可靠性。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

通过串行执行 harness 检查并针对暂时性进程故障添加定向重试，提高 CI 和发布的可靠性。

Bug 修复：
- 通过按顺序运行 harness 检查，并重试暂时性的 lint 和 Windows 子进程初始化故障，减少 CI 和发布过程中的间歇性失败。

改进：
- 通过捕获命令输出、退出代码和信号，改进 harness 失败报告。

CI：
- 为 Ubuntu CI gate 和发布前检查配置串行 harness 执行。
- 对受影响的 Windows 软件包构建重试一次，同时保留最终失败状态。

杂项：
- 将临时文件排除在 ESLint 检查之外。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

通过串行执行 harness 检查，并针对临时性进程故障添加定向重试，提高 CI 和发布的可靠性。

错误修复：
- 通过串行执行 harness 检查，并重试临时性的 lint 和 Windows 子进程初始化故障，减少 CI 和发布过程中的间歇性失败。

改进：
- 保留命令输出和进程退出详细信息，改进 harness 失败诊断。
- 从 ESLint 检查中排除临时 `.tmp` 文件。

CI：
- 为 Ubuntu Node 24 CI 门禁和发布前工作流检查配置顺序执行 harness。
- 对受影响的 Windows 软件包构建重试一次，同时保留最终失败状态。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

通过串行执行 harness 检查并针对特定的临时性故障添加重试机制，提高 CI 和发布验证的可靠性。

错误修复：
- 通过串行执行 harness 检查，并对临时性的 lint 和 Windows 子进程初始化失败进行重试，减少 CI 和发布过程中的间歇性失败。

改进：
- 通过捕获命令输出和进程退出详情，改进 harness 失败诊断。
- 从 ESLint 检查中排除临时的 `.tmp` 文件。

CI：
- 为 Ubuntu Node 24 CI 门禁和发布前工作流配置顺序执行 harness。
- 对受影响的 Windows 软件包构建重试一次，同时保留最终的失败状态。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make CI and release validation more reliable by serializing harness checks and adding targeted transient-failure retries.

Bug Fixes:
- Reduce intermittent CI and release failures by serializing harness checks and retrying transient lint and Windows child-process initialization failures.

Enhancements:
- Improve harness failure diagnostics with captured command output and process exit details.
- Exclude temporary `.tmp` files from ESLint checks.

CI:
- Configure sequential harness execution for the Ubuntu Node 24 CI gate and pre-publish workflow.
- Retry affected Windows package builds once while preserving the final failure status.

</details>

</details>

</details>

</details>

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Serialize CI and release harness checks and add targeted retries to reduce flaky failures. Previously checks ran in parallel with no retries; now the Ubuntu Node 24 gate and pre-publish run sequentially, Lint retries once, Windows builds retry once on STATUS_DLL_INIT_FAILED, and ESLint ignores `.tmp/**`. Expect slightly longer runs with fewer flakes.

- Set HARNESS_SEQUENTIAL='1' for `pnpm check:all` in CI and publish workflows; local runs remain parallel unless you set HARNESS_SEQUENTIAL.
- Enhance `scripts/check-all-harness.mjs` with per-check retries and captured stdout/stderr, exit code, and signal; configure Lint with 1 retry.
- Harden Windows build: run `pnpm build --concurrency=1`, retry once on child-process init failure (STATUS_DLL_INIT_FAILED), and propagate the final exit code.
- Update `eslint.config.mjs` to ignore `.tmp/**` to exclude temporary console checkouts from lint.

<sup>Written for commit f99ff74bd007f50ab265dedc34a673ca0f4f5dbc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zhinjs/zhin/pull/632?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

