### PR TITLE
fix(workroom): repair sponsor bootstrap and run authorization

### DIFF
--- a/.changeset/friendly-rivers-sponsor.md
+++ b/.changeset/friendly-rivers-sponsor.md
@@ -1,0 +1,7 @@
+---
+'@zhin.js/cli': patch
+'@zhin.js/host-http': patch
+'@zhin.js/agent': patch
+---
+
+Expose the token-bound Console principal for safe Workroom sponsor initialization, generate the missing governed Console disclosure sink, use one canonical Catalog binding digest, and renew stale Project disclosure authorities after Catalog or Sponsor changes.

--- a/basic/cli/src/plugin-runtime/agent-host-installer.ts
+++ b/basic/cli/src/plugin-runtime/agent-host-installer.ts
@@ -443,6 +443,7 @@ export function resolveWorkroomDisclosureBootstrap(
 export function assessWorkroomDisclosureSetup(input: Readonly<{
   resolution: WorkroomDisclosureBootstrapResolution;
   authorityPublished: boolean;
+  authorityCurrent: boolean;
   localIssuerAvailable: boolean;
 }>): Readonly<{
   disclosureReady: boolean;
@@ -463,13 +464,27 @@ export function assessWorkroomDisclosureSetup(input: Readonly<{
     diagnostics.push(`模型 Provider ${modelProviderAlias} 至少需要 project_internal 披露等级`);
   }
   if (!input.authorityPublished) diagnostics.push('尚未发布 Project Data Governance 披露 authority');
-  if (!input.localIssuerAvailable && !input.authorityPublished) {
+  else if (!input.authorityCurrent) {
+    diagnostics.push('Project Data Governance 披露 authority 未绑定当前 Catalog/Sponsor');
+  }
+  if (!input.localIssuerAvailable && !input.authorityCurrent) {
     diagnostics.push('Root-private Data Governance 签发能力不可用');
   }
   return Object.freeze({
-    disclosureReady: input.authorityPublished,
+    disclosureReady: input.authorityCurrent,
     disclosureConfigReady,
     diagnostics: Object.freeze(diagnostics),
+  });
+}
+
+export function resolveWorkroomDisclosureAuthorityPublication(
+  current: Readonly<{ revision: number; digest: string }> | undefined,
+  authorityCurrent: boolean,
+): Readonly<{ revision: number; previousDigest?: string }> | undefined {
+  if (authorityCurrent) return undefined;
+  return Object.freeze({
+    revision: (current?.revision ?? 0) + 1,
+    ...(current ? { previousDigest: current.digest } : {}),
   });
 }
 
@@ -929,6 +944,7 @@ export function installAgentHost(options: InstallAgentHostOptions): RootResource
       );
     };
     let workroomRuntime: WorkroomRuntimeHandle;
+    let consoleProjectionAuthority: ReturnType<typeof createCatalogGovernedWorkroomProjectionAuthority>;
     const dataGovernanceRuntimeRef: {
       current?: ReturnType<typeof installWorkroomDataGovernanceResources>;
     } = {};
@@ -950,7 +966,7 @@ export function installAgentHost(options: InstallAgentHostOptions): RootResource
 
       // Console reads the same replayed facts as tools; it never receives the
       // command authority or a mutable repository.
-      const consoleProjectionAuthority = createCatalogGovernedWorkroomProjectionAuthority({
+      consoleProjectionAuthority = createCatalogGovernedWorkroomProjectionAuthority({
         catalog: workroomCatalog,
         governance: Object.freeze({
           readProject: async (projectId: string) =>
@@ -1567,7 +1583,18 @@ export function installAgentHost(options: InstallAgentHostOptions): RootResource
       principalId: string;
     }>): Promise<void> => {
       const repository = dataGovernanceRuntime.options.repository;
-      if (await repository.readProject(input.projectId)) return;
+      const current = await repository.readProject(input.projectId);
+      const currentAuthorization = await consoleProjectionAuthority.authorize({
+        destination: 'console',
+        projectId: input.projectId,
+        recipientPrincipalId: input.principalId,
+        requestedMode: 'metadata_only',
+      });
+      const publication = resolveWorkroomDisclosureAuthorityPublication(
+        current,
+        currentAuthorization !== null,
+      );
+      if (!publication) return;
       if (!localDataGovernance) {
         throw new Error('Workroom 披露初始化缺少 Root-private Data Governance 签发能力');
       }
@@ -1582,7 +1609,8 @@ export function installAgentHost(options: InstallAgentHostOptions): RootResource
         projectId: input.projectId,
         tenantId: aiConfig.workroom?.disclosure?.tenantId ?? `workroom:${input.projectId}`,
         definition: input.definition,
-        revision: 1,
+        revision: publication.revision,
+        ...(publication.previousDigest ? { previousDigest: publication.previousDigest } : {}),
         model: {
           providerId: modelProviderAlias,
           endpoint: contract.endpoint,
@@ -1714,9 +1742,18 @@ export function installAgentHost(options: InstallAgentHostOptions): RootResource
         }
         const { modelProviderAlias, contract } = resolveDisclosureBootstrap(definition);
         const disclosureAuthority = await dataGovernanceRuntime.options.repository.readProject(projectId);
+        const disclosureAuthorization = principalId
+          ? await consoleProjectionAuthority.authorize({
+              destination: 'console',
+              projectId,
+              recipientPrincipalId: principalId,
+              requestedMode: 'metadata_only',
+            })
+          : null;
         const disclosure = assessWorkroomDisclosureSetup({
           resolution: { modelProviderAlias, contract },
           authorityPublished: disclosureAuthority !== undefined,
+          authorityCurrent: disclosureAuthorization !== null,
           localIssuerAvailable: localDataGovernance !== undefined,
         });
         diagnostics.push(...disclosure.diagnostics);

--- a/basic/cli/src/plugin-runtime/console-api-installer.ts
+++ b/basic/cli/src/plugin-runtime/console-api-installer.ts
@@ -834,6 +834,9 @@ export function registerConsoleApiRoutes(
             })])),
             workrooms: snapshot.definitions,
             revision: snapshot.revision,
+            ...(authenticatedPrincipal
+              ? { principalId: authenticatedPrincipal.principalId }
+              : {}),
           });
         },
         setWorkroomCatalog: async (workrooms, expectedRevision) => {

--- a/basic/cli/tests/plugin-runtime/agent-host-gaps.test.ts
+++ b/basic/cli/tests/plugin-runtime/agent-host-gaps.test.ts
@@ -36,6 +36,7 @@ import {
   resolveWorkroomTrustedPackPublishers,
   resolveWorkroomDisclosureBootstrap,
   assessWorkroomDisclosureSetup,
+  resolveWorkroomDisclosureAuthorityPublication,
 } from '../../src/plugin-runtime/agent-host-installer.js';
 import {
   createEndpointRoleResolver,
@@ -291,7 +292,7 @@ describe('Workroom Planning Console bootstrap', () => {
 
   it('reports each fail-closed disclosure setup prerequisite', () => {
     expect(assessWorkroomDisclosureSetup({
-      resolution: {}, authorityPublished: false, localIssuerAvailable: false,
+      resolution: {}, authorityPublished: false, authorityCurrent: false, localIssuerAvailable: false,
     })).toMatchObject({
       disclosureReady: false,
       disclosureConfigReady: false,
@@ -304,6 +305,7 @@ describe('Workroom Planning Console bootstrap', () => {
     expect(assessWorkroomDisclosureSetup({
       resolution: { modelProviderAlias: 'openrouter' },
       authorityPublished: false,
+      authorityCurrent: false,
       localIssuerAvailable: true,
     }).diagnostics).toContain('尚未配置 ai.workroom.disclosure.modelProviders.openrouter');
     expect(assessWorkroomDisclosureSetup({
@@ -317,6 +319,7 @@ describe('Workroom Planning Console bootstrap', () => {
         },
       },
       authorityPublished: true,
+      authorityCurrent: true,
       localIssuerAvailable: false,
     })).toMatchObject({
       disclosureReady: true,
@@ -334,8 +337,33 @@ describe('Workroom Planning Console bootstrap', () => {
         },
       },
       authorityPublished: false,
+      authorityCurrent: false,
       localIssuerAvailable: true,
     }).diagnostics).toContain('模型 Provider public-only 至少需要 project_internal 披露等级');
+  });
+
+  it('treats a Catalog-stale disclosure authority as not ready and advances its CAS chain', () => {
+    expect(assessWorkroomDisclosureSetup({
+      resolution: {},
+      authorityPublished: true,
+      authorityCurrent: false,
+      localIssuerAvailable: true,
+    })).toMatchObject({
+      disclosureReady: false,
+      diagnostics: expect.arrayContaining(['Project Data Governance 披露 authority 未绑定当前 Catalog/Sponsor']),
+    });
+    expect(resolveWorkroomDisclosureAuthorityPublication(undefined, false)).toEqual({ revision: 1 });
+    expect(resolveWorkroomDisclosureAuthorityPublication({
+      revision: 3,
+      digest: `sha256:${'a'.repeat(64)}`,
+    }, false)).toEqual({
+      revision: 4,
+      previousDigest: `sha256:${'a'.repeat(64)}`,
+    });
+    expect(resolveWorkroomDisclosureAuthorityPublication({
+      revision: 3,
+      digest: `sha256:${'a'.repeat(64)}`,
+    }, true)).toBeUndefined();
   });
 });
 

--- a/basic/cli/tests/plugin-runtime/console-api-installer.test.ts
+++ b/basic/cli/tests/plugin-runtime/console-api-installer.test.ts
@@ -793,6 +793,50 @@ describe('console REST routes', () => {
     expect(publishKnowledge).toHaveBeenCalledTimes(1);
   });
 
+  it('exposes the authenticated principal through the Workroom Catalog read contract', async () => {
+    await import('@zhin.js/agent/runtime');
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    const root = rootPluginId();
+    const readCatalog = vi.fn(async () => ({
+      revision: 'a'.repeat(64),
+      definitions: {},
+    }));
+    const snapshot = {
+      root,
+      resources: new Map([[root, new Map([[tokenId('zhin.host.agent'), {
+        console: {
+          sessionTree: {}, workroom: {}, assistant: null,
+          trace: { list: () => ({ sessionKey: '', events: [], latestSequence: 0, activeTurnIds: [] }) },
+          workroomCatalog: { read: readCatalog },
+          listBindings: () => [],
+        },
+      }]])]]),
+    } as unknown as RuntimeSnapshot;
+    const snapshots = {
+      acquire: () => ({ value: snapshot, active: true, release: () => undefined }),
+    } as unknown as SnapshotReader;
+    const { port } = await startHost({ projectRoot, withTokens: true, snapshots });
+
+    const sponsor = await fetch(`http://127.0.0.1:${port}/api/console/request`, {
+      method: 'POST',
+      headers: { authorization: 'Bearer sponsor-token', 'content-type': 'application/json' },
+      body: JSON.stringify({ type: 'workrooms:get', requestId: 31 }),
+    });
+    await expect(sponsor.json()).resolves.toMatchObject({
+      success: true,
+      data: { principalId: 'human:alice', workrooms: {}, revision: 'a'.repeat(64) },
+    });
+
+    const unbound = await fetch(`http://127.0.0.1:${port}/api/console/request`, {
+      method: 'POST',
+      headers: { authorization: 'Bearer full-token', 'content-type': 'application/json' },
+      body: JSON.stringify({ type: 'workrooms:get', requestId: 32, principalId: 'human:mallory' }),
+    });
+    const unboundBody = await unbound.json() as { data?: { principalId?: string } };
+    expect(unboundBody.data?.principalId).toBeUndefined();
+    expect(readCatalog).toHaveBeenCalledTimes(2);
+  });
+
   it('keeps Sponsor controls typed and injects the token principal without accepting forged identity', async () => {
     await import('@zhin.js/agent/runtime');
     await new Promise<void>((resolve) => setTimeout(resolve, 0));

--- a/packages/host/http/src/console-rpc.ts
+++ b/packages/host/http/src/console-rpc.ts
@@ -91,6 +91,8 @@ export type RuntimeConsoleRpcContext = {
     agents: Readonly<Record<string, unknown>>;
     workrooms: Readonly<Record<string, unknown>>;
     revision: string;
+    /** Principal bound to the authenticated Console token, never caller supplied. */
+    principalId?: string;
   }>>;
   setWorkroomCatalog?(
     workrooms: unknown,

--- a/packages/im/agent/src/plugin-runtime/workroom-assignment-authority-provider.ts
+++ b/packages/im/agent/src/plugin-runtime/workroom-assignment-authority-provider.ts
@@ -4,7 +4,11 @@ import { SkillIndex, skillFeatureId, type SkillDescriptor } from '@zhin.js/skill
 import type { ResolvedAgentBinding } from '../config/types.js';
 import type { GovernedDisclosureManifestSnapshot } from '../data-governance/disclosure-manifest.js';
 import type { WorkroomCatalog, WorkroomCatalogSnapshot } from '../workroom/catalog.js';
-import type { WorkroomDefinition } from '../workroom/catalog-definition.js';
+import {
+  digestWorkroomCatalogProjectBinding,
+  type WorkroomDefinition,
+} from '../workroom/catalog-definition.js';
+export { digestWorkroomCatalogProjectBinding } from '../workroom/catalog-definition.js';
 import {
   compareCanonicalWorkroomText,
   canonicalWorkroomJson,
@@ -473,10 +477,6 @@ export function createWorkroomAssignmentAuthorityGrant(
   });
   validateGrantProjection(projection);
   return deepFreeze({ ...projection, digest: digest(projection) });
-}
-
-export function digestWorkroomCatalogProjectBinding(definition: WorkroomDefinition): string {
-  return digest({ version: 1, definition: structuredClone(definition) });
 }
 
 export function digestWorkroomRemoteEndpointAuthority(

--- a/packages/im/agent/src/plugin-runtime/workroom-data-governance-authority-writer.ts
+++ b/packages/im/agent/src/plugin-runtime/workroom-data-governance-authority-writer.ts
@@ -11,7 +11,7 @@ import {
 import { join } from 'node:path';
 import type { WorkroomCatalog } from '../workroom/catalog.js';
 import { digestCanonicalWorkroomValue as digest } from '../workroom/canonical-value.js';
-import { digestWorkroomCatalogProjectBinding } from './workroom-assignment-authority-provider.js';
+import { digestWorkroomCatalogProjectBinding } from '../workroom/catalog-definition.js';
 
 export type ProjectDataGovernanceAuthorityCandidate = Omit<
   ProjectDataGovernanceAuthorityInput,

--- a/packages/im/agent/src/plugin-runtime/workroom-data-governance-bootstrap.ts
+++ b/packages/im/agent/src/plugin-runtime/workroom-data-governance-bootstrap.ts
@@ -114,6 +114,17 @@ export function createWorkroomDataGovernanceBootstrapCandidate(input: Readonly<{
         })),
       })
     : undefined;
+  const consoleRecipients = input.definition.sponsors?.length
+    ? createDisclosureRecipientSetSnapshot({
+        revision: input.revision,
+        recipients: input.definition.sponsors.map(principalId => ({
+          principalId,
+          tenantId: input.tenantId,
+          projectId: input.projectId,
+          clearance: 'project_internal' as const,
+        })),
+      })
+    : undefined;
   const sponsorDestination = input.definition.sponsorConversation && sponsorRecipients
     ? createProcessingDestinationContract({
         id: `workroom-sponsor-room:${input.projectId}`,
@@ -133,6 +144,27 @@ export function createWorkroomDataGovernanceBootstrapCandidate(input: Readonly<{
         supportsDeletion: true,
         recipientSnapshotRevision: sponsorRecipients.revision,
         recipientSnapshotDigest: sponsorRecipients.digest,
+      })
+    : undefined;
+  const consoleDestination = consoleRecipients
+    ? createProcessingDestinationContract({
+        id: `workroom-console:${input.projectId}`,
+        owner: `workroom:${input.projectId}`,
+        endpoint: `console://workroom/${encodeURIComponent(input.projectId)}`,
+        tenantId: input.tenantId,
+        projectId: input.projectId,
+        trustDomain: `workroom-console:${input.projectId}`,
+        processingRegions: ['local'],
+        maxConfidentiality: 'project_internal',
+        allowedCategories: [categoryId],
+        external: false,
+        noTraining: true,
+        loggingMode: 'metadata_only',
+        maximumRetentionSeconds: 86_400,
+        allowsRedisclosure: false,
+        supportsDeletion: true,
+        recipientSnapshotRevision: consoleRecipients.revision,
+        recipientSnapshotDigest: consoleRecipients.digest,
       })
     : undefined;
   const categoryRegistry = createDataCategoryRegistrySnapshot({
@@ -155,6 +187,7 @@ export function createWorkroomDataGovernanceBootstrapCandidate(input: Readonly<{
     [modelDestination.id]: modelDestination,
     [workroomDestination.id]: workroomDestination,
     ...(sponsorDestination ? { [sponsorDestination.id]: sponsorDestination } : {}),
+    ...(consoleDestination ? { [consoleDestination.id]: consoleDestination } : {}),
   };
   const policy = createDataGovernancePolicySnapshot({
     id: `workroom:${input.projectId}:policy`,
@@ -248,6 +281,20 @@ export function createWorkroomDataGovernanceBootstrapCandidate(input: Readonly<{
             allowedPurposes: ['portfolio_oversight' as const],
           },
           requestedMode: 'full' as const,
+        },
+      } : {}),
+      ...(consoleDestination && consoleRecipients ? {
+        'console:run-metadata': {
+          destinationId: consoleDestination.id,
+          channel: 'console' as const,
+          purpose: 'portfolio_oversight' as const,
+          recipients: consoleRecipients,
+          principal: {
+            role: 'sponsor' as const,
+            clearance: 'project_internal' as const,
+            allowedPurposes: ['portfolio_oversight' as const],
+          },
+          requestedMode: 'metadata_only' as const,
         },
       } : {}),
       'workroom-journal:kernel-replay': {

--- a/packages/im/agent/src/workroom/assignment-authority-grant-application.ts
+++ b/packages/im/agent/src/workroom/assignment-authority-grant-application.ts
@@ -1,10 +1,10 @@
 import type { MaterializedDisclosureManifest } from '../data-governance/disclosure-manifest.js';
 import {
   createWorkroomAssignmentAuthorityGrant,
-  digestWorkroomCatalogProjectBinding,
   type WorkroomAssignmentAuthorityGrant,
   type WorkroomCapabilityCeilingInput,
 } from '../plugin-runtime/workroom-assignment-authority-provider.js';
+import { digestWorkroomCatalogProjectBinding } from './catalog-definition.js';
 import type {
   AssignmentExecutionFactAnchor,
   AssignmentExecutionSnapshotReference,

--- a/packages/im/agent/src/workroom/catalog-definition.ts
+++ b/packages/im/agent/src/workroom/catalog-definition.ts
@@ -1,3 +1,5 @@
+import { digestCanonicalWorkroomValue as digest } from './canonical-value.js';
+
 export type WorkroomMemberRole = 'orchestrator' | 'executor' | 'reviewer' | 'integration';
 
 /**
@@ -49,6 +51,11 @@ export interface WorkroomDefinition {
   conversation?: WorkroomConversationBindingDefinition;
   /** Optional distinct collaboration space for authenticated Sponsor controls and projections. */
   sponsorConversation?: WorkroomConversationBindingDefinition;
+}
+
+/** Canonical digest used by every authority that binds one Catalog Project definition. */
+export function digestWorkroomCatalogProjectBinding(definition: WorkroomDefinition): string {
+  return digest({ version: 1, definition: structuredClone(definition) });
 }
 
 /** @deprecated Use WorkroomAgentMemberDefinition. */

--- a/packages/im/agent/src/workroom/runtime.ts
+++ b/packages/im/agent/src/workroom/runtime.ts
@@ -2,6 +2,7 @@ import type {
   DataGovernanceAuthorityRepository,
 } from '../data-governance/governance-authority-repository.js';
 import type { WorkroomCatalog } from './catalog.js';
+import { digestWorkroomCatalogProjectBinding } from './catalog-definition.js';
 import {
   deepFreezeWorkroomValue as deepFreeze,
   digestCanonicalWorkroomValue as digest,
@@ -231,7 +232,7 @@ export function createCatalogGovernedConsoleDisclosureAuthority(options: Readonl
       const definition = catalog.definitions[input.projectId];
       if (!definition || definition.enabled === false
         || policy.requireSponsor && !definition.sponsors?.includes(input.recipientPrincipalId)) return null;
-      const projectDigest = digest(definition);
+      const projectDigest = digestWorkroomCatalogProjectBinding(definition);
       const governance = await options.governance.readProject(input.projectId);
       if (!governance
         || governance.governanceDecision.catalogRevision !== catalog.revision

--- a/packages/im/agent/tests/plugin-runtime/workroom-data-governance-bootstrap.test.ts
+++ b/packages/im/agent/tests/plugin-runtime/workroom-data-governance-bootstrap.test.ts
@@ -13,6 +13,7 @@ import {
   WorkroomDataGovernanceAuthorityWriter,
 } from '../../src/plugin-runtime/workroom-data-governance-authority-writer.js';
 import { digestWorkroomCatalogProjectBinding } from '../../src/plugin-runtime/workroom-assignment-authority-provider.js';
+import { createCatalogGovernedWorkroomProjectionAuthority } from '../../src/workroom/runtime.js';
 
 describe('Workroom Data Governance bootstrap', () => {
   const definition = {
@@ -82,14 +83,31 @@ describe('Workroom Data Governance bootstrap', () => {
       },
     });
 
-    await expect(writer.publish({
+    const authority = await writer.publish({
       catalogRevision: 'catalog:1',
       catalogBindingDigest: digestWorkroomCatalogProjectBinding(definition),
       candidate,
-    }, new AbortController().signal)).resolves.toMatchObject({
+    }, new AbortController().signal);
+    expect(authority).toMatchObject({
       projectId: 'project-1',
       planning: { destinationId: 'model-provider:openrouter' },
     });
+    expect(authority.sinks['console:run-metadata']).toMatchObject({
+      channel: 'console',
+      purpose: 'portfolio_oversight',
+      requestedMode: 'metadata_only',
+      recipients: { recipients: [{ principalId: 'principal:sponsor' }] },
+    });
+    const consoleRead = createCatalogGovernedWorkroomProjectionAuthority({
+      catalog: { read: async () => ({ revision: 'catalog:1', definitions: { 'project-1': definition } }) },
+      governance: { readProject: async () => authority },
+    });
+    await expect(consoleRead.authorize({
+      destination: 'console',
+      projectId: 'project-1',
+      recipientPrincipalId: 'principal:sponsor',
+      requestedMode: 'metadata_only',
+    })).resolves.toMatchObject({ catalogRevision: 'catalog:1' });
   });
 
   it('persists the bootstrapped authority through the canonical file repository', async () => {

--- a/packages/im/agent/tests/workroom/runtime.test.ts
+++ b/packages/im/agent/tests/workroom/runtime.test.ts
@@ -5,6 +5,7 @@ import {
   createWorkroomRuntime,
 } from '../../src/workroom/runtime.js';
 import { digestCanonicalWorkroomValue as digest } from '../../src/workroom/canonical-value.js';
+import { digestWorkroomCatalogProjectBinding } from '../../src/workroom/catalog-definition.js';
 import {
   MemoryWorkroomJournal,
   MemoryWorkroomJournalPayloadPort,
@@ -173,7 +174,7 @@ describe('Workroom Console runtime projection', () => {
       sponsors: ['human:alice'],
     };
     const catalogRevision = digest({ definitions: { support: project } });
-    const projectDigest = digest(project);
+    const projectDigest = digestWorkroomCatalogProjectBinding(project);
     const recipientDigest = digest({ recipient: 'human:alice', projectId: 'support' });
     const governanceDigest = digest({ governance: 'support-v1' });
     const authority = createCatalogGovernedWorkroomProjectionAuthority({


### PR DESCRIPTION
## Summary
- expose the authenticated Console principal for safe Sponsor initialization
- generate the missing governed Console metadata sink and use the canonical Catalog binding digest
- detect and renew stale Data Governance authorities after Catalog or Sponsor changes
- add patch changesets and regression coverage

## Validation
- pnpm type-check
- pnpm check:architecture
- pnpm --filter @zhin.js/cli... build
- pnpm exec vitest run packages/im/agent/tests/plugin-runtime/workroom-data-governance-bootstrap.test.ts packages/im/agent/tests/plugin-runtime/workroom-data-governance-authority-writer.test.ts packages/im/agent/tests/workroom/runtime.test.ts basic/cli/tests/plugin-runtime/agent-host-gaps.test.ts
- pnpm exec vitest run basic/cli/tests/plugin-runtime/console-api-installer.test.ts

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Workroom sponsor bootstrap so the Console disclosure authority trusts only the authenticated sponsor principal and gets regenerated when the Catalog or Sponsor binding changes.

- Exposes the token-bound Console principal through the workroom catalog read contract; caller-supplied `principalId` values are ignored.
- Generates the missing governed Console metadata-only disclosure sink when a workroom has sponsors.
- Uses one canonical `digestWorkroomCatalogProjectBinding` for all authority digests so a stale authority is detected and republished with an incremented revision and previous digest.

<sup>Written for commit a728a20f7fbefd9c03bdcbdc022343ffa5c1b3fe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zhinjs/zhin/pull/650?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

