### PR TITLE
fix(docs): render install tier includes

### DIFF
--- a/docs/en/getting-started/index.md
+++ b/docs/en/getting-started/index.md
@@ -67,8 +67,6 @@ Doctor checks Node, pnpm, ports, `HTTP_TOKEN`, CORS, and the project manifest. W
 
 ## Install tiers
 
-```md
-<<< ../../snippets/install-tiers.md#tiers-table
-```
+<!--@include: ../../snippets/install-tiers.md#tiers-table-en-->
 
 Prefer an outcome over learning the package graph first: [Choose a solution](../solutions/).

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -67,8 +67,6 @@ Doctor 会检查 Node、pnpm、端口、`HTTP_TOKEN`、CORS 和项目清单。�
 
 ## Install tiers
 
-```md
-<<< ../snippets/install-tiers.md#tiers-table
-```
+<!--@include: ../snippets/install-tiers.md#tiers-table-->
 
 继续学习时先选目标，不必先读完整包结构：[从问题选解决方案](../solutions/)。

--- a/docs/snippets/README.md
+++ b/docs/snippets/README.md
@@ -1,6 +1,6 @@
 # 文档片段（VitePress SSOT）
 
-可复用 Markdown 片段，供站点内 `<<<` 引用，避免多页重复维护。
+可复用 Markdown 片段，供站点内 VitePress Markdown include 引用，避免多页重复维护。
 
 ## Install tiers
 
@@ -13,18 +13,18 @@
 在 `docs/**/*.md` 中（路径相对当前文件）：
 
 ```md
-<<< ../snippets/install-tiers.md#tiers-table
+<!--@include: ../snippets/install-tiers.md#tiers-table-->
 
-<<< ../snippets/install-tiers.md#breaking
+<!--@include: ../snippets/install-tiers.md#breaking-->
 
-<<< ../snippets/install-tiers.md#imports
+<!--@include: ../snippets/install-tiers.md#imports-->
 ```
 
 可用区域名见 `install-tiers.md` 内 `<!-- #region ... -->` 注释。
 
 ### 非 VitePress 文件
 
-仓库根英文 [`README.md`](../../README.md)、中文 [`README.zh-CN.md`](../../README.zh-CN.md)、`packages/im/zhin/README.md` 无法使用 `<<<`。中文根 README 的分档表由 `pnpm check:install-tiers-ssot` 与本文件对齐；改表时请**同步** `install-tiers.md`，或链到 [快速开始 — Install tiers](https://zhin.js.org/getting-started/#install-tierszhinjs-4x)。
+仓库根英文 [`README.md`](../../README.md)、中文 [`README.zh-CN.md`](../../README.zh-CN.md)、`packages/im/zhin/README.md` 无法使用 VitePress Markdown include。中文根 README 的分档表由 `pnpm check:install-tiers-ssot` 与本文件对齐；改表时请**同步** `install-tiers.md`，或链到 [快速开始 — Install tiers](https://zhin.js.org/getting-started/#install-tierszhinjs-4x)。
 
 ### 验证
 

--- a/docs/snippets/install-tiers.md
+++ b/docs/snippets/install-tiers.md
@@ -1,9 +1,9 @@
 # Install tiers（文档片段 SSOT）
 
-用户向 **Install tiers / 安装分层** 文案的唯一来源。VitePress 页面用区域引用，勿在正文手抄表格。
+用户向 **Install tiers / 安装分层** 文案的唯一来源。VitePress 页面用 Markdown include 区域引用，勿在正文手抄表格。
 
 ```md
-<<< ../snippets/install-tiers.md#tiers-table
+<!--@include: ../snippets/install-tiers.md#tiers-table-->
 ```
 
 维护：改表只改本文件，然后 `pnpm docs:build` 验证。仓库根英文 `README.md` 为入口；中文 `README.zh-CN.md` 保留简表并由 `pnpm check:install-tiers-ssot` 对齐。
@@ -18,6 +18,17 @@
 | **Rich media** | `+ @zhin.js/html-renderer` | +~数 MB | 出站 `html` / `markdown` 转 PNG（未装则降级 text） |
 | **Speech** | `+ @zhin.js/speech` | +~数 MB | 入站 STT、出站 TTS、`segment.tts`（未装则 warn 降级） |
 <!-- #endregion tiers-table -->
+
+<!-- #region tiers-table-en -->
+| Tier | Install | ~production size | Capabilities |
+|------|---------|------------------|--------------|
+| **IM** | `pnpm add zhin.js` + an adapter (for example, `@zhin.js/adapter-sandbox`); dev: `@zhin.js/cli` | **&lt;10MB** (library) | Plugin Runtime; command / component / adapter convention directories (Stable Features inherited via `@zhin.js/core` `zhin.features`; Host is an optional peer + `zhin.plugins`, see [Plugin model](/en/concepts/plugin-model)) |
+| **AI** | `+ @zhin.js/agent zod ai` | +~12–15MB | ZhinAgent, sessions, tools, compaction |
+| **Provider** | `+ @ai-sdk/openai` etc. | per vendor | LLM calls |
+| **MCP** | `+ @modelcontextprotocol/sdk` | + a few MB | MCP client |
+| **Rich media** | `+ @zhin.js/html-renderer` | + a few MB | outbound `html` / `markdown` to PNG (falls back to text if missing) |
+| **Speech** | `+ @zhin.js/speech` | + a few MB | inbound STT, outbound TTS, `segment.tts` (warns and degrades if missing) |
+<!-- #endregion tiers-table-en -->
 
 <!-- #region tiers-table-host -->
 | 档位 | 安装 | 能力 |

--- a/tests/docs/install-tiers-rendering.test.ts
+++ b/tests/docs/install-tiers-rendering.test.ts
@@ -1,0 +1,43 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+
+const repoRoot = resolve(import.meta.dirname, '../..');
+
+function readRepoFile(path: string): string {
+  return readFileSync(resolve(repoRoot, path), 'utf8');
+}
+
+function extractRegion(markdown: string, region: string): string {
+  const match = markdown.match(
+    new RegExp(`<!-- #region ${region} -->\\n([\\s\\S]*?)\\n<!-- #endregion ${region} -->`),
+  );
+  if (!match) throw new Error(`Markdown region not found: ${region}`);
+  return match[1].trim();
+}
+
+describe('Install tiers Markdown includes', () => {
+  it.each([
+    {
+      pagePath: 'docs/getting-started/index.md',
+      includePath: '../snippets/install-tiers.md',
+      region: 'tiers-table',
+      tableHeader: '| 档位 | 安装 | 约 production 体积 | 能力 |',
+    },
+    {
+      pagePath: 'docs/en/getting-started/index.md',
+      includePath: '../../snippets/install-tiers.md',
+      region: 'tiers-table-en',
+      tableHeader: '| Tier | Install | ~production size | Capabilities |',
+    },
+  ])('renders the table as Markdown in $pagePath', ({ pagePath, includePath, region, tableHeader }) => {
+    const page = readRepoFile(pagePath);
+    const directive = `<!--@include: ${includePath}#${region}-->`;
+
+    expect(page).toContain(directive);
+    expect(page).not.toMatch(/```md\s*<<<[^\n]*install-tiers\.md/);
+
+    const snippetPath = resolve(repoRoot, dirname(pagePath), includePath);
+    const snippet = readFileSync(snippetPath, 'utf8');
+    expect(extractRegion(snippet, region)).toContain(tableHeader);
+  });
+});


### PR DESCRIPTION
## Summary

- replace fenced code samples with VitePress Markdown include directives
- render localized install-tier tables on Chinese and English getting-started pages
- document the correct include syntax and add regression coverage

## Validation

- pnpm exec vitest run tests/docs/install-tiers-rendering.test.ts
- pnpm exec vitepress build . (from docs/)
- pnpm check:doc-links
- pnpm check:install-tiers-ssot
- pnpm exec eslint tests/docs/install-tiers-rendering.test.ts

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the getting-started pages so the install-tier tables render as actual Markdown tables in VitePress instead of showing the previous `<<<` include as raw code.

- Replaces the fenced `<<<` code samples with `<!--@include: -->` directives in `docs/getting-started/index.md` and `docs/en/getting-started/index.md`.
- Adds an English `tiers-table-en` region to `docs/snippets/install-tiers.md`; the English page includes it, and the Chinese page keeps using `tiers-table`.
- Updates `docs/snippets/README.md` to document the new include syntax and adds regression coverage in `tests/docs/install-tiers-rendering.test.ts`.

<sup>Written for commit 0a6c50af9c5966de1d90ae7d33c12fb5af8672b0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zhinjs/zhin/pull/648?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

## Sourcery 总结

通过采用 VitePress Markdown 包含指令，并使用回归测试覆盖相关引用，修复本地化入门文档中的安装层级渲染问题。

错误修复：
- 将旧版围栏引用替换为 VitePress Markdown 包含指令，正确渲染中文和英文入门页面中的本地化安装层级表格。

改进：
- 记录受支持的 VitePress Markdown 包含语法，并在共享代码片段源中维护独立的本地化安装层级内容区域。

文档：
- 更新代码片段文档，说明 VitePress Markdown 包含及其使用限制。

测试：
- 添加回归测试，验证入门页面使用预期的包含指令，并引用正确的本地化表格区域。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix install-tier rendering in localized getting-started documentation by adopting VitePress Markdown includes and covering the references with regression tests.

Bug Fixes:
- Render localized install-tier tables correctly on the Chinese and English getting-started pages by replacing fenced legacy references with VitePress Markdown include directives.

Enhancements:
- Document the supported VitePress Markdown include syntax and maintain separate localized install-tier content regions in the shared snippet source.

Documentation:
- Update snippet documentation to describe VitePress Markdown includes and their usage limitations.

Tests:
- Add regression coverage verifying the getting-started pages use the expected include directives and reference the correct localized table regions.

</details>