### PR TITLE
ci: serialize monorepo release creation

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -71,13 +71,26 @@ jobs:
         run: pnpm check:unpublished
 
       - name: bump versions and publish
+        id: changesets
         uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
         with:
           version: pnpm bump
           commit: "chore: update versions"
           title: "chore: update versions"
           publish: pnpm pub
+          # changesets/action pushes every package tag concurrently when this is
+          # enabled. Large monorepo releases can make GitHub reject some refs with
+          # `fatal error in commit_refs`; the next step batches tags and creates
+          # releases sequentially instead.
+          createGithubReleases: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.PERSONAL_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.PERSONAL_TOKEN }}
+
+      - name: push tags and create GitHub releases
+        if: steps.changesets.outputs.published == 'true'
+        run: node scripts/create-github-releases.mjs
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PUBLISHED_PACKAGES: ${{ steps.changesets.outputs.publishedPackages }}

--- a/scripts/create-github-releases.mjs
+++ b/scripts/create-github-releases.mjs
@@ -1,0 +1,155 @@
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+const dryRun = process.argv.includes('--dry-run');
+const repository = process.env.GITHUB_REPOSITORY || 'zhinjs/zhin';
+const token = process.env.GITHUB_TOKEN;
+
+function fail(message) {
+  throw new Error(`[github-releases] ${message}`);
+}
+
+function parsePublishedPackages(value) {
+  let parsed;
+  try {
+    parsed = JSON.parse(value || '[]');
+  } catch (error) {
+    fail(`PUBLISHED_PACKAGES is not valid JSON: ${error.message}`);
+  }
+  if (!Array.isArray(parsed)) fail('PUBLISHED_PACKAGES must be a JSON array');
+  return parsed.map((item) => {
+    if (!item || typeof item.name !== 'string' || typeof item.version !== 'string') {
+      fail('Each published package must contain string name and version fields');
+    }
+    return { name: item.name, version: item.version };
+  });
+}
+
+function getWorkspacePackages() {
+  const output = execFileSync('pnpm', ['-r', 'list', '--depth', '-1', '--json'], {
+    encoding: 'utf8',
+    maxBuffer: 16 * 1024 * 1024,
+  });
+  return new Map(JSON.parse(output).map((pkg) => [pkg.name, pkg]));
+}
+
+function changelogEntry(pkgPath, version) {
+  const changelogPath = path.join(pkgPath, 'CHANGELOG.md');
+  const changelog = readFileSync(changelogPath, 'utf8');
+  const escapedVersion = version.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const match = new RegExp(`^## ${escapedVersion}\\s*$`, 'm').exec(changelog);
+  if (!match) fail(`No CHANGELOG entry found for ${pkgPath}@${version}`);
+  const remainder = changelog.slice(match.index + match[0].length);
+  const nextHeading = remainder.search(/^## /m);
+  return remainder.slice(0, nextHeading === -1 ? undefined : nextHeading).trim();
+}
+
+async function github(pathname, options = {}) {
+  const response = await fetch(`https://api.github.com${pathname}`, {
+    ...options,
+    headers: {
+      Accept: 'application/vnd.github+json',
+      Authorization: `Bearer ${token}`,
+      'X-GitHub-Api-Version': '2022-11-28',
+      'User-Agent': 'zhin-release-workflow',
+      ...options.headers,
+    },
+  });
+  return response;
+}
+
+async function createRelease({ tag, version, body }) {
+  const existing = await github(`/repos/${repository}/releases/tags/${encodeURIComponent(tag)}`);
+  if (existing.ok) {
+    console.log(`[github-releases] Release already exists: ${tag}`);
+    return;
+  }
+  if (existing.status !== 404) {
+    fail(`Failed to check ${tag}: HTTP ${existing.status} ${await existing.text()}`);
+  }
+
+  for (let attempt = 1; attempt <= 3; attempt += 1) {
+    const response = await github(`/repos/${repository}/releases`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        tag_name: tag,
+        name: tag,
+        body,
+        prerelease: version.includes('-'),
+      }),
+    });
+    if (response.ok) {
+      console.log(`[github-releases] Created Release: ${tag}`);
+      return;
+    }
+    const detail = await response.text();
+    if (attempt === 3 || ![409, 422, 500, 502, 503, 504].includes(response.status)) {
+      fail(`Failed to create ${tag}: HTTP ${response.status} ${detail}`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, attempt * 2000));
+  }
+}
+
+const published = parsePublishedPackages(process.env.PUBLISHED_PACKAGES);
+if (published.length === 0) {
+  console.log('[github-releases] No published packages to process.');
+  process.exit(0);
+}
+if (!dryRun && !token) fail('GITHUB_TOKEN is required');
+
+const workspace = getWorkspacePackages();
+const releases = published.map(({ name, version }) => {
+  const pkg = workspace.get(name);
+  if (!pkg) fail(`Published package is not in the workspace: ${name}`);
+  if (pkg.version !== version) {
+    fail(`Workspace version mismatch for ${name}: expected ${version}, found ${pkg.version}`);
+  }
+  return {
+    name,
+    version,
+    tag: `${name}@${version}`,
+    body: changelogEntry(pkg.path, version),
+  };
+});
+
+if (dryRun) {
+  for (const release of releases) {
+    console.log(`[github-releases] Would publish ${release.tag} (${release.body.length} changelog bytes)`);
+  }
+  process.exit(0);
+}
+
+// `changeset publish` normally creates all annotated tags locally. Recreate a
+// missing local tag to make recovery runs idempotent after a failed Action.
+for (const { tag } of releases) {
+  try {
+    execFileSync('git', ['rev-parse', '--verify', '--quiet', `refs/tags/${tag}`], { stdio: 'ignore' });
+  } catch {
+    execFileSync('git', ['tag', tag, '-m', tag], { stdio: 'inherit' });
+  }
+}
+
+// Push all release tags in one atomic Git transaction so GitHub never receives
+// dozens of concurrent ref updates. Retry only the whole transaction.
+for (let attempt = 1; attempt <= 3; attempt += 1) {
+  try {
+    execFileSync(
+      'git',
+      ['push', '--atomic', 'origin', ...releases.map(({ tag }) => `refs/tags/${tag}`)],
+      { stdio: 'inherit' },
+    );
+    break;
+  } catch (error) {
+    if (attempt === 3) throw error;
+    console.warn(`[github-releases] Tag push failed; retrying transaction (${attempt}/3)`);
+    await new Promise((resolve) => setTimeout(resolve, attempt * 2000));
+  }
+}
+
+// GitHub Release creation is deliberately serial to avoid the same ref-store
+// contention in the Releases API. The existence check makes reruns idempotent.
+for (const release of releases) {
+  await createRelease(release);
+}


### PR DESCRIPTION
## Summary
- disable changesets/action concurrent GitHub Release creation
- push all package tags in one atomic Git transaction with retries
- create GitHub Releases sequentially and idempotently from published package outputs

## Incident recovery
- confirmed all 8 affected versions were published to npm
- restored the 8 missing Git tags and GitHub Releases

## Validation
- `node --check scripts/create-github-releases.mjs`
- dry-run against all 8 affected packages
- live idempotency run: tags up to date, releases already exist
- `pnpm lint:ci`
- publish workflow YAML parse
- `git diff --check`

## Sourcery 摘要

将 monorepo 标签和 GitHub Release 的创建过程串行化，使软件包发布更加可靠且可恢复。

错误修复：
- 将并发创建 Release 替换为可重试的串行处理，防止在大型 monorepo 发布过程中遗漏 Git 标签和 GitHub Release。

增强功能：
- 添加幂等的 Release 恢复功能：验证已发布的软件包版本、恢复缺失的标签、原子性地推送所有标签，并根据变更日志按顺序创建 GitHub Release。

CI：
- 更新发布工作流，禁用并发的 Changesets Release 创建，并在发布后运行串行的标签和 Release 处理流程。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Serialize monorepo tag and GitHub Release creation to make package publishing reliable and recoverable.

Bug Fixes:
- Prevent missing Git tags and GitHub Releases during large monorepo publications by replacing concurrent release creation with serialized, retryable processing.

Enhancements:
- Add idempotent release recovery that validates published package versions, restores missing tags, pushes all tags atomically, and creates GitHub Releases sequentially from changelogs.

CI:
- Update the publish workflow to disable concurrent Changesets Release creation and run the serialized tag and release process after publishing.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Serializes monorepo release creation in CI to avoid GitHub ref-store contention that dropped tags/releases. Previously `changesets/action` pushed tags and created Releases concurrently; now we disable that, push all tags atomically, and create Releases sequentially and idempotently from published package outputs.

- Disables Releases in `changesets/action` (`createGithubReleases: false`) and adds `scripts/create-github-releases.mjs` to: validate `publishedPackages` against the workspace, read `CHANGELOG.md` for release bodies (fails if missing), recreate missing local tags, push all tags with `git push --atomic` (with retries), and create Releases one-by-one with existence checks and transient-error retries (marks prereleases when the version contains a hyphen).
- Rollout: No change to publishing inputs; ensure `GITHUB_TOKEN` and `PERSONAL_TOKEN` secrets remain set. Re-running the workflow is safe; existing tags and Releases are left intact.

<sup>Written for commit 4264858e78b280b607f1a118e5b49299668bbb3a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zhinjs/zhin/pull/634?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

