### PR TITLE
fix(runtime): absorb config patches and finish client migration

### DIFF
--- a/.changeset/fix-runtime-config-regressions.md
+++ b/.changeset/fix-runtime-config-regressions.md
@@ -1,6 +1,7 @@
 ---
 "@zhin.js/adapter-icqq": patch
 "@zhin.js/runtime": patch
+"@zhin.js/service-activity-feedback": patch
 ---
 
-Fix direct ICQQ password configuration and keep Plugin-local JSON Schema references and UI annotations valid during runtime config composition.
+Fix direct ICQQ password configuration, keep Plugin-local JSON Schema references and UI annotations valid during runtime config composition, and make activity feedback rollback safe before generation activation.

--- a/.changeset/fix-runtime-config-regressions.md
+++ b/.changeset/fix-runtime-config-regressions.md
@@ -1,0 +1,6 @@
+---
+"@zhin.js/adapter-icqq": patch
+"@zhin.js/runtime": patch
+---
+
+Fix direct ICQQ password configuration and keep Plugin-local JSON Schema references and UI annotations valid during runtime config composition.

--- a/examples/test-bot/commands/gh/bind.ts
+++ b/examples/test-bot/commands/gh/bind.ts
@@ -5,6 +5,7 @@ import {
   requireOauthModel,
   startDeviceFlowBind,
 } from '../../lib/github-oauth.js';
+import { resolveGithubEndpoint } from '../../lib/github-api.js';
 
 /**
  * Bind the chat user to a GitHub identity (PAT or Device Flow).
@@ -12,16 +13,19 @@ import {
  */
 export default defineCommand({
   description: '绑定 GitHub 账号（PAT 或 Device Flow）',
-  execute: async ({ args, input, use }) => {
-    const modelOrError = requireOauthModel(use);
+  execute: async (context) => {
+    const { args, input } = context;
+    const endpoint = resolveGithubEndpoint(context);
+    if (typeof endpoint === 'string') return endpoint;
+    const modelOrError = requireOauthModel(endpoint);
     if (typeof modelOrError === 'string') return modelOrError;
     const identity = platformIdentity(input);
     if (typeof identity === 'string') return identity;
 
     const token = args.join(' ').trim();
     if (token) {
-      return bindWithPat(modelOrError, identity.platform, identity.uid, token);
+      return bindWithPat(endpoint, modelOrError, identity.platform, identity.uid, token);
     }
-    return startDeviceFlowBind(modelOrError, identity.platform, identity.uid);
+    return startDeviceFlowBind(endpoint, modelOrError, identity.platform, identity.uid);
   },
 });

--- a/examples/test-bot/commands/gh/branches/[repo].ts
+++ b/examples/test-bot/commands/gh/branches/[repo].ts
@@ -4,8 +4,9 @@ import { ghApiMessage, resolveGhClient } from '../../../lib/github-api.js';
 export default defineCommand({
   description: '查看分支列表',
   params: { repo: { type: 'string' } },
-  execute: async ({ params, input }) => {
-    const api = await resolveGhClient(input);
+  execute: async (context) => {
+    const { params } = context;
+    const api = await resolveGhClient(context);
     if (typeof api === 'string') return api;
     const r = await api.listBranches(String(params.repo), 20);
     if (!r.ok) return ghApiMessage(r.data, '查询失败');

--- a/examples/test-bot/commands/gh/ci/[repo].ts
+++ b/examples/test-bot/commands/gh/ci/[repo].ts
@@ -4,8 +4,9 @@ import { ghApiMessage, resolveGhClient } from '../../../lib/github-api.js';
 export default defineCommand({
   description: '查看 CI / Actions 状态',
   params: { repo: { type: 'string' } },
-  execute: async ({ params, input }) => {
-    const api = await resolveGhClient(input);
+  execute: async (context) => {
+    const { params } = context;
+    const api = await resolveGhClient(context);
     if (typeof api === 'string') return api;
     const r = await api.listWorkflowRuns(String(params.repo), 10);
     if (!r.ok) return ghApiMessage(r.data, '查询失败');

--- a/examples/test-bot/commands/gh/close.ts
+++ b/examples/test-bot/commands/gh/close.ts
@@ -8,12 +8,13 @@ import {
 
 export default defineCommand({
   description: '关闭 Issue 或 PR',
-  execute: async ({ args, input }) => {
+  execute: async (context) => {
+    const { args } = context;
     const parsed = requireRepo(args, '用法: gh close <owner/repo> <编号>');
     if (typeof parsed === 'string') return parsed;
     const number = parsePositiveInt(parsed.rest[0], '编号');
     if (typeof number === 'string') return number;
-    const api = await resolveGhClient(input);
+    const api = await resolveGhClient(context);
     if (typeof api === 'string') return api;
     const ir = await api.closeIssue(parsed.repo, number);
     if (ir.ok) return `Issue #${number} 已关闭`;

--- a/examples/test-bot/commands/gh/comment.ts
+++ b/examples/test-bot/commands/gh/comment.ts
@@ -8,14 +8,15 @@ import {
 
 export default defineCommand({
   description: '评论 Issue 或 PR',
-  execute: async ({ args, input }) => {
+  execute: async (context) => {
+    const { args } = context;
     const parsed = requireRepo(args, '用法: gh comment <owner/repo> <编号> <内容>');
     if (typeof parsed === 'string') return parsed;
     const number = parsePositiveInt(parsed.rest[0], '编号');
     if (typeof number === 'string') return number;
     const body = parsed.rest.slice(1).join(' ').trim();
     if (!body) return '用法: gh comment <owner/repo> <编号> <内容>';
-    const api = await resolveGhClient(input);
+    const api = await resolveGhClient(context);
     if (typeof api === 'string') return api;
     const r = await api.createIssueComment(parsed.repo, number, body);
     return r.ok ? `已评论 #${number}` : ghApiMessage(r.data, '评论失败');

--- a/examples/test-bot/commands/gh/commits/[repo].ts
+++ b/examples/test-bot/commands/gh/commits/[repo].ts
@@ -4,8 +4,9 @@ import { ghApiMessage, resolveGhClient } from '../../../lib/github-api.js';
 export default defineCommand({
   description: '查看提交记录',
   params: { repo: { type: 'string' } },
-  execute: async ({ params, args, input }) => {
-    const api = await resolveGhClient(input);
+  execute: async (context) => {
+    const { params, args } = context;
+    const api = await resolveGhClient(context);
     if (typeof api === 'string') return api;
     const limitRaw = args[0];
     const limit = limitRaw ? Number(limitRaw) : 10;

--- a/examples/test-bot/commands/gh/issue.ts
+++ b/examples/test-bot/commands/gh/issue.ts
@@ -8,12 +8,13 @@ import {
 
 export default defineCommand({
   description: '查看 Issue 详情',
-  execute: async ({ args, input }) => {
+  execute: async (context) => {
+    const { args } = context;
     const parsed = requireRepo(args, '用法: gh issue <owner/repo> <编号>');
     if (typeof parsed === 'string') return parsed;
     const number = parsePositiveInt(parsed.rest[0], '编号');
     if (typeof number === 'string') return number;
-    const api = await resolveGhClient(input);
+    const api = await resolveGhClient(context);
     if (typeof api === 'string') return api;
     const r = await api.getIssue(parsed.repo, number);
     if (!r.ok) return ghApiMessage(r.data, 'Issue 不存在');

--- a/examples/test-bot/commands/gh/issues/[repo].ts
+++ b/examples/test-bot/commands/gh/issues/[repo].ts
@@ -4,8 +4,9 @@ import { ghApiMessage, resolveGhClient } from '../../../lib/github-api.js';
 export default defineCommand({
   description: '列出 Issue',
   params: { repo: { type: 'string' } },
-  execute: async ({ params, input }) => {
-    const api = await resolveGhClient(input);
+  execute: async (context) => {
+    const { params } = context;
+    const api = await resolveGhClient(context);
     if (typeof api === 'string') return api;
     const r = await api.listIssues(String(params.repo), 'open');
     if (!r.ok) return ghApiMessage(r.data, '查询失败');

--- a/examples/test-bot/commands/gh/pr.ts
+++ b/examples/test-bot/commands/gh/pr.ts
@@ -8,12 +8,13 @@ import {
 
 export default defineCommand({
   description: '查看 PR 详情',
-  execute: async ({ args, input }) => {
+  execute: async (context) => {
+    const { args } = context;
     const parsed = requireRepo(args, '用法: gh pr <owner/repo> <编号>');
     if (typeof parsed === 'string') return parsed;
     const number = parsePositiveInt(parsed.rest[0], '编号');
     if (typeof number === 'string') return number;
-    const api = await resolveGhClient(input);
+    const api = await resolveGhClient(context);
     if (typeof api === 'string') return api;
     const r = await api.getPR(parsed.repo, number);
     if (!r.ok) return ghApiMessage(r.data, 'PR 不存在');

--- a/examples/test-bot/commands/gh/prs/[repo].ts
+++ b/examples/test-bot/commands/gh/prs/[repo].ts
@@ -4,8 +4,9 @@ import { ghApiMessage, resolveGhClient } from '../../../lib/github-api.js';
 export default defineCommand({
   description: '列出 Pull Request',
   params: { repo: { type: 'string' } },
-  execute: async ({ params, input }) => {
-    const api = await resolveGhClient(input);
+  execute: async (context) => {
+    const { params } = context;
+    const api = await resolveGhClient(context);
     if (typeof api === 'string') return api;
     const r = await api.listPRs(String(params.repo), 'open');
     if (!r.ok) return ghApiMessage(r.data, '查询失败');

--- a/examples/test-bot/commands/gh/releases/[repo].ts
+++ b/examples/test-bot/commands/gh/releases/[repo].ts
@@ -4,8 +4,9 @@ import { ghApiMessage, resolveGhClient } from '../../../lib/github-api.js';
 export default defineCommand({
   description: '查看发布列表',
   params: { repo: { type: 'string' } },
-  execute: async ({ params, input }) => {
-    const api = await resolveGhClient(input);
+  execute: async (context) => {
+    const { params } = context;
+    const api = await resolveGhClient(context);
     if (typeof api === 'string') return api;
     const r = await api.listReleases(String(params.repo), 10);
     if (!r.ok) return ghApiMessage(r.data, '查询失败');

--- a/examples/test-bot/commands/gh/repo/[repo].ts
+++ b/examples/test-bot/commands/gh/repo/[repo].ts
@@ -4,8 +4,9 @@ import { ghApiMessage, resolveGhClient } from '../../../lib/github-api.js';
 export default defineCommand({
   description: '查看仓库信息',
   params: { repo: { type: 'string' } },
-  execute: async ({ params, input }) => {
-    const api = await resolveGhClient(input);
+  execute: async (context) => {
+    const { params } = context;
+    const api = await resolveGhClient(context);
     if (typeof api === 'string') return api;
     const repo = String(params.repo);
     const r = await api.getRepo(repo);

--- a/examples/test-bot/commands/gh/search/[query].ts
+++ b/examples/test-bot/commands/gh/search/[query].ts
@@ -4,8 +4,9 @@ import { ghApiMessage, resolveGhClient } from '../../../lib/github-api.js';
 export default defineCommand({
   description: '搜索 GitHub 仓库',
   params: { query: { type: 'string' } },
-  execute: async ({ params, args, input }) => {
-    const api = await resolveGhClient(input);
+  execute: async (context) => {
+    const { params, args } = context;
+    const api = await resolveGhClient(context);
     if (typeof api === 'string') return api;
     const query = [String(params.query), ...args].join(' ').trim();
     if (!query) return '用法: gh search <关键词>';

--- a/examples/test-bot/commands/gh/star/[repo].ts
+++ b/examples/test-bot/commands/gh/star/[repo].ts
@@ -4,8 +4,9 @@ import { ghApiMessage, resolveGhClient } from '../../../lib/github-api.js';
 export default defineCommand({
   description: 'Star 仓库',
   params: { repo: { type: 'string' } },
-  execute: async ({ params, input }) => {
-    const api = await resolveGhClient(input);
+  execute: async (context) => {
+    const { params } = context;
+    const api = await resolveGhClient(context);
     if (typeof api === 'string') return api;
     const repo = String(params.repo);
     const r = await api.starRepo(repo);

--- a/examples/test-bot/commands/gh/unbind.ts
+++ b/examples/test-bot/commands/gh/unbind.ts
@@ -4,11 +4,15 @@ import {
   requireOauthModel,
   unbindOauth,
 } from '../../lib/github-oauth.js';
+import { resolveGithubEndpoint } from '../../lib/github-api.js';
 
 export default defineCommand({
   description: '解绑 GitHub 账号',
-  execute: async ({ input, use }) => {
-    const modelOrError = requireOauthModel(use);
+  execute: async (context) => {
+    const { input } = context;
+    const endpoint = resolveGithubEndpoint(context);
+    if (typeof endpoint === 'string') return endpoint;
+    const modelOrError = requireOauthModel(endpoint);
     if (typeof modelOrError === 'string') return modelOrError;
     const identity = platformIdentity(input);
     if (typeof identity === 'string') return identity;

--- a/examples/test-bot/commands/gh/unstar/[repo].ts
+++ b/examples/test-bot/commands/gh/unstar/[repo].ts
@@ -4,8 +4,9 @@ import { ghApiMessage, resolveGhClient } from '../../../lib/github-api.js';
 export default defineCommand({
   description: '取消 Star',
   params: { repo: { type: 'string' } },
-  execute: async ({ params, input }) => {
-    const api = await resolveGhClient(input);
+  execute: async (context) => {
+    const { params } = context;
+    const api = await resolveGhClient(context);
     if (typeof api === 'string') return api;
     const repo = String(params.repo);
     const r = await api.unstarRepo(repo);

--- a/examples/test-bot/commands/gh/whoami.ts
+++ b/examples/test-bot/commands/gh/whoami.ts
@@ -4,26 +4,24 @@ import {
   requireOauthModel,
   whoamiOauth,
 } from '../../lib/github-oauth.js';
-import { resolveGhClient } from '../../lib/github-api.js';
-import { getAdapter } from '@zhin.js/adapter-github';
+import { resolveGhClient, resolveGithubEndpoint } from '../../lib/github-api.js';
 
 export default defineCommand({
   description: '查看 Bot / App 与当前用户绑定状态',
-  execute: async ({ input, use }) => {
-    const modelOrError = requireOauthModel(use);
+  execute: async (context) => {
+    const { input } = context;
+    const endpoint = resolveGithubEndpoint(context);
+    if (typeof endpoint === 'string') return endpoint;
+    const modelOrError = requireOauthModel(endpoint);
     if (typeof modelOrError === 'string') {
       // DB missing: still report App identity honestly.
-      const api = await resolveGhClient(input);
+      const api = await resolveGhClient(context);
       if (typeof api === 'string') return `${api}\n${modelOrError}`;
       const auth = await api.verifyAuth();
       let extra = '';
-      try {
-        const installs = getAdapter().getInstallations();
-        if (installs.length) {
-          extra = `\nInstallations: ${installs.map((i) => i.account.login).join(', ')}`;
-        }
-      } catch {
-        /* registry 未就绪 */
+      const installs = endpoint.installations;
+      if (installs.length) {
+        extra = `\nInstallations: ${installs.map((i) => i.account.login).join(', ')}`;
       }
       return auth.ok
         ? `Bot / App: ${auth.user}${extra}\n${modelOrError}`
@@ -31,13 +29,13 @@ export default defineCommand({
     }
     const identity = platformIdentity(input);
     if (typeof identity === 'string') {
-      const api = await resolveGhClient(input);
+      const api = await resolveGhClient(context);
       if (typeof api === 'string') return api;
       const auth = await api.verifyAuth();
       return auth.ok
         ? `Bot / App: ${auth.user}\n${identity}`
         : `GitHub 认证失败: ${auth.message}`;
     }
-    return whoamiOauth(modelOrError, identity.platform, identity.uid);
+    return whoamiOauth(endpoint, modelOrError, identity.platform, identity.uid);
   },
 });

--- a/examples/test-bot/commands/赞我.ts
+++ b/examples/test-bot/commands/赞我.ts
@@ -84,7 +84,6 @@ export default defineCommand({
   permit: ['adapter(icqq)'],
   execute: async (context) => {
     const { sender, args, segments } = context;
-    console.log(sender);
 
     const parsed = parseZanArgs({
       args,

--- a/examples/test-bot/commands/赞我.ts
+++ b/examples/test-bot/commands/赞我.ts
@@ -1,5 +1,5 @@
 import { defineCommand, type CommandSegment } from 'zhin.js/command';
-import { Actions } from '@zhin.js/adapter-icqq';
+import type { IcqqClient } from '@zhin.js/adapter-icqq';
 
 const MAX_TIMES = 20;
 const DEFAULT_TIMES = 10;
@@ -94,14 +94,9 @@ export default defineCommand({
     if ('error' in parsed) return parsed.error;
 
     try {
-      const bot = context.$client;
-      const resp = await bot.ipc.request(Actions.FRIEND_LIKE, {
-        user_id: parsed.userId,
-        times: parsed.times,
-      });
-      if (!resp.ok) {
-        return `点赞失败：${resp.error ?? '未知错误'}`;
-      }
+      const bot: IcqqClient = context.$client;
+      const ok = await bot.sendLike(parsed.userId, parsed.times);
+      if (!ok) return '点赞失败：ICQQ 未确认操作成功';
       return `已给 ${parsed.userId} 点赞 ${parsed.times} 次`;
     } catch (error) {
       return `点赞失败：${error instanceof Error ? error.message : String(error)}`;

--- a/examples/test-bot/lib/github-api.ts
+++ b/examples/test-bot/lib/github-api.ts
@@ -1,8 +1,14 @@
 /**
- * Runtime `gh *` 命令共享：从 adapter-github 进程内 registry 取 GhClient。
- * Endpoint start 后才会 register；未上线时返回可读错误。
+ * Runtime `gh *` 命令共享：从当前 generation 的 Adapter projection 取 GithubClient。
  */
-import { getAdapter, type GhClient } from '@zhin.js/adapter-github';
+import {
+  githubClient,
+  type GhClient,
+  type GithubClient,
+} from '@zhin.js/adapter-github';
+import type { EndpointClientContext } from 'zhin.js/adapter';
+
+const GITHUB_ENDPOINT = process.env.GITHUB_ENDPOINT_ID?.trim() || 'zhin-dev';
 
 export function ghApiMessage(data: unknown, fallback: string): string {
   if (data && typeof data === 'object' && 'message' in data) {
@@ -38,16 +44,19 @@ function platformFromInput(input: unknown): { adapter?: string; senderId?: strin
   return { adapter, senderId };
 }
 
-export async function resolveGhClient(input?: unknown): Promise<GhClient | string> {
+export function resolveGithubEndpoint(context: EndpointClientContext): GithubClient | string {
   try {
-    const endpoint = getAdapter();
-    const { adapter, senderId } = platformFromInput(input);
-    const api = await endpoint.getUserOrDefaultAPI(adapter, senderId);
-    if (!api) return 'GitHub 未就绪（无可用 client）';
-    return api;
+    return githubClient.get({ project: context.project }, GITHUB_ENDPOINT);
   } catch (error) {
     return error instanceof Error ? error.message : String(error);
   }
+}
+
+export async function resolveGhClient(context: EndpointClientContext): Promise<GhClient | string> {
+  const endpoint = resolveGithubEndpoint(context);
+  if (typeof endpoint === 'string') return endpoint;
+  const { adapter, senderId } = platformFromInput(context.input);
+  return endpoint.getUserOrDefaultApi(adapter, senderId);
 }
 
 export function requireRepo(args: readonly string[], usage: string): string | { repo: string; rest: string[] } {

--- a/examples/test-bot/lib/github-oauth.ts
+++ b/examples/test-bot/lib/github-oauth.ts
@@ -4,14 +4,11 @@
  */
 import {
   GhClient,
-  getAdapter,
   GITHUB_OAUTH_USERS_TABLE,
+  type GithubClient,
 } from '@zhin.js/adapter-github';
 import {
-  databaseHostToken,
-  type DatabaseHost,
   type DatabaseHostModel,
-  type Token,
 } from 'zhin.js';
 
 export { GITHUB_OAUTH_USERS_TABLE };
@@ -25,13 +22,9 @@ export interface GithubOauthRow {
   readonly created_at: number;
 }
 
-export function requireOauthModel(use: <T>(token: Token<T>) => T): DatabaseHostModel | string {
-  let host: DatabaseHost;
-  try {
-    host = use(databaseHostToken);
-  } catch {
-    return '数据库未就绪（缺少 DatabaseHost）';
-  }
+export function requireOauthModel(endpoint: GithubClient): DatabaseHostModel | string {
+  const host = endpoint.database;
+  if (!host) return '数据库未就绪（缺少 DatabaseHost）';
   if (!host.started) return '数据库尚未启动';
   const model = host.models.get(GITHUB_OAUTH_USERS_TABLE);
   if (!model) return `表 ${GITHUB_OAUTH_USERS_TABLE} 未定义`;
@@ -83,6 +76,7 @@ export async function findOauthBinding(
 }
 
 export async function bindWithPat(
+  endpoint: GithubClient,
   model: DatabaseHostModel,
   platform: string,
   uid: string,
@@ -92,8 +86,7 @@ export async function bindWithPat(
   if (existing) {
     return `已绑定 GitHub 账号: ${existing.github_login}\n请先执行 gh unbind`;
   }
-  const endpoint = getAdapter();
-  const userGh = new GhClient({ host: endpoint.getHost(), token });
+  const userGh = new GhClient({ host: endpoint.host, token });
   const auth = await userGh.verifyAuth();
   if (!auth.ok) return `Token 验证失败: ${auth.message}`;
   await model.insert({
@@ -108,6 +101,7 @@ export async function bindWithPat(
 }
 
 export async function startDeviceFlowBind(
+  endpoint: GithubClient,
   model: DatabaseHostModel,
   platform: string,
   uid: string,
@@ -117,8 +111,7 @@ export async function startDeviceFlowBind(
   if (existing) {
     return `已绑定 GitHub 账号: ${existing.github_login}\n请先执行 gh unbind`;
   }
-  const endpoint = getAdapter();
-  const clientId = endpoint.getClientId();
+  const clientId = endpoint.clientId;
   if (!clientId) {
     return [
       'Device Flow 不可用（App 未配置 client_id）',
@@ -128,7 +121,7 @@ export async function startDeviceFlowBind(
       '2. gh bind <token>',
     ].join('\n');
   }
-  const host = endpoint.getHost();
+  const host = endpoint.host;
   let codeResp: Awaited<ReturnType<typeof GhClient.deviceFlowRequestCode>>;
   try {
     codeResp = await GhClient.deviceFlowRequestCode(clientId, host);
@@ -188,18 +181,18 @@ export async function unbindOauth(
 }
 
 export async function whoamiOauth(
+  endpoint: GithubClient,
   model: DatabaseHostModel,
   platform: string,
   uid: string,
 ): Promise<string> {
   const existing = await findOauthBinding(model, platform, uid);
-  const endpoint = getAdapter();
-  const appAuth = await endpoint.getAPI().verifyAuth();
+  const appAuth = await endpoint.api.verifyAuth();
   const appLine = appAuth.ok ? `Bot / App: ${appAuth.user}` : `Bot / App: ${appAuth.message}`;
   if (!existing) {
     return `${appLine}\n用户绑定: 无（gh bind <PAT> 或 Device Flow）`;
   }
-  const userGh = new GhClient({ host: endpoint.getHost(), token: existing.access_token });
+  const userGh = new GhClient({ host: endpoint.host, token: existing.access_token });
   const auth = await userGh.verifyAuth();
   if (auth.ok) {
     return [

--- a/examples/test-bot/tests/github-client-context.test.ts
+++ b/examples/test-bot/tests/github-client-context.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import { resolveGhClient, resolveGithubEndpoint } from '../lib/github-api.js';
-import { requireOauthModel } from '../lib/github-oauth.js';
+import { platformIdentity, requireOauthModel } from '../lib/github-oauth.js';
 
 describe('test-bot GitHub client access', () => {
   it('resolves the configured GitHub endpoint from the current generation projection', () => {
@@ -55,5 +55,26 @@ describe('test-bot GitHub client access', () => {
 
     expect(requireOauthModel(endpoint as never)).toBe(model);
     expect(endpoint.database.models.get).toHaveBeenCalledWith('github_oauth_users');
+  });
+
+  it('reports each unavailable owner-database state', () => {
+    expect(requireOauthModel({ database: undefined } as never))
+      .toBe('数据库未就绪（缺少 DatabaseHost）');
+    expect(requireOauthModel({ database: { started: false } } as never))
+      .toBe('数据库尚未启动');
+    expect(requireOauthModel({
+      database: { started: true, models: { get: () => undefined } },
+    } as never)).toBe('表 github_oauth_users 未定义');
+  });
+
+  it('derives OAuth identities from message and metadata context shapes', () => {
+    expect(platformIdentity({ $adapter: 'icqq', $sender: { id: 10001 } }))
+      .toEqual({ platform: 'icqq', uid: '10001' });
+    expect(platformIdentity({ adapter: 'sandbox', sender: 'alice' }))
+      .toEqual({ platform: 'sandbox', uid: 'alice' });
+    expect(platformIdentity({ metadata: { adapter: 'qq', senderId: 'openid' } }))
+      .toEqual({ platform: 'qq', uid: 'openid' });
+    expect(platformIdentity(undefined)).toContain('缺少消息上下文');
+    expect(platformIdentity({ adapter: 'qq' })).toContain('platform + sender');
   });
 });

--- a/examples/test-bot/tests/github-client-context.test.ts
+++ b/examples/test-bot/tests/github-client-context.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from 'vitest';
+import { resolveGithubEndpoint } from '../lib/github-api.js';
+import { requireOauthModel } from '../lib/github-oauth.js';
+
+describe('test-bot GitHub client access', () => {
+  it('resolves the configured GitHub endpoint from the current generation projection', () => {
+    const client = { name: 'zhin-dev' };
+    const endpointClient = vi.fn((adapter: string, endpointKey: string) => {
+      expect(adapter).toBe('github');
+      expect(endpointKey).toBe('zhin-dev');
+      return client;
+    });
+    const project = vi.fn(() => ({
+      $projection: 'zhin.adapter-index/1',
+      client: endpointClient,
+    }));
+
+    expect(resolveGithubEndpoint({ project } as never)).toBe(client);
+    expect(endpointClient).toHaveBeenCalledOnce();
+  });
+
+  it('reads OAuth models from the GitHub Plugin owner database', () => {
+    const model = { select: vi.fn() };
+    const endpoint = {
+      database: {
+        started: true,
+        models: { get: vi.fn(() => model) },
+      },
+    };
+
+    expect(requireOauthModel(endpoint as never)).toBe(model);
+    expect(endpoint.database.models.get).toHaveBeenCalledWith('github_oauth_users');
+  });
+});

--- a/examples/test-bot/tests/github-client-context.test.ts
+++ b/examples/test-bot/tests/github-client-context.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { resolveGithubEndpoint } from '../lib/github-api.js';
+import { resolveGhClient, resolveGithubEndpoint } from '../lib/github-api.js';
 import { requireOauthModel } from '../lib/github-oauth.js';
 
 describe('test-bot GitHub client access', () => {
@@ -17,6 +17,31 @@ describe('test-bot GitHub client access', () => {
 
     expect(resolveGithubEndpoint({ project } as never)).toBe(client);
     expect(endpointClient).toHaveBeenCalledOnce();
+  });
+
+  it('resolves the user GitHub API from the endpoint bound to the current generation', async () => {
+    const getUserOrDefaultApi = vi.fn(async () => ({ login: 'alice' }));
+    const endpointClient = vi.fn(() => ({ getUserOrDefaultApi }));
+    const project = vi.fn(() => ({
+      $projection: 'zhin.adapter-index/1',
+      client: endpointClient,
+    }));
+
+    await expect(resolveGhClient({
+      project,
+      input: { $adapter: 'icqq', $sender: { id: '10001' } },
+    } as never)).resolves.toEqual({ login: 'alice' });
+    expect(getUserOrDefaultApi).toHaveBeenCalledWith('icqq', '10001');
+  });
+
+  it('returns a readable projection error instead of consulting a process-global adapter', async () => {
+    const project = vi.fn(() => {
+      throw new Error('GitHub endpoint is offline');
+    });
+    const context = { project, input: undefined } as never;
+
+    expect(resolveGithubEndpoint(context)).toBe('GitHub endpoint is offline');
+    await expect(resolveGhClient(context)).resolves.toBe('GitHub endpoint is offline');
   });
 
   it('reads OAuth models from the GitHub Plugin owner database', () => {

--- a/examples/test-bot/tests/github-oauth-endpoint.test.ts
+++ b/examples/test-bot/tests/github-oauth-endpoint.test.ts
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  construct: vi.fn(),
+  verifyAuth: vi.fn(),
+  requestCode: vi.fn(),
+  pollToken: vi.fn(),
+}));
+
+vi.mock('@zhin.js/adapter-github', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@zhin.js/adapter-github')>();
+  class MockGhClient {
+    static deviceFlowRequestCode = mocks.requestCode;
+    static deviceFlowPollToken = mocks.pollToken;
+
+    constructor(options: unknown) {
+      mocks.construct(options);
+    }
+
+    verifyAuth = mocks.verifyAuth;
+  }
+  return { ...actual, GhClient: MockGhClient };
+});
+
+import {
+  bindWithPat,
+  startDeviceFlowBind,
+  whoamiOauth,
+} from '../lib/github-oauth.js';
+
+function modelWithRows(rows: unknown[]) {
+  return {
+    select: vi.fn(() => ({ where: vi.fn(async () => rows) })),
+    insert: vi.fn(async () => undefined),
+  };
+}
+
+describe('test-bot GitHub OAuth endpoint access', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('uses the generation-bound endpoint host for PAT verification', async () => {
+    const model = modelWithRows([]);
+    mocks.verifyAuth.mockResolvedValueOnce({ ok: true, user: 'alice' });
+    const endpoint = { host: 'https://github.example' };
+
+    await expect(bindWithPat(endpoint as never, model as never, 'icqq', '10001', 'token'))
+      .resolves.toBe('GitHub 绑定成功\n用户: alice');
+    expect(mocks.construct).toHaveBeenCalledWith({ host: endpoint.host, token: 'token' });
+    expect(model.insert).toHaveBeenCalledWith(expect.objectContaining({
+      platform: 'icqq',
+      platform_uid: '10001',
+      github_login: 'alice',
+      access_token: 'token',
+    }));
+  });
+
+  it('uses the generation-bound endpoint client id and host for Device Flow', async () => {
+    const model = modelWithRows([]);
+    mocks.requestCode.mockResolvedValueOnce({
+      device_code: 'device',
+      user_code: 'ABCD-EFGH',
+      verification_uri: 'https://github.com/login/device',
+      interval: 5,
+      expires_in: 900,
+    });
+    mocks.pollToken.mockResolvedValueOnce(null);
+    const endpoint = { clientId: 'client-id', host: 'https://github.example' };
+
+    await expect(startDeviceFlowBind(endpoint as never, model as never, 'icqq', '10001'))
+      .resolves.toContain('ABCD-EFGH');
+    expect(mocks.requestCode).toHaveBeenCalledWith('client-id', endpoint.host);
+    expect(mocks.pollToken).toHaveBeenCalledWith('client-id', 'device', 5, 900, endpoint.host);
+  });
+
+  it('uses endpoint API and host when reporting a bound identity', async () => {
+    const model = modelWithRows([{
+      id: 1,
+      platform: 'icqq',
+      platform_uid: '10001',
+      github_login: 'alice',
+      access_token: 'user-token',
+      created_at: 1,
+    }]);
+    const endpoint = {
+      host: 'https://github.example',
+      api: { verifyAuth: vi.fn(async () => ({ ok: true, user: 'bot' })) },
+    };
+    mocks.verifyAuth.mockResolvedValueOnce({ ok: false, message: 'expired' });
+
+    await expect(whoamiOauth(endpoint as never, model as never, 'icqq', '10001'))
+      .resolves.toContain('Token 已失效');
+    expect(endpoint.api.verifyAuth).toHaveBeenCalledOnce();
+    expect(mocks.construct).toHaveBeenCalledWith({ host: endpoint.host, token: 'user-token' });
+  });
+});

--- a/examples/test-bot/tests/github-oauth-endpoint.test.ts
+++ b/examples/test-bot/tests/github-oauth-endpoint.test.ts
@@ -25,13 +25,17 @@ vi.mock('@zhin.js/adapter-github', async (importOriginal) => {
 import {
   bindWithPat,
   startDeviceFlowBind,
+  unbindOauth,
   whoamiOauth,
 } from '../lib/github-oauth.js';
 
 function modelWithRows(rows: unknown[]) {
+  const deleteWhere = vi.fn(async () => undefined);
   return {
     select: vi.fn(() => ({ where: vi.fn(async () => rows) })),
     insert: vi.fn(async () => undefined),
+    delete: vi.fn(() => ({ where: deleteWhere })),
+    deleteWhere,
   };
 }
 
@@ -56,6 +60,28 @@ describe('test-bot GitHub OAuth endpoint access', () => {
     }));
   });
 
+  it('preserves existing bindings and reports PAT verification failures', async () => {
+    const existing = modelWithRows([{
+      id: 1,
+      platform: 'icqq',
+      platform_uid: '10001',
+      github_login: 'alice',
+      access_token: 'old-token',
+      created_at: 1,
+    }]);
+    await expect(bindWithPat({ host: 'https://github.example' } as never, existing as never,
+      'icqq', '10001', 'new-token'))
+      .resolves.toContain('请先执行 gh unbind');
+    expect(mocks.construct).not.toHaveBeenCalled();
+
+    const invalid = modelWithRows([]);
+    mocks.verifyAuth.mockResolvedValueOnce({ ok: false, message: 'bad credentials' });
+    await expect(bindWithPat({ host: 'https://github.example' } as never, invalid as never,
+      'icqq', '10001', 'bad-token'))
+      .resolves.toBe('Token 验证失败: bad credentials');
+    expect(invalid.insert).not.toHaveBeenCalled();
+  });
+
   it('uses the generation-bound endpoint client id and host for Device Flow', async () => {
     const model = modelWithRows([]);
     mocks.requestCode.mockResolvedValueOnce({
@@ -72,6 +98,52 @@ describe('test-bot GitHub OAuth endpoint access', () => {
       .resolves.toContain('ABCD-EFGH');
     expect(mocks.requestCode).toHaveBeenCalledWith('client-id', endpoint.host);
     expect(mocks.pollToken).toHaveBeenCalledWith('client-id', 'device', 5, 900, endpoint.host);
+  });
+
+  it('persists and announces a completed Device Flow binding', async () => {
+    const model = modelWithRows([]);
+    const reply = vi.fn(async () => undefined);
+    mocks.requestCode.mockResolvedValueOnce({
+      device_code: 'device',
+      user_code: 'ABCD-EFGH',
+      verification_uri: 'https://github.com/login/device',
+      interval: 5,
+      expires_in: 900,
+    });
+    mocks.pollToken.mockResolvedValueOnce({ access_token: 'device-token' });
+    mocks.verifyAuth.mockResolvedValueOnce({ ok: true, user: 'alice' });
+    const endpoint = { clientId: 'client-id', host: 'https://github.example' };
+
+    await startDeviceFlowBind(endpoint as never, model as never, 'icqq', '10001', reply);
+    await vi.waitFor(() => expect(reply).toHaveBeenCalledWith('GitHub 绑定成功\n用户: alice'));
+    expect(model.insert).toHaveBeenCalledWith(expect.objectContaining({
+      github_login: 'alice',
+      access_token: 'device-token',
+    }));
+  });
+
+  it('reports missing Device Flow configuration and request failures', async () => {
+    const model = modelWithRows([]);
+    await expect(startDeviceFlowBind({ clientId: '', host: 'https://github.example' } as never,
+      model as never, 'icqq', '10001'))
+      .resolves.toContain('App 未配置 client_id');
+
+    mocks.requestCode.mockRejectedValueOnce(new Error('device endpoint offline'));
+    await expect(startDeviceFlowBind({ clientId: 'client-id', host: 'https://github.example' } as never,
+      model as never, 'icqq', '10001'))
+      .resolves.toContain('device endpoint offline');
+
+    const existing = modelWithRows([{
+      id: 1,
+      platform: 'icqq',
+      platform_uid: '10001',
+      github_login: 'alice',
+      access_token: 'old-token',
+      created_at: 1,
+    }]);
+    await expect(startDeviceFlowBind({ clientId: 'client-id', host: 'https://github.example' } as never,
+      existing as never, 'icqq', '10001'))
+      .resolves.toContain('请先执行 gh unbind');
   });
 
   it('uses endpoint API and host when reporting a bound identity', async () => {
@@ -93,5 +165,32 @@ describe('test-bot GitHub OAuth endpoint access', () => {
       .resolves.toContain('Token 已失效');
     expect(endpoint.api.verifyAuth).toHaveBeenCalledOnce();
     expect(mocks.construct).toHaveBeenCalledWith({ host: endpoint.host, token: 'user-token' });
+  });
+
+  it('reports unbound and valid identities, then removes the binding', async () => {
+    const endpoint = {
+      host: 'https://github.example',
+      api: { verifyAuth: vi.fn(async () => ({ ok: false, message: 'app token missing' })) },
+    };
+    const unbound = modelWithRows([]);
+    await expect(whoamiOauth(endpoint as never, unbound as never, 'icqq', '10001'))
+      .resolves.toContain('用户绑定: 无');
+    await expect(unbindOauth(unbound as never, 'icqq', '10001'))
+      .resolves.toBe('尚未绑定 GitHub 账号');
+
+    const bound = modelWithRows([{
+      id: 7,
+      platform: 'icqq',
+      platform_uid: '10001',
+      github_login: 'alice',
+      access_token: 'user-token',
+      created_at: 1,
+    }]);
+    mocks.verifyAuth.mockResolvedValueOnce({ ok: true, user: 'alice' });
+    await expect(whoamiOauth(endpoint as never, bound as never, 'icqq', '10001'))
+      .resolves.toContain('用户绑定: alice');
+    await expect(unbindOauth(bound as never, 'icqq', '10001'))
+      .resolves.toBe('已解绑: alice');
+    expect(bound.deleteWhere).toHaveBeenCalledWith({ id: 7 });
   });
 });

--- a/examples/test-bot/tests/zan.test.ts
+++ b/examples/test-bot/tests/zan.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from 'vitest';
-import { parseZanArgs } from '../commands/赞我.js';
+import { describe, expect, it, vi } from 'vitest';
+import zanCommand, { parseZanArgs } from '../commands/赞我.js';
 
 describe('parseZanArgs', () => {
   it('无参数时给发送者默认次数', () => {
@@ -28,5 +28,32 @@ describe('parseZanArgs', () => {
   it('仅 QQ 号时用默认次数', () => {
     expect(parseZanArgs({ args: ['123456789'], segments: [], senderId: '10001' }))
       .toEqual({ userId: 123456789, times: 10 });
+  });
+
+  it('通过当前 operation 的 IcqqClient 发起点赞', async () => {
+    const sendLike = vi.fn(async () => true);
+    const context = {
+      sender: { id: '10001' },
+      args: [],
+      segments: [],
+      $client: { sendLike },
+    };
+
+    await expect(zanCommand.execute(context as never)).resolves.toBe('已给 10001 点赞 10 次');
+    expect(sendLike).toHaveBeenCalledWith(10001, 10);
+  });
+
+  it('返回 IcqqClient 未确认与异常结果', async () => {
+    const base = { sender: { id: '10001' }, args: [], segments: [] };
+
+    await expect(zanCommand.execute({
+      ...base,
+      $client: { sendLike: vi.fn(async () => false) },
+    } as never)).resolves.toBe('点赞失败：ICQQ 未确认操作成功');
+
+    await expect(zanCommand.execute({
+      ...base,
+      $client: { sendLike: vi.fn(async () => { throw new Error('offline'); }) },
+    } as never)).resolves.toBe('点赞失败：offline');
   });
 });

--- a/packages/im/runtime/src/config-composer.ts
+++ b/packages/im/runtime/src/config-composer.ts
@@ -94,6 +94,7 @@ export class ConfigComposer {
       allowUnionTypes: true,
     });
     ajv.addKeyword({ keyword: 'x-descriptionZh', schemaType: 'string' });
+    ajv.addKeyword({ keyword: 'x-keyPlaceholder', schemaType: 'string' });
     const validate = ajv.compile(effectiveSchema);
     if (!validate(document)) {
       throw new ConfigValidationError(formatErrors(validate.errors ?? []), source);
@@ -223,6 +224,7 @@ async function readOwnSchema(node: PluginGraphNode): Promise<JsonSchema> {
     );
   }
   return Object.freeze({
+    $id: `urn:zhin:plugin-config:${encodeURIComponent(String(node.id))}`,
     type: 'object',
     additionalProperties: false,
     ...schema,

--- a/packages/im/runtime/tests/config-composer.test.ts
+++ b/packages/im/runtime/tests/config-composer.test.ts
@@ -48,6 +48,45 @@ describe('hierarchical Plugin config', () => {
     });
   });
 
+  it('scopes local refs to each Plugin schema and accepts UI annotations', async () => {
+    const root = await configProject({
+      rootSchema: {},
+      childSchema: {
+        type: 'object',
+        additionalProperties: false,
+        $defs: {
+          profile: {
+            type: 'object',
+            additionalProperties: false,
+            properties: { enabled: { type: 'boolean' } },
+            required: ['enabled'],
+          },
+        },
+        properties: {
+          profiles: {
+            type: 'object',
+            'x-keyPlaceholder': '<profile-name>',
+            additionalProperties: { $ref: '#/$defs/profile' },
+          },
+        },
+      },
+    });
+    const resolver = await NodePackageResolver.create(root);
+    const graph = await new ProjectGraphService(resolver).inspect(root);
+    const composer = new ConfigComposer();
+
+    const config = await composer.compose(graph, {
+      plugins: { child: { profiles: { default: { enabled: true } } } },
+    });
+    expect(config.views.get(graph.root.children[0]!.id)).toEqual({
+      profiles: { default: { enabled: true } },
+    });
+
+    await expect(composer.compose(graph, {
+      plugins: { child: { profiles: { default: { enabled: 'yes' } } } },
+    })).rejects.toBeInstanceOf(ConfigValidationError);
+  });
+
   it('rejects parent fields colliding with child instance keys', async () => {
     const root = await configProject({
       rootSchema: {},

--- a/plugins/adapters/icqq/src/protocol.ts
+++ b/plugins/adapters/icqq/src/protocol.ts
@@ -321,7 +321,7 @@ export function resolveIcqqConfig(config: IcqqAdapterConfig = {}): ResolvedIcqqC
   }
   const autoReconnect = config.autoReconnect ?? entry?.autoReconnect ?? true;
   const outboundMedia = config.outboundMedia ?? entry?.outboundMedia;
-  const password = entry?.password;
+  const password = config.password ?? entry?.password;
   const platform = config.platform ?? entry?.platform ?? 2;
   const ver = config.ver ?? entry?.ver ?? '9.1.70';
   const dataDir = config.dataDir ?? entry?.dataDir ?? `data/icqq/${id}`;

--- a/plugins/adapters/icqq/tests/icqq-runtime.test.ts
+++ b/plugins/adapters/icqq/tests/icqq-runtime.test.ts
@@ -70,6 +70,18 @@ describe('icqq protocol helpers', () => {
     expect(resolved.context).toBe('icqq');
   });
 
+  it('prefers the direct password and keeps transitional endpoint fallback', () => {
+    expect(resolveIcqqConfig({
+      id: '12345',
+      password: 'direct-secret',
+      endpoints: [{ context: 'icqq', id: '54321', password: 'legacy-secret' }],
+    }).password).toBe('direct-secret');
+
+    expect(resolveIcqqConfig({
+      endpoints: [{ context: 'icqq', id: '12345', password: 'legacy-secret' }],
+    }).password).toBe('legacy-secret');
+  });
+
   it('rejects non-numeric id', () => {
     expect(() => resolveIcqqConfig({ id: 'bot' })).toThrow(/numeric id/);
   });

--- a/plugins/services/activity-feedback/src/ai-event-binder.ts
+++ b/plugins/services/activity-feedback/src/ai-event-binder.ts
@@ -129,8 +129,10 @@ export function bindActivityFeedbackToAIEventBus(
   runWithView: <T>(operation: () => Promise<T>) => Promise<T>,
 ): () => Promise<void> {
   let stopWatchingRetirement: (() => void) | undefined;
+  let cleanupNeedsGenerationView = false;
   const watchRetirement = () => {
     if (stopWatchingRetirement) return;
+    cleanupNeedsGenerationView = true;
     stopWatchingRetirement = admission.onDeactivate(() => {
       void close();
     });
@@ -148,14 +150,17 @@ export function bindActivityFeedbackToAIEventBus(
   let shutdown: Promise<void> | undefined;
   function close(): Promise<void> {
     if (shutdown) return shutdown;
-    // Retirement is published before SnapshotStore changes its current pointer.
-    // Enter the IM view synchronously here so timers, native-typing keepalives,
-    // and final reaction/message cleanup all remain on this generation's Endpoint.
-    shutdown = runWithView(async () => {
+    const cleanup = async () => {
       unsubscribe();
       await serialized.close();
       await orchestrator.dispose();
-    });
+    };
+    // Retirement is published before SnapshotStore changes its current pointer.
+    // Enter the IM view synchronously here so timers, native-typing keepalives,
+    // and final reaction/message cleanup all remain on this generation's Endpoint.
+    // A candidate rolled back before admitting any event has no generation-local
+    // feedback state, and its view is unavailable while Root is still idle.
+    shutdown = cleanupNeedsGenerationView ? runWithView(cleanup) : cleanup();
     return shutdown;
   }
   return async () => {

--- a/plugins/services/activity-feedback/tests/activity-feedback-runtime.test.ts
+++ b/plugins/services/activity-feedback/tests/activity-feedback-runtime.test.ts
@@ -152,6 +152,26 @@ describe('@zhin.js/service-activity-feedback runtime', () => {
     expect(startPhase).not.toHaveBeenCalled();
   });
 
+  it('rolls back an unactivated binder without entering a generation view', async () => {
+    const orchestrator = {
+      startPhase: vi.fn(),
+      stopPhase: vi.fn(),
+      dispose: vi.fn().mockResolvedValue(undefined),
+    };
+    const runWithUnavailableView = vi.fn(async () => {
+      throw new Error('Root is not accepting generation operations (idle)');
+    });
+    const dispose = bindActivityFeedbackToAIEventBus(
+      orchestrator as never,
+      mutableAdmission(false).gate,
+      runWithUnavailableView,
+    );
+
+    await expect(dispose()).resolves.toBeUndefined();
+    expect(runWithUnavailableView).not.toHaveBeenCalled();
+    expect(orchestrator.dispose).toHaveBeenCalledOnce();
+  });
+
   it('createActivityFeedbackOrchestratorForRuntime uses noop endpoint access by default', async () => {
     const orchestrator = createActivityFeedbackOrchestratorForRuntime(
       loadActivityFeedbackServiceConfig({}),


### PR DESCRIPTION
## Summary
- honor direct ICQQ password configuration before the transitional endpoint fallback
- register `x-keyPlaceholder` and scope Plugin-local `#/$defs/*` references with stable schema resource IDs
- finish the endpoint-client refactor migration across test-bot callers:
  - replace the removed GitHub process-global adapter registry with generation-bound `githubClient`
  - migrate OAuth and command code to `GithubClient`'s owner-scoped database and current property/method surface
  - replace ICQQ `ipc.request` with the operation-bound SDK `sendLike` API
- allow activity-feedback candidates to roll back before generation activation without entering an unavailable IM view
- add patch changesets for `@zhin.js/adapter-icqq`, `@zhin.js/runtime`, and `@zhin.js/service-activity-feedback`

## Regression coverage
- generation-bound GitHub endpoint lookup, user API lookup, offline projection, OAuth database ownership, PAT/Device Flow/whoami/unbind paths
- ICQQ `sendLike` success, rejected result, and exception paths
- pre-activation activity-feedback rollback
- ICQQ password precedence and runtime schema composition

## Verification
- `pnpm --filter test-bot build`
- `pnpm type-check`
- `pnpm --filter @zhin.js/service-activity-feedback test`
- `pnpm --filter @zhin.js/adapter-github test`
- `pnpm exec vitest run examples/test-bot/tests`
- `pnpm --filter @zhin.js/service-activity-feedback build`
- real `examples/test-bot` startup reached HTTP/Agent/Schedule activation and connected GitHub endpoint `zhin-dev`
- Ubuntu/Windows Node 22, 24, 26 CI matrix: pass
- CodeQL, production-install, Codecov patch/project: pass
