### PR TITLE
fix(agent): canonicalize governance bootstrap decisions

### DIFF
--- a/.changeset/fix-workroom-governance-bootstrap.md
+++ b/.changeset/fix-workroom-governance-bootstrap.md
@@ -1,0 +1,5 @@
+---
+"@zhin.js/agent": patch
+---
+
+Normalize Project Data Governance authority candidates before requesting the exact publication decision, so Workroom disclosure bootstrap persists through the canonical repository without digest drift.

--- a/packages/im/agent/src/data-governance/governance-authority-repository.ts
+++ b/packages/im/agent/src/data-governance/governance-authority-repository.ts
@@ -108,11 +108,10 @@ export interface ProjectDataGovernanceAuthority extends ProjectDataGovernanceAut
   readonly digest: string;
 }
 
-export function createProjectDataGovernanceAuthority(
-  input: ProjectDataGovernanceAuthorityInput,
-): ProjectDataGovernanceAuthority {
-  assertProjectAuthorityInput(input);
-  const body = deepFreeze({
+export function canonicalizeProjectDataGovernanceAuthorityCandidate(
+  input: Omit<ProjectDataGovernanceAuthorityInput, 'governanceDecision'>,
+): Omit<ProjectDataGovernanceAuthorityInput, 'governanceDecision'> {
+  return deepFreeze({
     ...structuredClone(input),
     planning: {
       ...structuredClone(input.planning),
@@ -156,6 +155,21 @@ export function createProjectDataGovernanceAuthority(
     approvals: [...input.approvals]
       .sort((left, right) => compareCanonicalWorkroomText(left.id, right.id))
       .map(value => structuredClone(value)),
+  });
+}
+
+export function createProjectDataGovernanceAuthority(
+  input: ProjectDataGovernanceAuthorityInput,
+): ProjectDataGovernanceAuthority {
+  assertProjectAuthorityInput(input);
+  const { governanceDecision, ...candidateInput } = structuredClone(input);
+  const candidate = canonicalizeProjectDataGovernanceAuthorityCandidate(candidateInput);
+  if (governanceDecision.candidateDigest !== digest(candidate)) {
+    throw new Error('Data Governance decision does not bind the exact authority candidate');
+  }
+  const body = deepFreeze({
+    ...candidate,
+    governanceDecision: structuredClone(governanceDecision),
   });
   return deepFreeze({ ...body, digest: digest(body) });
 }
@@ -578,10 +592,6 @@ function assertProjectAuthorityInput(input: ProjectDataGovernanceAuthorityInput)
   if (decision.projectId !== input.projectId
     || decision.expectedPreviousDigest !== input.previousDigest) {
     throw new Error('Data Governance decision scope/chain binding mismatch');
-  }
-  const { governanceDecision: _governanceDecision, ...candidate } = structuredClone(input);
-  if (decision.candidateDigest !== digest(candidate)) {
-    throw new Error('Data Governance decision does not bind the exact authority candidate');
   }
 }
 

--- a/packages/im/agent/src/plugin-runtime/workroom-data-governance-authority-writer.ts
+++ b/packages/im/agent/src/plugin-runtime/workroom-data-governance-authority-writer.ts
@@ -1,4 +1,5 @@
 import {
+  canonicalizeProjectDataGovernanceAuthorityCandidate,
   createProjectDataGovernanceAuthority,
   FileDataGovernanceAuthorityRepository,
   type DataGovernanceAuthorityDecision,
@@ -64,22 +65,23 @@ implements WorkroomDataGovernanceAuthorityControlPort {
     }
     assertProjectionAuthority(input.candidate, definition);
     assertWorkroomJournalDataGovernanceAuthority(input.candidate);
-    const current = await this.options.repository.readProject(input.candidate.projectId);
-    if ((!current && input.candidate.revision !== 1)
-      || (current && (input.candidate.revision !== current.revision + 1
-        || input.candidate.previousDigest !== current.digest))) {
+    const candidate = canonicalizeProjectDataGovernanceAuthorityCandidate(input.candidate);
+    const current = await this.options.repository.readProject(candidate.projectId);
+    if ((!current && candidate.revision !== 1)
+      || (current && (candidate.revision !== current.revision + 1
+        || candidate.previousDigest !== current.digest))) {
       throw new Error('Data Governance publication revision/CAS authority is stale');
     }
-    const candidateDigest = digest(input.candidate);
+    const candidateDigest = digest(candidate);
     const decision = await this.options.decisions.authorize({
-      projectId: input.candidate.projectId,
+      projectId: candidate.projectId,
       catalogRevision: input.catalogRevision,
       catalogBindingDigest: input.catalogBindingDigest,
       candidateDigest,
       ...(current ? { expectedPreviousDigest: current.digest } : {}),
     }, signal);
     if (!decision
-      || decision.projectId !== input.candidate.projectId
+      || decision.projectId !== candidate.projectId
       || decision.candidateDigest !== candidateDigest
       || decision.expectedPreviousDigest !== current?.digest
       || decision.catalogRevision !== input.catalogRevision
@@ -88,7 +90,7 @@ implements WorkroomDataGovernanceAuthorityControlPort {
       throw new Error('Data Governance publication decision is unavailable or forged');
     }
     const authority = createProjectDataGovernanceAuthority({
-      ...structuredClone(input.candidate),
+      ...candidate,
       governanceDecision: structuredClone(decision),
     });
     return (await this.options.repository.appendProject(authority, current?.digest)).authority;

--- a/packages/im/agent/tests/plugin-runtime/workroom-data-governance-authority-writer.test.ts
+++ b/packages/im/agent/tests/plugin-runtime/workroom-data-governance-authority-writer.test.ts
@@ -5,7 +5,10 @@ import {
   createDisclosureRecipientSetSnapshot,
   createProcessingDestinationContract,
 } from '../../src/data-governance/data-governance.js';
-import type { ProjectDataGovernanceAuthority } from '../../src/data-governance/governance-authority-repository.js';
+import {
+  canonicalizeProjectDataGovernanceAuthorityCandidate,
+  type ProjectDataGovernanceAuthority,
+} from '../../src/data-governance/governance-authority-repository.js';
 import {
   WorkroomDataGovernanceAuthorityWriter,
   type ProjectDataGovernanceAuthorityCandidate,
@@ -80,7 +83,8 @@ describe('trusted Project Data Governance authority writer', () => {
       recipients: { recipients: [{ principalId: 'principal:sponsor' }] },
     });
     expect(authorize).toHaveBeenCalledWith(expect.objectContaining({
-      candidateDigest: digest(candidate), catalogRevision: 'catalog:1',
+      candidateDigest: digest(canonicalizeProjectDataGovernanceAuthorityCandidate(candidate)),
+      catalogRevision: 'catalog:1',
     }), expect.any(AbortSignal));
   });
 

--- a/packages/im/agent/tests/plugin-runtime/workroom-data-governance-bootstrap.test.ts
+++ b/packages/im/agent/tests/plugin-runtime/workroom-data-governance-bootstrap.test.ts
@@ -1,4 +1,11 @@
+import { mkdir } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { randomUUID } from 'node:crypto';
 import { describe, expect, it } from 'vitest';
+import {
+  FileDataGovernanceAuthorityRepository,
+} from '../../src/data-governance/governance-authority-repository.js';
 import {
   createWorkroomDataGovernanceBootstrapCandidate,
 } from '../../src/plugin-runtime/workroom-data-governance-bootstrap.js';
@@ -82,6 +89,51 @@ describe('Workroom Data Governance bootstrap', () => {
     }, new AbortController().signal)).resolves.toMatchObject({
       projectId: 'project-1',
       planning: { destinationId: 'model-provider:openrouter' },
+    });
+  });
+
+  it('persists the bootstrapped authority through the canonical file repository', async () => {
+    const stateRoot = join(tmpdir(), `zhin-workroom-governance-bootstrap-${randomUUID()}`);
+    await mkdir(stateRoot);
+    const candidate = createWorkroomDataGovernanceBootstrapCandidate({
+      projectId: 'project-1',
+      tenantId: 'tenant:project-1',
+      definition,
+      revision: 1,
+      model,
+    });
+    const repository = new FileDataGovernanceAuthorityRepository(stateRoot, {
+      verify: async (decision, candidateDigest) => decision.candidateDigest === candidateDigest,
+    });
+    const writer = new WorkroomDataGovernanceAuthorityWriter({
+      catalog: {
+        read: async () => ({ revision: 'catalog:1', definitions: { 'project-1': definition } }),
+      },
+      repository,
+      decisions: {
+        authorize: async input => ({
+          decisionId: 'decision:file-repository',
+          projectId: input.projectId,
+          candidateDigest: input.candidateDigest,
+          principalId: 'principal:sponsor',
+          authorizedBy: 'sponsor',
+          decidedAt: 1,
+          catalogRevision: input.catalogRevision,
+          catalogBindingDigest: input.catalogBindingDigest,
+        }),
+      },
+    });
+
+    await expect(writer.publish({
+      catalogRevision: 'catalog:1',
+      catalogBindingDigest: digestWorkroomCatalogProjectBinding(definition),
+      candidate,
+    }, new AbortController().signal)).resolves.toMatchObject({
+      projectId: 'project-1',
+      governanceDecision: { candidateDigest: expect.stringMatching(/^sha256:/u) },
+    });
+    await expect(repository.readProject('project-1')).resolves.toMatchObject({
+      projectId: 'project-1',
     });
   });
 


### PR DESCRIPTION
## Summary
- canonicalize Project Data Governance authority candidates before requesting an exact publication decision
- verify the decision digest against the canonical persisted candidate
- cover Workroom disclosure bootstrap with the real file repository
- add a patch changeset for @zhin.js/agent

## Verification
- pnpm exec vitest run --root . packages/im/agent/tests (334 files, 2322 tests)
- pnpm turbo run build --filter='...@zhin.js/agent' --concurrency=1 (97 tasks)
- eslint on changed Agent source and tests

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Canonicalizes Project Data Governance authority candidates before requesting an exact publication decision, so Workroom disclosure bootstrap persists through the canonical repository without digest drift.

- Verifies the decision digest against the canonical persisted candidate.
- Adds a test that runs Workroom disclosure bootstrap against a real file repository.
- Adds a patch changeset for `@zhin.js/agent`.

<sup>Written for commit 337fd0599bae629a7d1df2f0ba3380b4e98afb0c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zhinjs/zhin/pull/646?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

## Sourcery 摘要

通过在授权和持久化之前始终对权威候选项进行规范化，防止治理引导摘要发生漂移。

错误修复：
- 在授权之前对项目数据治理权威候选项进行规范化，并验证已持久化的决策是否绑定到规范化候选项的摘要。
- 确保 Workroom 治理引导权威项能够通过文件存储库成功持久化，且不会发生摘要漂移。

增强功能：
- 集中处理权威候选项的规范化，以确保授权和持久化过程中的摘要计算保持一致。

测试：
- 增加使用规范文件存储库进行 Workroom 引导持久化的测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Prevent governance bootstrap digest drift by canonicalizing authority candidates consistently before authorization and persistence.

Bug Fixes:
- Canonicalize Project Data Governance authority candidates before authorization and verify that persisted decisions bind to the canonical candidate digest.
- Ensure Workroom governance bootstrap authorities persist successfully through the file repository without digest drift.

Enhancements:
- Centralize authority candidate canonicalization for consistent digest calculation across authorization and persistence.

Tests:
- Add coverage for Workroom bootstrap persistence using the canonical file repository.

</details>