### PR TITLE
fix(workroom): restore end-to-end local execution

### DIFF
--- a/.changeset/calm-workrooms-recover.md
+++ b/.changeset/calm-workrooms-recover.md
@@ -1,0 +1,6 @@
+---
+"@zhin.js/agent": patch
+"@zhin.js/cli": patch
+---
+
+Repair Workroom bootstrap, planning, governed payload, Portfolio assignment, scheduling, projection, acceptance, and graceful shutdown flows so fresh self-hosted projects can execute `/work` end to end.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,24 +76,18 @@ jobs:
       - name: build packages (Windows)
         if: runner.os == 'Windows'
         run: |
-          # GitHub's pwsh wrapper treats native non-zero exits as terminating
-          # errors. Disable that behavior so this step can inspect pnpm's
-          # normalized exit and run the intended incremental retry.
-          $ErrorActionPreference = 'Continue'
-          if (Test-Path variable:PSNativeCommandUseErrorActionPreference) {
-            $PSNativeCommandUseErrorActionPreference = $false
-          }
-          pnpm build --concurrency=1
-          $firstBuildExit = $LASTEXITCODE
-          # pnpm normalizes Turbo/child-process native exits to code 1, so the
-          # original STATUS_DLL_INIT_FAILED value is not observable here. A
-          # second incremental pass reuses every completed Turbo task; a real
-          # compiler error remains red on the second pass.
-          if ($firstBuildExit -ne 0) {
-            Write-Warning "Windows build exited with $firstBuildExit; retrying incremental build once."
-            pnpm build --concurrency=1
-          }
-          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          # Invoke pnpm through Start-Process so GitHub's pwsh wrapper cannot
+          # terminate the script on a native STATUS_DLL_INIT_FAILED exit before
+          # the incremental retry starts.
+          $pnpm = (Get-Command pnpm.cmd -ErrorAction Stop).Source
+          $firstBuild = Start-Process -FilePath $pnpm -ArgumentList @('build', '--concurrency=1') -NoNewWindow -Wait -PassThru
+          if ($firstBuild.ExitCode -eq 0) { exit 0 }
+
+          # The second pass reuses every completed Turbo task. Transient process
+          # initialization failures recover, while real compiler errors stay red.
+          Write-Warning "Windows build exited with $($firstBuild.ExitCode); retrying incremental build once."
+          $retryBuild = Start-Process -FilePath $pnpm -ArgumentList @('build', '--concurrency=1') -NoNewWindow -Wait -PassThru
+          exit $retryBuild.ExitCode
 
       - name: build packages
         if: runner.os != 'Windows'

--- a/basic/cli/src/plugin-runtime/agent-host-installer.ts
+++ b/basic/cli/src/plugin-runtime/agent-host-installer.ts
@@ -17,6 +17,7 @@ import {
   type SendContent,
 } from '@zhin.js/core/runtime';
 import type { UserInteraction } from '@zhin.js/interaction';
+
 import {
   expandEnvironmentValue,
   type ConfigDocumentPort,
@@ -218,6 +219,7 @@ import {
   workroomTaskReportPayloadToken,
   type WorkroomEvidencePayloadWriteInput,
   createAgentCoreWorkroomLocalTurnPort,
+  structuredTaskReportPrompt,
   bindWorkroomCapabilityRealization,
   installWorkroomDataGovernanceResources,
   createWorkroomDataGovernanceBootstrapCandidate,
@@ -225,6 +227,7 @@ import {
   digestWorkroomCatalogProjectBinding,
   resolveWorkroomDataGovernanceRootAuthorities,
   createGenerationOwnedWorkroomDataGovernanceStorage,
+  assertAcceptanceProjectionDataGovernanceAuthority,
   createFileWorkroomDataLifecycleRuntime,
   createWorkroomDataLifecycleHumanIngressControlPort,
   createGenerationOwnedWorkroomJournalPayloadPort,
@@ -312,6 +315,11 @@ import {
   type PortfolioSponsorProjection,
 } from '@zhin.js/agent/runtime';
 import type { LocalWorkroomDataGovernanceAuthority } from './local-workroom-data-governance.js';
+import {
+  createLocalWorkroomAssignmentGrantProvider,
+  installLocalWorkroomPortfolioAuthorities,
+  LOCAL_WORKROOM_RESOURCE_REQUIREMENTS,
+} from './local-workroom-portfolio.js';
 
 export { AgentRuntime, AgentTurnCoordinator } from '@zhin.js/agent/runtime';
 
@@ -334,6 +342,7 @@ const WORKROOM_DYNAMIC_PLANNING_SYSTEM_PROMPT = `You produce one untrusted Workr
 Return exactly: {"version":1,"strategy":{"id":"...","version":"...","digest":"sha256:..."},"tasks":[...]}
 Each task must contain exactly: key, title, role, required, maxAttempts, localRank, dependsOn, requires, approval.
 requires must contain exactly tools, skills, integrations, authorities arrays. approval is "none" or "sponsor_required".
+Copy every requirement only from the matching supplied capability array: tools from tools, skills from skills, integrations from integrations, and authorities from authorities. Never classify a skill as a tool.
 Use only the supplied strategies, roles, capabilities and constraints. Include at least one required task.
 Do not output markdown, commentary, identity, authority, Project state, Sponsor lane, deadline, policy, assignment, or execution state.`;
 
@@ -486,6 +495,21 @@ export function resolveWorkroomDisclosureAuthorityPublication(
     revision: (current?.revision ?? 0) + 1,
     ...(current ? { previousDigest: current.digest } : {}),
   });
+}
+
+export function resolveWorkroomPlanningPolicyPublication(
+  current: Readonly<{ revision: number; digest: string }> | undefined,
+): Readonly<{ revision: number; expectedPreviousDigest?: string }> {
+  return Object.freeze({
+    revision: (current?.revision ?? 0) + 1,
+    ...(current ? { expectedPreviousDigest: current.digest } : {}),
+  });
+}
+
+export function isWorkroomPlanningPolicyReady(authority: Readonly<{
+  policy: Readonly<{ schedulerPolicy: Readonly<{ pinnedAtSequence: number }> }>;
+}> | undefined): boolean {
+  return authority?.policy.schedulerPolicy.pinnedAtSequence === 1;
 }
 
 export function resolveWorkroomStorageMode(ai: AIConfig | undefined): WorkroomStorageMode {
@@ -656,7 +680,25 @@ export function resolveCatalogSponsorProjectionConversation(
     id: string; name: string; adapter: string; owner: string;
   }>[],
 ): WorkroomProjectionBinding['conversation'] | undefined {
-  const configured = definition.sponsorConversation;
+  return resolveCatalogProjectionConversation(definition.sponsorConversation, endpoints);
+}
+
+/** Resolves a persisted Workroom conversation to one exact current Endpoint capability. */
+export function resolveCatalogWorkroomProjectionConversation(
+  definition: WorkroomDefinition,
+  endpoints: readonly Readonly<{
+    id: string; name: string; adapter: string; owner: string;
+  }>[],
+): WorkroomProjectionBinding['conversation'] | undefined {
+  return resolveCatalogProjectionConversation(definition.conversation, endpoints);
+}
+
+function resolveCatalogProjectionConversation(
+  configured: WorkroomDefinition['conversation'] | WorkroomDefinition['sponsorConversation'],
+  endpoints: readonly Readonly<{
+    id: string; name: string; adapter: string; owner: string;
+  }>[],
+): WorkroomProjectionBinding['conversation'] | undefined {
   if (!configured || configured.kind === 'repository') return undefined;
   const matches = endpoints.filter(endpoint =>
     endpoint.adapter === configured.adapter && endpoint.name === configured.endpoint);
@@ -1346,7 +1388,8 @@ export function installAgentHost(options: InstallAgentHostOptions): RootResource
       });
       if (!useDatabase) await dataGovernanceStorage.activateFile();
     }
-    const lifecycleAuthorities = rootDataGovernance?.lifecycle;
+    const lifecycleAuthorities = rootDataGovernance?.lifecycle
+      ?? localDataGovernance?.lifecycle;
     const dataLifecycle = dataGovernanceStorage && lifecycleAuthorities
       ? createFileWorkroomDataLifecycleRuntime({
           stateRoot: workroomStateRoot,
@@ -1418,9 +1461,12 @@ export function installAgentHost(options: InstallAgentHostOptions): RootResource
         ) {
           operationSignal.throwIfAborted();
           if (intent.consumer === 'journal_header') {
-            return workroomJournal.verifyGovernedPayloadPublication
+            const verification = workroomJournal.verifyGovernedPayloadPublication
               ? await workroomJournal.verifyGovernedPayloadPublication(intent)
               : Object.freeze({ status: 'unknown' as const });
+            return verification.status === 'missing'
+              ? Object.freeze({ status: 'unknown' as const })
+              : verification;
           }
           if (intent.consumer === 'evidence_header'
             || intent.consumer === 'task_report_header') {
@@ -1590,9 +1636,17 @@ export function installAgentHost(options: InstallAgentHostOptions): RootResource
         recipientPrincipalId: input.principalId,
         requestedMode: 'metadata_only',
       });
+      let acceptanceProjectionAuthorityCurrent = current !== undefined;
+      if (current) {
+        try {
+          assertAcceptanceProjectionDataGovernanceAuthority(current);
+        } catch {
+          acceptanceProjectionAuthorityCurrent = false;
+        }
+      }
       const publication = resolveWorkroomDisclosureAuthorityPublication(
         current,
-        currentAuthorization !== null,
+        currentAuthorization !== null && acceptanceProjectionAuthorityCurrent,
       );
       if (!publication) return;
       if (!localDataGovernance) {
@@ -1712,8 +1766,16 @@ export function installAgentHost(options: InstallAgentHostOptions): RootResource
         const activeRevision = active ? profiles.revisions[active.revisionId] : undefined;
         if (!active || !activeRevision) diagnostics.push('尚未发布并激活 Project Profile');
         let planningPolicyReady = false;
+        let acceptancePolicyReady = false;
         if (definition && active && activeRevision) {
           const profile = activeRevision.compiledProfile;
+          const acceptance = profile.acceptancePolicies ?? [];
+          acceptancePolicyReady = acceptance.length === 1
+            && profile.workflows.every(workflow => workflow.tasks.every(task =>
+              acceptance[0]!.tasks.some(policyTask => policyTask.taskKey === task.key)));
+          if (!acceptancePolicyReady) {
+            diagnostics.push('active Profile 尚未绑定覆盖 Workflow Task 的 Acceptance Policy');
+          }
           const authority = await profileComposition.planningPolicy.resolve({
             version: 1,
             generation: createWorkroomDynamicPlanningGenerationSnapshot(generation),
@@ -1737,8 +1799,11 @@ export function installAgentHost(options: InstallAgentHostOptions): RootResource
               },
             },
           });
-          planningPolicyReady = authority !== undefined;
-          if (!planningPolicyReady) diagnostics.push('active Profile 尚未绑定 Planning Policy');
+          planningPolicyReady = isWorkroomPlanningPolicyReady(authority);
+          if (!authority) diagnostics.push('active Profile 尚未绑定 Planning Policy');
+          else if (!planningPolicyReady) {
+            diagnostics.push('active Planning Policy 的 Scheduler 序列锚点已过期');
+          }
         }
         const { modelProviderAlias, contract } = resolveDisclosureBootstrap(definition);
         const disclosureAuthority = await dataGovernanceRuntime.options.repository.readProject(projectId);
@@ -1759,7 +1824,7 @@ export function installAgentHost(options: InstallAgentHostOptions): RootResource
         diagnostics.push(...disclosure.diagnostics);
         const { disclosureReady, disclosureConfigReady } = disclosure;
         const ready = catalogReady && activeRevision !== undefined && planningPolicyReady
-          && disclosureReady;
+          && acceptancePolicyReady && disclosureReady;
         return Object.freeze({
           projectId,
           ready,
@@ -1807,7 +1872,14 @@ export function installAgentHost(options: InstallAgentHostOptions): RootResource
         projectProfiles.read(command.projectId),
       ]);
       const definition = catalog.definitions[command.projectId]!;
-      if (before.planningPolicyReady) {
+      const activeRevision = before.activeProfile
+        ? profiles.revisions[before.activeProfile.revisionId]
+        : undefined;
+      const activeAcceptancePolicies = activeRevision?.compiledProfile.acceptancePolicies ?? [];
+      const activeAcceptanceReady = Boolean(activeRevision && activeAcceptancePolicies.length === 1
+        && activeRevision.compiledProfile.workflows.every(workflow => workflow.tasks.every(task =>
+          activeAcceptancePolicies[0]!.tasks.some(policyTask => policyTask.taskKey === task.key))));
+      if (before.planningPolicyReady && activeAcceptanceReady) {
         await ensureDisclosureAuthority({
           projectId: command.projectId,
           catalogRevision: catalog.revision,
@@ -1836,6 +1908,88 @@ export function installAgentHost(options: InstallAgentHostOptions): RootResource
         if (before.activeProfile) {
           const active = profiles.revisions[before.activeProfile.revisionId];
           if (!active) throw new Error('Active Project Profile revision is unavailable');
+          if (!activeAcceptanceReady) {
+            if ((active.compiledProfile.acceptancePolicies ?? []).length > 0) {
+              throw new Error('active Profile 的 Acceptance Policy 未完整覆盖 Workflow Task，请发布修订后的 Profile');
+            }
+            const acceptancePolicy = createBootstrapAcceptancePolicy({
+              projectId: command.projectId,
+              definition,
+              principalId: authenticatedPrincipal.principalId,
+              tasks: active.compiledProfile.workflows.flatMap(workflow => workflow.tasks),
+            });
+            const acceptancePack = createCapabilityPackManifest({
+              id: `workroom:${command.projectId}:acceptance-bootstrap`,
+              version: '1.0.0',
+              kind: 'policy',
+              acceptancePolicies: [acceptancePolicy],
+            });
+            const { digest: _acceptancePackDigest, ...acceptancePackInput } = acceptancePack;
+            const publication = await profileComposition.control.publishPack({
+              version: 1,
+              operationId: `${command.operationId}:acceptance-pack`,
+              authenticatedPrincipalId: authenticatedPrincipal.principalId,
+              pack: acceptancePackInput,
+            }, signal);
+            const upgradedOverlay = createWorkroomProfileOverlay({
+              version: 1,
+              projectId: command.projectId,
+              revisionId: `${active.revisionId}:acceptance:1`,
+              charterRevisionId: active.charterRevisionId,
+              parentRevisionId: active.revisionId,
+              packs: [...active.packRefs, publication.pack],
+              enabledTools: active.compiledProfile.tools.map(tool => tool.id),
+              enabledSkills: active.compiledProfile.skills.map(skill => skill.id),
+              enabledAgents: active.compiledProfile.agents.map(agent => agent.id),
+              enabledWorkflows: active.compiledProfile.workflows.map(workflow => workflow.id),
+              enabledMemories: active.compiledProfile.memories.map(memory => memory.id),
+              enabledGlossaries: active.compiledProfile.glossaries.map(glossary => glossary.id),
+              enabledAcceptancePolicies: [acceptancePolicy.id],
+            });
+            const upgraded = await profileComposition.control.publishProfile({
+              version: 1,
+              operationId: `${command.operationId}:acceptance-profile`,
+              authenticatedPrincipalId: authenticatedPrincipal.principalId,
+              projectId: command.projectId,
+              expectedRegistryRevision: profiles.registryRevision,
+              overlay: upgradedOverlay,
+              source: {
+                kind: 'sponsor_decision',
+                sourceId: `console-bootstrap:${command.operationId}:acceptance`,
+              },
+              activate: true,
+            }, signal);
+            const upgradedActive = upgraded.active!;
+            const currentPlanningPolicy = await profileComposition.control.readPlanningPolicy(
+              command.projectId,
+              upgradedActive.revisionId,
+            );
+            const planningPublication = resolveWorkroomPlanningPolicyPublication(currentPlanningPolicy);
+            await profileComposition.control.publishPlanningPolicy({
+              version: 1,
+              operationId: `${command.operationId}:policy`,
+              authenticatedPrincipalId: authenticatedPrincipal.principalId,
+              projectId: command.projectId,
+              catalogRevision: catalog.revision,
+              projectDigest: digestWorkroomProfileCatalogProject(definition),
+              profileRevisionId: upgradedActive.revisionId,
+              profileDigest: upgradedActive.compiledDigest,
+              ...planningPublication,
+              policy: artifacts.policy,
+            }, signal);
+            await ensureDisclosureAuthority({
+              projectId: command.projectId,
+              catalogRevision: catalog.revision,
+              definition,
+              principalId: authenticatedPrincipal.principalId,
+            });
+            return await readPlanningSetupStatus(command.projectId, authenticatedPrincipal);
+          }
+          const currentPlanningPolicy = await profileComposition.control.readPlanningPolicy(
+            command.projectId,
+            active.revisionId,
+          );
+          const planningPublication = resolveWorkroomPlanningPolicyPublication(currentPlanningPolicy);
           await profileComposition.control.publishPlanningPolicy({
             version: 1,
             operationId: `${command.operationId}:policy`,
@@ -1845,7 +1999,7 @@ export function installAgentHost(options: InstallAgentHostOptions): RootResource
             projectDigest: digestWorkroomProfileCatalogProject(definition),
             profileRevisionId: active.revisionId,
             profileDigest: active.compiledDigest,
-            revision: 1,
+            ...planningPublication,
             policy: artifacts.policy,
           }, signal);
           await ensureDisclosureAuthority({
@@ -1872,6 +2026,7 @@ export function installAgentHost(options: InstallAgentHostOptions): RootResource
           enabledSkills: artifacts.overlay.enabledSkills,
           enabledAgents: artifacts.overlay.enabledAgents,
           enabledWorkflows: artifacts.overlay.enabledWorkflows,
+          enabledAcceptancePolicies: artifacts.overlay.enabledAcceptancePolicies,
         });
         const profile = await profileComposition.control.publishProfile({
           version: 1,
@@ -1887,6 +2042,11 @@ export function installAgentHost(options: InstallAgentHostOptions): RootResource
           activate: true,
         }, signal);
         const active = profile.active!;
+        const currentPlanningPolicy = await profileComposition.control.readPlanningPolicy(
+          command.projectId,
+          active.revisionId,
+        );
+        const planningPublication = resolveWorkroomPlanningPolicyPublication(currentPlanningPolicy);
         await profileComposition.control.publishPlanningPolicy({
           version: 1,
           operationId: `${command.operationId}:policy`,
@@ -1896,7 +2056,7 @@ export function installAgentHost(options: InstallAgentHostOptions): RootResource
           projectDigest: digestWorkroomProfileCatalogProject(definition),
           profileRevisionId: active.revisionId,
           profileDigest: active.compiledDigest,
-          revision: 1,
+          ...planningPublication,
           policy: artifacts.policy,
         }, signal);
         await ensureDisclosureAuthority({
@@ -2260,6 +2420,7 @@ export function installAgentHost(options: InstallAgentHostOptions): RootResource
       resources,
       profiles: projectProfiles,
       catalog: workroomCatalog,
+      journal: workroomJournal,
       reports: workroomReports,
       projections: acceptanceProjections,
       riskHeaders: artifactRiskHeaders,
@@ -2343,6 +2504,13 @@ export function installAgentHost(options: InstallAgentHostOptions): RootResource
     if (!resources.has(portfolioControlOutboxRepositoryToken)) {
       resources.provide(portfolioControlOutboxRepositoryToken, portfolioControlOutbox);
     }
+    installLocalWorkroomPortfolioAuthorities({
+      generation,
+      resources,
+      catalog: workroomCatalog,
+      profiles: projectProfiles,
+      portfolioJournal: resources.use(portfolioJournalRepositoryToken),
+    });
     if (!resources.has(portfolioSponsorCommandToken)) {
       const portfolioSponsor = new WorkroomPortfolioSponsorRuntime({
         generation,
@@ -2422,13 +2590,31 @@ export function installAgentHost(options: InstallAgentHostOptions): RootResource
       catalog: workroomCatalog,
       profiles: projectProfiles,
       journal: workroomJournal,
+      runState: Object.freeze({
+        read: (projectId: string, runId: string) => workroomKernel.read(projectId, runId),
+        pinTaskAcceptance: (projectId: string, runId: string, taskKey: string) =>
+          workroomKernel.pinTaskAcceptance(projectId, runId, taskKey),
+      }),
+      fallbackResourceRequirements: LOCAL_WORKROOM_RESOURCE_REQUIREMENTS,
     });
     resources.provide(workroomAssignmentAuthorityGrantRepositoryToken, assignmentAuthorityGrants);
+    const durableAssignmentGrants = createDurableWorkroomAssignmentAuthorityGrantProvider({
+      repository: assignmentAuthorityGrants,
+      generation,
+    });
     resources.provide(
       workroomAssignmentAuthorityGrantToken,
-      createDurableWorkroomAssignmentAuthorityGrantProvider({
-        repository: assignmentAuthorityGrants,
+      createLocalWorkroomAssignmentGrantProvider({
         generation,
+        projectRoot: options.projectRoot,
+        repository: assignmentAuthorityGrants,
+        durable: durableAssignmentGrants,
+        journal: workroomJournal,
+        catalog: workroomCatalog,
+        profiles: projectProfiles,
+        runState: Object.freeze({
+          read: (projectId: string, runId: string) => workroomKernel.read(projectId, runId),
+        }),
       }),
     );
     resources.provide(
@@ -2532,6 +2718,24 @@ export function installAgentHost(options: InstallAgentHostOptions): RootResource
       maxRunsPerTick: 64,
       maxDeliveriesPerTick: 32,
       governance: governedOutbound.projection,
+      renewWorkroomBinding: async (projectId, catalog, operationSignal) => {
+        operationSignal.throwIfAborted();
+        const definition = catalog.definitions[projectId];
+        if (!definition) return;
+        const conversation = resolveCatalogWorkroomProjectionConversation(
+          definition,
+          options.im.listEndpoints(),
+        );
+        if (!conversation) return;
+        await ensureCatalogWorkroomProjectionBinding({
+          repository: projectionRepository,
+          catalog,
+          projectId,
+          conversation,
+          interactionBindingRevision: 1,
+          endpoints: options.im.listEndpoints(),
+        });
+      },
       resolveSponsorConversation: (_projectId, definition) =>
         resolveCatalogSponsorProjectionConversation(definition, options.im.listEndpoints()),
       ...(dataLifecycle ? { lifecycleOverdue: dataLifecycle.overdue } : {}),
@@ -2589,7 +2793,8 @@ export function installAgentHost(options: InstallAgentHostOptions): RootResource
             `Task identity: ${task.key}@${task.revision}`,
             `Workspace mount: ${request.envelope.workspace.mountRef}`,
             `Acceptance Contract: ${task.acceptanceContract?.id ?? 'missing'}`,
-            'Return only structured Task Report JSON with claims[] and evidence[].',
+            ...structuredTaskReportPrompt(),
+            'Do not use chat Subagent lifecycle or emit Task status commands.',
           ].join('\n');
         },
       });
@@ -2905,7 +3110,7 @@ export function installAgentHost(options: InstallAgentHostOptions): RootResource
         if (!definition.members.some(member => member.agent === agent && member.role === 'orchestrator')) {
           throw new Error(`Workroom Catalog ${projectId} has no valid Orchestrator binding`);
         }
-        const projectDigest = workroomProjectionCatalogBindingDigest(definition);
+        const projectDigest = digestWorkroomCatalogProjectBinding(definition);
         return Object.freeze({
           orchestratorAgentDefinitionId: agent,
           projectRevision: snapshot.revision,
@@ -2993,13 +3198,16 @@ export function installAgentHost(options: InstallAgentHostOptions): RootResource
     let humanIngressRetryTimer: ReturnType<typeof setTimeout> | undefined;
     let humanIngressRetryAt: number | undefined;
     const scheduleHumanIngressRetry = (retryAt: number) => {
+      if (signal.aborted) return;
       if (humanIngressRetryAt !== undefined && humanIngressRetryAt <= retryAt) return;
       if (humanIngressRetryTimer) clearTimeout(humanIngressRetryTimer);
       humanIngressRetryAt = retryAt;
       humanIngressRetryTimer = setTimeout(() => {
         humanIngressRetryTimer = undefined;
         humanIngressRetryAt = undefined;
+        if (signal.aborted) return;
         void recoverHumanIngress().catch(error => {
+          if (signal.aborted) return;
           logger.error(formatCompact({
             op: 'workroom_human_ingress_recovery',
             error: error instanceof Error ? error.message : String(error),
@@ -4730,8 +4938,15 @@ export function createWorkroomPlanningBootstrapArtifacts(input: Readonly<{
     key: `${role}-${index + 1}`,
     role,
     requires: {},
+    resourceRequirements: LOCAL_WORKROOM_RESOURCE_REQUIREMENTS,
   }));
   const workflowDigest = digestInstallerValue({ workflowId, workflowTasks });
+  const acceptancePolicy = createBootstrapAcceptancePolicy({
+    projectId: input.projectId,
+    definition: input.definition,
+    principalId: input.principalId,
+    tasks: workflowTasks,
+  });
   const pack = createCapabilityPackManifest({
     id: `workroom:${input.projectId}:bootstrap`,
     version: '1.0.0',
@@ -4754,6 +4969,7 @@ export function createWorkroomPlanningBootstrapArtifacts(input: Readonly<{
       requiredByProfile: true,
       tasks: workflowTasks,
     }],
+    acceptancePolicies: [acceptancePolicy],
   });
   const { digest: _packDigest, ...packInput } = pack;
   const revisionId = `profile:${input.projectId}:bootstrap:1`;
@@ -4767,6 +4983,7 @@ export function createWorkroomPlanningBootstrapArtifacts(input: Readonly<{
     enabledSkills: skillIds,
     enabledAgents: members.map(member => member.agent).sort(),
     enabledWorkflows: [workflowId],
+    enabledAcceptancePolicies: [acceptancePolicy.id],
   });
   const policy = createWorkroomDynamicPlanningPolicySnapshot({
     revisionId: `planning:${input.projectId}:1`,
@@ -4779,7 +4996,7 @@ export function createWorkroomPlanningBootstrapArtifacts(input: Readonly<{
     schedulerPolicy: createWorkroomSchedulerPolicySnapshot({
       policyRef: `scheduler:${input.projectId}:bootstrap`,
       revision: 1,
-      pinnedAtSequence: 0,
+      pinnedAtSequence: 1,
       capacity: Math.max(1, Math.min(4, taskRoles.length)),
       agingStepMs: 30_000,
       starvationBoundMs: {
@@ -4791,7 +5008,65 @@ export function createWorkroomPlanningBootstrapArtifacts(input: Readonly<{
     defaultTaskDeadlineMs: 60 * 60_000,
     defaultPreemptibility: 'atomic',
   });
-  return Object.freeze({ pack, packInput: Object.freeze(packInput), overlay, policy, revisionId, workflowId });
+  return Object.freeze({
+    pack,
+    packInput: Object.freeze(packInput),
+    overlay,
+    policy,
+    acceptancePolicy,
+    revisionId,
+    workflowId,
+  });
+}
+
+function createBootstrapAcceptancePolicy(input: Readonly<{
+  projectId: string;
+  definition: WorkroomDefinition;
+  principalId: string;
+  tasks: readonly Readonly<{ key: string; role: string }>[];
+}>) {
+  if (!input.definition.sponsors?.includes(input.principalId)) {
+    throw new Error(`principal ${input.principalId} 不在 Project sponsors`);
+  }
+  const reviewers = input.definition.members.filter(member => member.role === 'reviewer');
+  if (reviewers.length !== 1) {
+    throw new Error('Workroom Acceptance Policy 需要且只能配置一个 reviewer 成员');
+  }
+  const templates = new Map<string, Readonly<{ key: string; role: string }>>();
+  for (const task of input.tasks) {
+    const current = templates.get(task.key);
+    if (current && current.role !== task.role) {
+      throw new Error(`Workroom Task 模板 ${task.key} 的角色不唯一`);
+    }
+    templates.set(task.key, Object.freeze({ key: task.key, role: task.role }));
+  }
+  if (templates.size === 0) {
+    throw new Error('Workroom Acceptance Policy 缺少 Workflow Task 模板');
+  }
+  const id = `workroom:${input.projectId}:acceptance`;
+  const tasks = [...templates.values()]
+    .sort((left, right) => left.key.localeCompare(right.key))
+    .map(task => ({
+      taskKey: task.key,
+      kind: task.role === 'integration' ? 'integration_candidate' as const : 'task_result' as const,
+      criteria: [{
+        id: 'reviewer-verdict',
+        kind: 'judgment' as const,
+        description: 'Reviewer verifies the task report, evidence, and governed artifacts against the task objective.',
+      }],
+      requiredEvidence: [],
+      minimumRoute: 'reviewer_required' as const,
+      reviewerPrincipalId: reviewers[0]!.agent,
+      sponsorPrincipalId: input.principalId,
+      reviewerTimeoutMs: 15 * 60_000,
+      sponsorTimeoutMs: 15 * 60_000,
+    }));
+  const body = Object.freeze({
+    id,
+    tasks,
+    memorySchema: Object.freeze({ revision: 1 as const, claimRules: Object.freeze([]) }),
+  });
+  return Object.freeze({ ...body, digest: digestInstallerValue(body) });
 }
 
 function digestInstallerValue(value: unknown): string {

--- a/basic/cli/src/plugin-runtime/local-workroom-data-governance.ts
+++ b/basic/cli/src/plugin-runtime/local-workroom-data-governance.ts
@@ -8,8 +8,10 @@ import {
 } from 'node:crypto';
 import { open, readFile, stat } from 'node:fs/promises';
 import { join } from 'node:path';
-import type {
-  WorkroomDataGovernancePublicationDecision,
+import {
+  digestCanonicalWorkroomValue,
+  type WorkroomDataGovernancePublicationDecision,
+  type WorkroomDataGovernanceRootProviderResolution,
   installWorkroomDataGovernanceResources,
 } from '@zhin.js/agent/runtime';
 
@@ -20,6 +22,13 @@ type VerificationPort = NonNullable<
 Parameters<typeof installWorkroomDataGovernanceResources>[0]['governance']
 >;
 type GovernanceDecision = Parameters<VerificationPort['verify']>[0];
+type LifecycleAuthorities = NonNullable<WorkroomDataGovernanceRootProviderResolution['lifecycle']>;
+type LifecycleAuthorizationRequest = Parameters<LifecycleAuthorities['authority']['authorize']>[0];
+type LifecycleAuthorizationDecision = Parameters<LifecycleAuthorities['authority']['verify']>[1];
+type LifecycleDeletionDispatch = Parameters<LifecycleAuthorities['deletion']['purge']>[0];
+type LifecyclePurgeReceipt = Parameters<LifecycleAuthorities['receipts']['verify']>[0];
+type LifecycleOrphanPurgeRequest = Parameters<LifecycleAuthorities['orphanPurge']['purge']>[0];
+type LifecycleOrphanPurgeReceipt = Parameters<LifecycleAuthorities['orphanPurge']['reconcile']>[1];
 
 interface LocalRootKeyDocument {
   readonly version: 1;
@@ -30,6 +39,7 @@ interface LocalRootKeyDocument {
 export interface LocalWorkroomDataGovernanceAuthority {
   readonly cryptography: CryptographyPort;
   readonly verification: VerificationPort;
+  readonly lifecycle: LifecycleAuthorities;
   issuePublicationDecision(input: Readonly<{
     projectId: string;
     catalogRevision: string;
@@ -110,9 +120,117 @@ export function createLocalWorkroomDataGovernanceAuthority(options: Readonly<{
     },
   });
 
+  const lifecyclePrincipalId = 'local-workroom-data-steward';
+  const lifecycleAuthority: LifecycleAuthorities['authority'] = Object.freeze({
+    async authorize(request: LifecycleAuthorizationRequest) {
+      if (request.authenticatedPrincipalId !== lifecyclePrincipalId) {
+        return Object.freeze({
+          approved: false as const,
+          requestDigest: request.digest,
+          reason: 'local_root_principal_required',
+        });
+      }
+      const rootKey = await key();
+      const decidedAt = request.clock.now;
+      const proof = lifecycleDecisionProof(request, decidedAt);
+      const decisionId = signDecision(rootKey.key, proof);
+      return Object.freeze({
+        approved: true as const,
+        requestDigest: request.digest,
+        decisionId,
+        principalId: request.authenticatedPrincipalId,
+        role: request.requiredRole,
+        authorityDigest: digestCanonicalWorkroomValue({
+          kind: 'local-workroom-lifecycle-authority',
+          requestDigest: request.digest,
+          decisionId,
+        }),
+        decidedAt,
+      });
+    },
+    async verify(request: LifecycleAuthorizationRequest, decision: LifecycleAuthorizationDecision) {
+      if (decision.requestDigest !== request.digest
+        || decision.principalId !== request.authenticatedPrincipalId
+        || decision.role !== request.requiredRole
+        || decision.decidedAt !== request.clock.now) return false;
+      const rootKey = await key();
+      const expectedDecisionId = signDecision(
+        rootKey.key,
+        lifecycleDecisionProof(request, decision.decidedAt),
+      );
+      return decision.decisionId === expectedDecisionId
+        && decision.authorityDigest === digestCanonicalWorkroomValue({
+          kind: 'local-workroom-lifecycle-authority',
+          requestDigest: request.digest,
+          decisionId: decision.decisionId,
+        });
+    },
+  });
+  const lifecycle: LifecycleAuthorities = Object.freeze({
+    registrationPrincipalId: lifecyclePrincipalId,
+    clock: Object.freeze({
+      async read() {
+        const body = Object.freeze({ version: 1 as const, now: now(), revision: 1 });
+        return Object.freeze({ ...body, digest: digestCanonicalWorkroomValue(body) });
+      },
+    }),
+    authority: lifecycleAuthority,
+    subjects: Object.freeze({ resolve: async () => undefined }),
+    deletion: Object.freeze({
+      async purge(dispatch: LifecycleDeletionDispatch) {
+        const body = Object.freeze({
+          version: 1 as const,
+          purgeId: dispatch.id,
+          projectId: dispatch.governance.request.projectId,
+          objectId: dispatch.governance.request.objectId,
+          locationId: dispatch.location.id,
+          locationAuthorityDigest: dispatch.location.authorityDigest,
+          locationManifestDigest: dispatch.locationManifestDigest,
+          attempt: dispatch.attempt,
+          fence: dispatch.fence,
+          requestDigest: dispatch.requestDigest,
+          status: 'failed' as const,
+          reasonCode: 'unsupported' as const,
+          authenticatedBy: lifecyclePrincipalId,
+          observedAt: Math.max(now(), dispatch.requestedAt),
+          authorityDigest: digestCanonicalWorkroomValue({
+            kind: 'local-workroom-lifecycle-deletion',
+            purgeDigest: dispatch.digest,
+          }),
+        });
+        return Object.freeze({ ...body, digest: digestCanonicalWorkroomValue(body) });
+      },
+    }),
+    receipts: Object.freeze({
+      async verify(receipt: LifecyclePurgeReceipt, dispatch: LifecycleDeletionDispatch) {
+        const { digest, ...body } = receipt;
+        return receipt.requestDigest === dispatch.requestDigest
+          && receipt.locationId === dispatch.location.id
+          && receipt.authorityDigest === digestCanonicalWorkroomValue({
+            kind: 'local-workroom-lifecycle-deletion',
+            purgeDigest: dispatch.digest,
+          })
+          && digest === digestCanonicalWorkroomValue(body);
+      },
+    }),
+    orphanPurge: Object.freeze({
+      async purge(request: LifecycleOrphanPurgeRequest) {
+        return createLocalOrphanPurgeReceipt(request.digest, now());
+      },
+      async reconcile(
+        request: LifecycleOrphanPurgeRequest,
+        previous: LifecycleOrphanPurgeReceipt,
+      ) {
+        if (previous?.requestDigest === request.digest) return previous;
+        return createLocalOrphanPurgeReceipt(request.digest, now());
+      },
+    }),
+  });
+
   return Object.freeze({
     cryptography,
     verification,
+    lifecycle,
     async issuePublicationDecision(
       input: Parameters<LocalWorkroomDataGovernanceAuthority['issuePublicationDecision']>[0],
       signal: Parameters<LocalWorkroomDataGovernanceAuthority['issuePublicationDecision']>[1],
@@ -204,7 +322,28 @@ function decisionBody(decision: GovernanceDecision) {
   });
 }
 
-function signDecision(key: Buffer, body: ReturnType<typeof decisionBody>): string {
+function lifecycleDecisionProof(request: LifecycleAuthorizationRequest, decidedAt: number) {
+  return Object.freeze({
+    kind: 'local-workroom-lifecycle-decision',
+    requestDigest: request.digest,
+    principalId: request.authenticatedPrincipalId,
+    role: request.requiredRole,
+    decidedAt,
+  });
+}
+
+function createLocalOrphanPurgeReceipt(requestDigest: string, observedAt: number) {
+  const body = Object.freeze({
+    version: 1 as const,
+    requestDigest,
+    providerId: 'local-workroom-orphan-purge',
+    status: 'outcome_unknown' as const,
+    observedAt,
+  });
+  return Object.freeze({ ...body, digest: digestCanonicalWorkroomValue(body) });
+}
+
+function signDecision(key: Buffer, body: object): string {
   const digest = createHmac('sha256', key)
     .update(JSON.stringify(body))
     .digest('hex');

--- a/basic/cli/src/plugin-runtime/local-workroom-portfolio.ts
+++ b/basic/cli/src/plugin-runtime/local-workroom-portfolio.ts
@@ -1,0 +1,526 @@
+import { createHash } from 'node:crypto';
+import type { Scope } from '@zhin.js/plugin-runtime';
+import {
+  assertWorkflowPlanProposal,
+  assignmentAuthorityGrantKey,
+  createAssignmentAuthorityGrantRecord,
+  createAtomicResourceBundleProfileCeiling,
+  createPortfolioPolicySnapshot,
+  createResourcePoolCatalogSnapshot,
+  parseWorkroomDispatchTaskDecision,
+  portfolioKernelCommandDigest,
+  replayPortfolioAdmission,
+  validateAtomicResourceBundle,
+  workroomLocalAssignmentId,
+  type AssignmentAuthorityGrantRepository,
+  type PortfolioJournalRepository,
+  type PortfolioResourceBundle,
+  type ProjectProfileRegistry,
+  type WorkroomCatalog,
+  type WorkroomJournal,
+  type WorkroomKernel,
+  type WorkflowPlanProposal,
+} from '@zhin.js/agent';
+import {
+  createWorkroomAssignmentAuthorityGrant,
+  digestCanonicalWorkroomValue,
+  digestWorkroomCatalogProjectBinding,
+  portfolioAtomicBundleAuthorityToken,
+  portfolioKernelCommandAuthorityToken,
+  portfolioPolicyAuthorityToken,
+  workroomSchedulerPortfolioScopeAuthorityToken,
+  workroomSchedulerPortfolioScopeBindingDigest,
+  type WorkroomAssignmentAuthorityGrantPort,
+  type PortfolioAtomicBundleAuthorityPort,
+  type PortfolioKernelCommandAuthorityPort,
+  type PortfolioPolicyAuthorityPort,
+  type WorkroomSchedulerPortfolioScopeAuthorityPort,
+} from '@zhin.js/agent/runtime';
+
+export const LOCAL_WORKROOM_MODEL_POOL_ID = 'model:local';
+export const LOCAL_WORKROOM_EXECUTOR_POOL_ID = 'executor:local';
+export const LOCAL_WORKROOM_RESOURCE_REQUIREMENTS: PortfolioResourceBundle = Object.freeze({
+  demands: Object.freeze([
+    Object.freeze({
+      poolId: LOCAL_WORKROOM_MODEL_POOL_ID,
+      capacityUnits: 1,
+      rateUnits: 1,
+      budgetUnits: 1,
+    }),
+    Object.freeze({
+      poolId: LOCAL_WORKROOM_EXECUTOR_POOL_ID,
+      capacityUnits: 1,
+      rateUnits: 1,
+      budgetUnits: 0,
+    }),
+  ]),
+});
+
+const LOCAL_ASSIGNMENT_GRANT_TTL_MS = 7 * 24 * 60 * 60 * 1_000;
+
+interface LocalAssignmentGrantOptions {
+  readonly generation: number;
+  readonly projectRoot: string;
+  readonly repository: AssignmentAuthorityGrantRepository;
+  readonly durable: WorkroomAssignmentAuthorityGrantPort;
+  readonly journal: Pick<WorkroomJournal, 'read'>;
+  readonly catalog: Pick<WorkroomCatalog, 'read'>;
+  readonly profiles: Pick<ProjectProfileRegistry, 'read'>;
+  readonly runState: Pick<WorkroomKernel, 'read'>;
+}
+
+type LocalAssignmentGrantRequest = Parameters<WorkroomAssignmentAuthorityGrantPort['resolve']>[0];
+
+/**
+ * Materializes the Root-local Assignment grant from exact durable Workroom
+ * facts, persists it with CAS, then delegates every read to the ordinary
+ * durable grant provider. Remote grants are never synthesized here.
+ */
+export function createLocalWorkroomAssignmentGrantProvider(
+  options: Readonly<LocalAssignmentGrantOptions>,
+): WorkroomAssignmentAuthorityGrantPort {
+  return Object.freeze({
+    resolve: async (request: LocalAssignmentGrantRequest) => {
+      const persisted = await options.durable.resolve(request);
+      if (persisted || request.requestedEndpointId !== undefined) return persisted;
+      const prepared = await prepareLocalAssignmentGrant(options, request);
+      return await options.durable.resolve(request) ?? prepared;
+    },
+  });
+}
+
+async function prepareLocalAssignmentGrant(
+  options: Readonly<LocalAssignmentGrantOptions>,
+  request: LocalAssignmentGrantRequest,
+) {
+  const [events, state, registry, catalog] = await Promise.all([
+    options.journal.read(request.runId),
+    options.runState.read(request.projectId, request.runId),
+    options.profiles.read(request.projectId),
+    options.catalog.read(),
+  ]);
+  if (state.projectId !== request.projectId || state.runId !== request.runId) {
+    throw new Error('Local Assignment Grant Project/Run scope drift');
+  }
+  const task = state.tasks[request.taskKey];
+  if (!task || task.status !== 'ready' || !task.acceptanceContract
+    || task.revision !== request.taskRevision || task.attempt + 1 !== request.attempt) {
+    throw new Error('Local Assignment Grant targets a stale or unpinned Task');
+  }
+  const expectedFence = Object.values(state.assignments)
+    .filter(assignment => assignment.taskKey === task.key)
+    .reduce((highest, assignment) => Math.max(highest, assignment.fence), 0) + 1;
+  if (expectedFence !== request.fence || request.assignmentRevision !== 1) {
+    throw new Error('Local Assignment Grant attempt or fence drift');
+  }
+  const schedulerFacts = events.filter(event => event.type === 'scheduler.dispatch_requested'
+    && workroomLocalAssignmentId(String(event.payload.decisionId ?? '')) === request.assignmentId);
+  if (schedulerFacts.length !== 1) {
+    throw new Error('Local Assignment Grant requires one exact Scheduler decision fact');
+  }
+  const schedulerFact = schedulerFacts[0]!;
+  const decision = parseWorkroomDispatchTaskDecision(schedulerFact.payload);
+  if (decision.projectId !== request.projectId || decision.runId !== request.runId
+    || decision.taskKey !== request.taskKey || decision.taskRevision !== request.taskRevision
+    || workroomLocalAssignmentId(decision.decisionId) !== request.assignmentId
+    || (decision.role !== 'executor' && decision.role !== 'integration')) {
+    throw new Error('Local Assignment Grant Scheduler decision scope drift');
+  }
+  const pin = registry.runPins[request.runId];
+  const revision = pin && registry.revisions[pin.profileRevisionId];
+  if (!pin || !revision || pin.projectId !== request.projectId
+    || revision.compiledDigest !== pin.profileDigest
+    || revision.compiledProfile.projectId !== request.projectId
+    || revision.compiledProfile.revisionId !== pin.profileRevisionId
+    || revision.compiledProfile.digest !== pin.profileDigest) {
+    throw new Error('Local Assignment Grant requires an exact persisted Run Profile pin');
+  }
+  const definition = catalog.definitions[request.projectId];
+  const member = definition?.members.find(candidate =>
+    candidate.agent === request.requestedAgentDefinitionId && candidate.role === decision.role);
+  if (!definition || definition.enabled === false || !member
+    || member.assignmentRoute?.kind === 'remote') {
+    throw new Error('Local Assignment Grant route is outside the exact Catalog role binding');
+  }
+  const profileAgent = revision.compiledProfile.agents.find(candidate =>
+    candidate.id === request.requestedAgentDefinitionId && candidate.role === member.role);
+  if (!profileAgent) throw new Error('Local Assignment Grant Agent is outside the pinned Profile');
+  const planFacts = events.filter(event => event.type === 'plan.admitted');
+  if (planFacts.length !== 1) throw new Error('Local Assignment Grant requires one admitted Plan');
+  const planFact = planFacts[0]!;
+  const plan = planFact.payload.plan as WorkflowPlanProposal;
+  assertWorkflowPlanProposal(plan);
+  if (plan.projectId !== request.projectId) {
+    throw new Error('Local Assignment Grant Plan Project scope drift');
+  }
+  if (plan.authority.profileRevisionId !== pin.profileRevisionId
+    || plan.authority.profileDigest !== pin.profileDigest) {
+    throw new Error('Local Assignment Grant Plan Profile pin drift');
+  }
+  if (plan.authority.projectRevision !== catalog.revision) {
+    throw new Error('Local Assignment Grant Plan Catalog revision drift');
+  }
+  if (plan.authority.projectDigest !== digestWorkroomCatalogProjectBinding(definition)) {
+    throw new Error('Local Assignment Grant Plan Catalog binding drift');
+  }
+  const plannedTask = plan.tasks.find(candidate => candidate.key === request.taskKey);
+  if (!plannedTask || plannedTask.role !== decision.role) {
+    throw new Error('Local Assignment Grant Task is absent from the admitted Plan');
+  }
+  const tools = profileAgent.allowedTools.map(name => {
+    const tool = revision.compiledProfile.tools.find(candidate => candidate.id === name);
+    if (!tool) throw new Error(`Local Assignment Grant Tool ${name} is absent from the pinned Profile`);
+    return Object.freeze({ name: tool.id, digest: tool.digest });
+  });
+  const skills = profileAgent.allowedSkills.map(name => {
+    const skill = revision.compiledProfile.skills.find(candidate => candidate.id === name);
+    if (!skill) throw new Error(`Local Assignment Grant Skill ${name} is absent from the pinned Profile`);
+    return Object.freeze({
+      name: skill.id,
+      digest: skill.digest,
+      requiredTools: skill.requiresTools,
+    });
+  });
+  const factDigest = digestCanonicalWorkroomValue(events);
+  const factAnchor = Object.freeze({
+    ref: `workroom-journal:${encodeURIComponent(request.runId)}:${state.sequence}`,
+    sequence: state.sequence,
+    digest: factDigest,
+  });
+  const capabilityRevision = pin.activationRegistryRevision + 1;
+  const ceiling = (id: string, revisionNumber: number) =>
+    Object.freeze({ id, revision: revisionNumber, tools, skills });
+  const grant = createWorkroomAssignmentAuthorityGrant({
+    generation: options.generation,
+    projectId: request.projectId,
+    runId: request.runId,
+    taskKey: request.taskKey,
+    taskRevision: request.taskRevision,
+    assignmentId: request.assignmentId,
+    assignmentRevision: request.assignmentRevision,
+    attempt: request.attempt,
+    fence: request.fence,
+    agentDefinitionId: request.requestedAgentDefinitionId,
+    catalogRevision: catalog.revision,
+    catalogBindingDigest: digestWorkroomCatalogProjectBinding(definition),
+    profileRevisionId: pin.profileRevisionId,
+    profileDigest: pin.profileDigest,
+    principalId: `agent:${request.requestedAgentDefinitionId}`,
+    role: decision.role,
+    capabilitySnapshotRef:
+      `local-capability:${encodeURIComponent(request.assignmentId)}:${request.assignmentRevision}`,
+    capabilitySnapshotRevision: capabilityRevision,
+    roleCapabilities: ceiling(`role:${decision.role}:${pin.profileRevisionId}`, capabilityRevision),
+    taskCapabilities: ceiling(`task:${request.taskKey}:${request.taskRevision}`, request.taskRevision),
+    policyCapabilities: ceiling(`policy:${pin.profileRevisionId}`, capabilityRevision),
+    plan: Object.freeze({
+      ref: `workflow-plan:${encodeURIComponent(plan.proposalId)}`,
+      revision: planFact.sequence + 1,
+      digest: plan.digest,
+    }),
+    contextPolicy: Object.freeze({
+      ref: `planning-policy:${encodeURIComponent(plan.authority.planningPolicyRevisionId)}`,
+      revision: planFact.sequence + 1,
+      digest: plan.authority.planningPolicyDigest,
+    }),
+    policySnapshot: Object.freeze({
+      ref: `workroom-profile:${encodeURIComponent(pin.profileRevisionId)}`,
+      revision: capabilityRevision,
+      digest: pin.profileDigest,
+    }),
+    workspace: Object.freeze({
+      leaseRef: `local-workspace:${encodeURIComponent(request.assignmentId)}:${request.fence}`,
+      mountRef: options.projectRoot,
+      baseRevision: plan.digest,
+      fence: request.fence,
+    }),
+    contextView: Object.freeze({ ref: factAnchor.ref, hash: factDigest }),
+    capabilityGrantRef:
+      `local-grant:${encodeURIComponent(request.assignmentId)}:${request.assignmentRevision}`,
+  });
+  const assignmentKey = assignmentAuthorityGrantKey({ ...request, generation: options.generation });
+  const current = await options.repository.read(assignmentKey);
+  const now = Date.now();
+  const record = createAssignmentAuthorityGrantRecord({
+    assignmentKey,
+    revision: (current?.revision ?? 0) + 1,
+    ...(current ? { previousDigest: current.digest } : {}),
+    generation: options.generation,
+    projectId: request.projectId,
+    runId: request.runId,
+    taskKey: request.taskKey,
+    taskRevision: request.taskRevision,
+    assignmentId: request.assignmentId,
+    assignmentRevision: request.assignmentRevision,
+    attempt: request.attempt,
+    fence: request.fence,
+    operationId: decision.decisionId,
+    agentDefinitionId: request.requestedAgentDefinitionId,
+    profileRevisionId: pin.profileRevisionId,
+    profileDigest: pin.profileDigest,
+    factAnchor,
+    createdAt: now,
+    expiresAt: now + LOCAL_ASSIGNMENT_GRANT_TTL_MS,
+    status: 'ready',
+    grant,
+  });
+  try {
+    return (await options.repository.append(record, current?.digest)).record.grant;
+  } catch (error) {
+    const winner = await options.repository.read(assignmentKey);
+    if (winner?.status === 'ready' && winner.grant) return winner.grant;
+    throw error;
+  }
+}
+
+interface LocalPortfolioContext {
+  readonly portfolioId: string;
+  readonly projectId: string;
+  readonly profileRevisionId: string;
+  readonly profileDigest: string;
+  readonly workroomCatalogRevision: string;
+  readonly tenantId: string;
+  readonly policy: ReturnType<typeof createPortfolioPolicySnapshot>;
+  readonly catalog: ReturnType<typeof createResourcePoolCatalogSnapshot>;
+  readonly ceiling: ReturnType<typeof createAtomicResourceBundleProfileCeiling>;
+  readonly profileAuthority: Readonly<{
+    tenantId: string;
+    projectId: string;
+    profileRevisionId: string;
+    profileDigest: string;
+    resourceCeilingDigest: string;
+  }>;
+}
+
+/** Installs the bounded single-Root Portfolio authority for local Workroom execution. */
+export function installLocalWorkroomPortfolioAuthorities(options: Readonly<{
+  generation: number;
+  resources: Pick<Scope, 'has' | 'provide'>;
+  catalog: Pick<WorkroomCatalog, 'read'>;
+  profiles: Pick<ProjectProfileRegistry, 'read'>;
+  portfolioJournal: Pick<PortfolioJournalRepository, 'read'>;
+}>): void {
+  const contexts = new Map<string, LocalPortfolioContext>();
+  const resolveContext = async (
+    input: Parameters<WorkroomSchedulerPortfolioScopeAuthorityPort['resolve']>[0],
+  ): Promise<LocalPortfolioContext | undefined> => {
+    const workroomCatalog = await options.catalog.read();
+    const definition = workroomCatalog.definitions[input.projectId];
+    if (!definition || definition.enabled === false
+      || workroomCatalog.revision !== input.workroomCatalogRevision) return undefined;
+    const registry = await options.profiles.read(input.projectId);
+    const revision = registry.revisions[input.profileRevisionId];
+    if (!revision || revision.projectId !== input.projectId
+      || revision.compiledDigest !== input.profileDigest
+      || revision.compiledProfile.projectId !== input.projectId
+      || revision.compiledProfile.revisionId !== input.profileRevisionId
+      || revision.compiledProfile.digest !== input.profileDigest) return undefined;
+    const tenantId = 'workroom-local';
+    const identity = stableDigest({
+      projectId: input.projectId,
+      workroomCatalogRevision: input.workroomCatalogRevision,
+      profileRevisionId: input.profileRevisionId,
+      profileDigest: input.profileDigest,
+    });
+    const portfolioId = `workroom-local:${identity.slice('sha256:'.length)}`;
+    const existing = contexts.get(portfolioId);
+    if (existing) return existing;
+    const catalog = createResourcePoolCatalogSnapshot({
+      generationId: `workroom-local:${input.workroomCatalogRevision}`,
+      revision: 1,
+      tenantId,
+      pools: [
+        {
+          kind: 'model', poolId: LOCAL_WORKROOM_MODEL_POOL_ID, tenantId,
+          region: 'local', trustDomain: 'root', compatibilityGroup: 'local-v1',
+          capacityUnits: 64, maxCapacityUnitsPerBundle: 1,
+          rateUnitsPerWindow: 1_000_000, maxRateUnitsPerBundle: 1,
+          priceMicrosPerUsageUnit: 0, maxUsageUnitsPerBundle: 1,
+          providerId: 'root-model', modelTier: 'configured',
+        },
+        {
+          kind: 'executor', poolId: LOCAL_WORKROOM_EXECUTOR_POOL_ID, tenantId,
+          region: 'local', trustDomain: 'root', compatibilityGroup: 'local-v1',
+          capacityUnits: 64, maxCapacityUnitsPerBundle: 1,
+          rateUnitsPerWindow: 1_000_000, maxRateUnitsPerBundle: 1,
+          priceMicrosPerUsageUnit: 0, maxUsageUnitsPerBundle: 1,
+          executorPoolId: 'root-local', sandboxId: 'configured',
+          workspaceProviderId: 'configured',
+        },
+      ],
+    });
+    const allowedPools = [LOCAL_WORKROOM_EXECUTOR_POOL_ID, LOCAL_WORKROOM_MODEL_POOL_ID];
+    const policy = createPortfolioPolicySnapshot({
+      revision: 1,
+      globalBudgetMicros: 0,
+      offerTtlTicks: 30,
+      leaseTtlTicks: 300,
+      leaseHeartbeatTicks: 60,
+      maxLeaseQuantumTicks: 3_600,
+      maxLeaseRenewals: 11,
+      reclaimTtlTicks: 30,
+      pools: {
+        [LOCAL_WORKROOM_MODEL_POOL_ID]: {
+          poolId: LOCAL_WORKROOM_MODEL_POOL_ID, capacityUnits: 64,
+          rateUnitsPerWindow: 1_000_000, rateWindowTicks: 60,
+          priceMicrosPerBudgetUnit: 0,
+        },
+        [LOCAL_WORKROOM_EXECUTOR_POOL_ID]: {
+          poolId: LOCAL_WORKROOM_EXECUTOR_POOL_ID, capacityUnits: 64,
+          rateUnitsPerWindow: 1_000_000, rateWindowTicks: 60,
+          priceMicrosPerBudgetUnit: 0,
+        },
+      },
+      projects: {
+        [input.projectId]: {
+          projectId: input.projectId, revision: 1, lane: 'normal', weight: 1,
+          hardBudgetMicros: 0, allowedPools, maxOutstandingRequests: 64,
+          maxConcurrentGrants: 8, burstLimit: 16, starvationTicks: 30, status: 'active',
+        },
+      },
+    });
+    const ceiling = createAtomicResourceBundleProfileCeiling({
+      tenantId,
+      projectId: input.projectId,
+      profileRevisionId: input.profileRevisionId,
+      profileDigest: input.profileDigest,
+      catalogRevision: catalog.revision,
+      catalogDigest: catalog.digest,
+      allowedPoolIds: allowedPools,
+      poolLimits: [
+        { poolId: LOCAL_WORKROOM_MODEL_POOL_ID, maxCapacityUnits: 1, maxRateUnits: 1, maxUsageUnits: 1 },
+        { poolId: LOCAL_WORKROOM_EXECUTOR_POOL_ID, maxCapacityUnits: 1, maxRateUnits: 1, maxUsageUnits: 1 },
+      ],
+      maxWorstCaseCostMicros: 0,
+    });
+    const profileAuthority = Object.freeze({
+      tenantId,
+      projectId: input.projectId,
+      profileRevisionId: input.profileRevisionId,
+      profileDigest: input.profileDigest,
+      resourceCeilingDigest: ceiling.ceilingDigest,
+    });
+    const context = Object.freeze({
+      portfolioId, projectId: input.projectId,
+      profileRevisionId: input.profileRevisionId, profileDigest: input.profileDigest,
+      workroomCatalogRevision: input.workroomCatalogRevision,
+      tenantId, policy, catalog, ceiling, profileAuthority,
+    });
+    contexts.set(portfolioId, context);
+    return context;
+  };
+
+  if (!options.resources.has(workroomSchedulerPortfolioScopeAuthorityToken)) {
+    options.resources.provide(workroomSchedulerPortfolioScopeAuthorityToken, Object.freeze({
+      resolve: async (input: Parameters<WorkroomSchedulerPortfolioScopeAuthorityPort['resolve']>[0]) => {
+        if (input.generation !== options.generation) return undefined;
+        const context = await resolveContext(input);
+        if (!context) return undefined;
+        const body = Object.freeze({
+          version: 1 as const,
+          generation: options.generation,
+          projectId: context.projectId,
+          workroomCatalogRevision: context.workroomCatalogRevision,
+          profileRevisionId: context.profileRevisionId,
+          profileDigest: context.profileDigest,
+          portfolioId: context.portfolioId,
+          tenantId: context.tenantId,
+          portfolioPolicyRevision: context.policy.revision,
+          portfolioPolicyDigest: context.policy.digest,
+          portfolioClockAnchor: 0,
+          portfolioClockDigest: stableDigest({ portfolioId: context.portfolioId, now: 0 }),
+          resourceCatalogGenerationId: context.catalog.generationId,
+          resourceCatalogRevision: context.catalog.revision,
+          resourceCatalogDigest: context.catalog.digest,
+        });
+        return Object.freeze({
+          ...body,
+          bindingDigest: workroomSchedulerPortfolioScopeBindingDigest(body),
+        });
+      },
+    }));
+  }
+  if (!options.resources.has(portfolioPolicyAuthorityToken)) {
+    options.resources.provide(portfolioPolicyAuthorityToken, Object.freeze({
+      resolve: async (portfolioId: Parameters<PortfolioPolicyAuthorityPort['resolve']>[0]) => {
+        const context = contexts.get(portfolioId);
+        if (!context) return undefined;
+        return Object.freeze({
+          policy: context.policy,
+          governance: Object.freeze({
+            principalId: 'workroom-admin',
+            authorizedBy: 'root:local-workroom-portfolio',
+            reasonDigest: stableDigest({ portfolioId, reason: 'local-workroom-bootstrap' }),
+            targetDigest: context.policy.digest,
+            expectedRevision: 0,
+          }),
+        });
+      },
+    }));
+  }
+  if (!options.resources.has(portfolioAtomicBundleAuthorityToken)) {
+    options.resources.provide(portfolioAtomicBundleAuthorityToken, Object.freeze({
+      validate: async (input: Parameters<PortfolioAtomicBundleAuthorityPort['validate']>[0]) => {
+        if (input.generation !== options.generation) return undefined;
+        const context = contexts.get(input.portfolioId);
+        if (!context || input.tenantId !== context.tenantId
+          || input.capacityRequest.projectId !== context.projectId
+          || input.capacityRequest.workRef.profileRevisionId !== context.profileRevisionId
+          || input.capacityRequest.workRef.profileDigest !== context.profileDigest) return undefined;
+        return validateAtomicResourceBundle({
+          request: {
+            tenantId: input.tenantId,
+            catalogRevision: input.catalogRevision,
+            catalogDigest: input.catalogDigest,
+            capacityRequest: input.capacityRequest,
+          },
+          catalog: context.catalog,
+          profileCeiling: context.ceiling,
+          profileAuthority: context.profileAuthority,
+        });
+      },
+    }));
+  }
+  if (!options.resources.has(portfolioKernelCommandAuthorityToken)) {
+    options.resources.provide(portfolioKernelCommandAuthorityToken, Object.freeze({
+      authorize: async (input: Parameters<PortfolioKernelCommandAuthorityPort['authorize']>[0]) => {
+        if (input.generation !== options.generation || input.action !== 'consume'
+          || !input.assignmentRef.trim() || !input.portfolioId.startsWith('workroom-local:')) {
+          return undefined;
+        }
+        const state = replayPortfolioAdmission(
+          input.portfolioId,
+          await options.portfolioJournal.read(input.portfolioId),
+        );
+        const grant = state.grants[input.grant.grantId];
+        const request = grant && state.requests[grant.requestId]?.request;
+        const context = contexts.get(input.portfolioId);
+        if (!grant || !request || request.projectId !== grant.projectId
+          || (context !== undefined && grant.projectId !== context.projectId)
+          || (grant.status !== 'offered' && grant.status !== 'consumed')
+          || (grant.status === 'consumed' && grant.assignmentRef !== input.assignmentRef)
+          || digestCanonicalWorkroomValue(grant) !== digestCanonicalWorkroomValue(input.grant)) {
+          return undefined;
+        }
+        const claims = Object.freeze({
+          portfolioId: input.portfolioId,
+          action: 'consume' as const,
+          projectId: grant.projectId,
+          requestId: grant.requestId,
+          grantId: grant.grantId,
+          fence: grant.fence,
+          assignmentRef: input.assignmentRef,
+        });
+        return Object.freeze({
+          ...claims,
+          commandDigest: portfolioKernelCommandDigest(claims),
+          authorizedBy: `root:local-workroom-portfolio:${options.generation}`,
+        });
+      },
+    }));
+  }
+}
+
+function stableDigest(value: unknown): string {
+  return `sha256:${createHash('sha256').update(JSON.stringify(value)).digest('hex')}`;
+}

--- a/basic/cli/src/plugin-runtime/start-command.ts
+++ b/basic/cli/src/plugin-runtime/start-command.ts
@@ -46,6 +46,7 @@ import {
   resolvePluginLifecycleFile,
 } from './plugin-lifecycle-store.js';
 import {
+  DEFAULT_SHUTDOWN_BUDGET_MS,
   installProcessLifecycle,
   nodeProcessLifecycleAdapter,
 } from './process-lifecycle.js';
@@ -57,6 +58,8 @@ const REMOTE_CONSOLE_URL = 'https://console.zhin.dev';
 /** Storm guard parity with the `zhin start` daemon: 10 restarts/minute, 3s delay. */
 export const MAX_RESPAWNS_PER_MINUTE = 10;
 export const RESPAWN_DELAY_MS = 3_000;
+/** Gives the Runtime its complete shutdown budget before fencing leaked handles. */
+export const SUPERVISOR_CHILD_EXIT_GRACE_MS = DEFAULT_SHUTDOWN_BUDGET_MS + 1_000;
 const RESPAWN_WINDOW_MS = 60_000;
 
 export interface RespawnPlan {
@@ -334,9 +337,9 @@ export async function runStartCommand(options: StartCommandOptions): Promise<voi
     options.writeError(`${error instanceof Error ? error.stack ?? error.message : String(error)}\n`);
   };
   const orphanWatchdog = startOrphanWatchdog(() => {
-    void control.stop().catch((error) => {
-      process.exitCode = 1;
+    void control.stop().then(() => process.exit(0), (error) => {
       reportStopError(error);
+      process.exit(1);
     });
   });
   const disposeProcessLifecycle = installProcessLifecycle({
@@ -544,17 +547,24 @@ async function relaunchWithNativeTypeScript(parsed: StartOptions, root: string):
   let attempts: readonly number[] = [];
   let interrupted = false;
   let activeChild: ChildProcess | undefined;
-  const onSigint = (): void => {
-    interrupted = true;
-    activeChild?.kill('SIGINT');
-  };
+  let forceChildExitTimer: ReturnType<typeof setTimeout> | undefined;
   // Forward the other terminal signals too, and never leave the child behind:
   // a bot whose wrapper died keeps platform connections (and file watchers)
   // alive as a zombie.
   const forward = (signal: NodeJS.Signals) => (): void => {
     interrupted = true;
-    activeChild?.kill(signal);
+    const child = activeChild;
+    if (!child) return;
+    child.kill(signal);
+    if (!forceChildExitTimer) {
+      forceChildExitTimer = setTimeout(() => {
+        if (activeChild === child && child.exitCode === null && child.signalCode === null) {
+          child.kill('SIGKILL');
+        }
+      }, SUPERVISOR_CHILD_EXIT_GRACE_MS);
+    }
   };
+  const onSigint = forward('SIGINT');
   const onSigterm = forward('SIGTERM');
   const onSighup = forward('SIGHUP');
   const onExit = (): void => {
@@ -588,6 +598,8 @@ async function relaunchWithNativeTypeScript(parsed: StartOptions, root: string):
           child.once('exit', (code, signal) => resolve({ code, signal }));
         },
       );
+      if (forceChildExitTimer) clearTimeout(forceChildExitTimer);
+      forceChildExitTimer = undefined;
       activeChild = undefined;
       if (interrupted) {
         process.exitCode = result.code ?? 130;
@@ -619,6 +631,7 @@ async function relaunchWithNativeTypeScript(parsed: StartOptions, root: string):
       }
     }
   } finally {
+    if (forceChildExitTimer) clearTimeout(forceChildExitTimer);
     removePidFile();
     process.off('SIGINT', onSigint);
     process.off('SIGTERM', onSigterm);

--- a/basic/cli/src/utils/process.ts
+++ b/basic/cli/src/utils/process.ts
@@ -4,8 +4,12 @@ import path from 'path';
 import { formatCompact } from '@zhin.js/logger';
 import { logger } from './logger.js';
 import os from 'os';
+import { DEFAULT_SHUTDOWN_BUDGET_MS } from '../plugin-runtime/process-lifecycle.js';
 
 const PID_FILE = '.zhin.pid';
+const PROCESS_EXIT_POLL_MS = 100;
+/** The supervisor must outlive the Runtime child's complete graceful-stop budget. */
+export const PROCESS_STOP_GRACE_MS = DEFAULT_SHUTDOWN_BUDGET_MS + 2_000;
 
 /**
  * 检查进程是否存在的跨平台实现
@@ -120,30 +124,30 @@ export async function stopProcess(cwd: string): Promise<void> {
     }
     
     // 等待进程结束
-    let attempts = 0;
-    while (attempts < 30) {
+    let waitedMs = 0;
+    while (waitedMs < PROCESS_STOP_GRACE_MS) {
       const stillRunning = await isProcessRunning(pid);
       if (!stillRunning) {
         break;
       }
-      await new Promise(resolve => setTimeout(resolve, 100));
-      attempts++;
+      await new Promise(resolve => setTimeout(resolve, PROCESS_EXIT_POLL_MS));
+      waitedMs += PROCESS_EXIT_POLL_MS;
     }
 
     // 如果进程仍然存在，强制结束
-    if (attempts >= 30) {
+    if (waitedMs >= PROCESS_STOP_GRACE_MS) {
       logger.warn(formatCompact( { op: 'kill', signal: 'SIGKILL' }));
       await killProcess(pid, 'SIGKILL');
       
       // 再次等待
-      attempts = 0;
-      while (attempts < 10) {
+      waitedMs = 0;
+      while (waitedMs < 1_000) {
         const stillRunning = await isProcessRunning(pid);
         if (!stillRunning) {
           break;
         }
-        await new Promise(resolve => setTimeout(resolve, 100));
-        attempts++;
+        await new Promise(resolve => setTimeout(resolve, PROCESS_EXIT_POLL_MS));
+        waitedMs += PROCESS_EXIT_POLL_MS;
       }
     }
 
@@ -337,11 +341,11 @@ async function getRelatedProcessesInternal(processName: string): Promise<Array<{
 /**
  * 获取所有相关进程列表
  */
-export async function getRelatedProcesses(processName: string): Promise<Array<{ 
-  pid: number; 
-  name: string; 
-  memory?: string; 
-  cpu?: string 
+export async function getRelatedProcesses(processName: string): Promise<Array<{
+  pid: number;
+  name: string;
+  memory?: string;
+  cpu?: string
 }>> {
   return await getRelatedProcessesInternal(processName);
-} 
+}

--- a/basic/cli/tests/plugin-runtime/local-workroom-portfolio.test.ts
+++ b/basic/cli/tests/plugin-runtime/local-workroom-portfolio.test.ts
@@ -1,0 +1,267 @@
+import { createHash } from 'node:crypto';
+import { rootPluginId, Scope } from '@zhin.js/plugin-runtime';
+import {
+  createDurableWorkroomAssignmentAuthorityGrantProvider,
+  createWorkroomSchedulerPolicySnapshot,
+  decideWorkroomSchedule,
+  MemoryAssignmentAuthorityGrantRepository,
+  MemoryWorkroomJournal,
+  WorkflowPlanBuilder,
+  WorkroomKernel,
+  workroomLocalAssignmentId,
+  type WorkroomCatalogSnapshot,
+} from '@zhin.js/agent';
+import {
+  digestWorkroomCatalogProjectBinding,
+  portfolioAtomicBundleAuthorityToken,
+  portfolioPolicyAuthorityToken,
+  workroomSchedulerPortfolioScopeAuthorityToken,
+} from '@zhin.js/agent/runtime';
+import {
+  createLocalWorkroomAssignmentGrantProvider,
+  installLocalWorkroomPortfolioAuthorities,
+  LOCAL_WORKROOM_EXECUTOR_POOL_ID,
+  LOCAL_WORKROOM_MODEL_POOL_ID,
+  LOCAL_WORKROOM_RESOURCE_REQUIREMENTS,
+} from '../../src/plugin-runtime/local-workroom-portfolio.js';
+
+const generation = 7;
+const projectId = 'project-1';
+const profileRevisionId = 'profile-1';
+const profileDigest = sha('p');
+
+describe('CLI local Workroom Portfolio authorities', () => {
+  it('materializes and durably replays an exact local Assignment grant', async () => {
+    const catalog = catalogSnapshot();
+    const journal = new MemoryWorkroomJournal();
+    const kernel = new WorkroomKernel({
+      journal,
+      now: () => 100,
+      acceptancePolicy: acceptancePolicy(),
+    });
+    const plan = WorkflowPlanBuilder.create({
+      proposalId: 'plan-1',
+      projectId,
+      parameterDigest: sha('a'),
+      strategy: { id: 'strategy-1', version: '1', digest: sha('b') },
+      authority: {
+        projectRevision: catalog.revision,
+        projectDigest: digestWorkroomCatalogProjectBinding(catalog.definitions[projectId]!),
+        profileRevisionId,
+        profileDigest,
+        planningPolicyRevisionId: 'planning-1',
+        planningPolicyDigest: sha('c'),
+        orchestratorAgentDefinitionId: 'orchestrator',
+        orchestratorAuthorityDigest: sha('d'),
+      },
+      budget: { maxTasks: 2, maxTotalAttempts: 4 },
+      schedulerPolicy: createWorkroomSchedulerPolicySnapshot({
+        policyRef: 'scheduler-1', revision: 1, pinnedAtSequence: 1, capacity: 1,
+        agingStepMs: 100,
+        starvationBoundMs: { urgent: 100, high: 200, normal: 300, low: 400 },
+        preemptionDeadlineMs: 50,
+      }),
+    }).addTask({
+      key: 'build', title: 'Build', role: 'executor', required: true, maxAttempts: 2,
+      dependsOn: [], requires: {}, resourceRequirements: LOCAL_WORKROOM_RESOURCE_REQUIREMENTS,
+      scheduler: {
+        sponsorLane: 'normal', localRank: 0, enqueuedAt: 100,
+        deadline: 1_000, preemptibility: 'atomic',
+      },
+    }).build();
+    const admitted = await kernel.admitWorkflowPlan({
+      operationId: 'admit-1', projectId, title: 'Local Workroom',
+      sourceEventRef: 'conversation:1', sourceEventDigest: sha('e'),
+      orchestratorAgentDefinitionId: 'orchestrator', plan,
+    });
+    await kernel.pinTaskAcceptance(projectId, admitted.runId, 'build');
+    const decision = decideWorkroomSchedule(await journal.read(admitted.runId));
+    if (!decision || decision.type !== 'dispatch_task') throw new Error('fixture must dispatch');
+    await kernel.commitSchedulerDecision(decision);
+
+    const repository = new MemoryAssignmentAuthorityGrantRepository();
+    const durable = createDurableWorkroomAssignmentAuthorityGrantProvider({
+      repository, generation, now: () => 101,
+    });
+    const profile = profileRegistry(admitted.runId);
+    const provider = createLocalWorkroomAssignmentGrantProvider({
+      generation,
+      projectRoot: '/workspace/project-1',
+      repository,
+      durable,
+      journal,
+      catalog: { read: async () => catalog },
+      profiles: { read: async () => profile },
+      runState: kernel,
+    });
+    const request = {
+      projectId,
+      runId: admitted.runId,
+      taskKey: 'build',
+      taskRevision: 1,
+      assignmentId: workroomLocalAssignmentId(decision.decisionId),
+      assignmentRevision: 1,
+      attempt: 1,
+      fence: 1,
+      requestedAgentDefinitionId: 'developer',
+    };
+
+    const first = await provider.resolve(request);
+    expect(first).toMatchObject({
+      generation,
+      projectId,
+      runId: admitted.runId,
+      taskKey: 'build',
+      principalId: 'agent:developer',
+      role: 'executor',
+      workspace: { mountRef: '/workspace/project-1', fence: 1 },
+      roleCapabilities: {
+        tools: [{ name: 'read_file', digest: sha('1') }],
+        skills: [{ name: 'typescript', digest: sha('2'), requiredTools: ['read_file'] }],
+      },
+    });
+    await expect(provider.resolve(request)).resolves.toEqual(first);
+    await expect(provider.resolve({ ...request, requestedEndpointId: 'remote-1' }))
+      .resolves.toBeUndefined();
+  });
+
+  it('installs bounded local scope, policy, and bundle authorities without replacing plugins', async () => {
+    const resources = new Scope(rootPluginId());
+    const catalog = catalogSnapshot();
+    const profile = profileRegistry('run-1');
+    installLocalWorkroomPortfolioAuthorities({
+      generation,
+      resources,
+      catalog: { read: async () => catalog },
+      profiles: { read: async () => profile },
+      portfolioJournal: { read: async () => [] },
+    });
+    const scope = resources.use(workroomSchedulerPortfolioScopeAuthorityToken);
+    const binding = await scope.resolve({
+      generation,
+      projectId,
+      workroomCatalogRevision: catalog.revision,
+      profileRevisionId,
+      profileDigest,
+    });
+    expect(binding).toMatchObject({
+      generation,
+      projectId,
+      tenantId: 'workroom-local',
+      resourceCatalogRevision: 1,
+    });
+    expect(binding?.portfolioId).toMatch(/^workroom-local:/u);
+    await expect(scope.resolve({
+      generation: generation + 1,
+      projectId,
+      workroomCatalogRevision: catalog.revision,
+      profileRevisionId,
+      profileDigest,
+    })).resolves.toBeUndefined();
+
+    const policy = await resources.use(portfolioPolicyAuthorityToken).resolve(binding!.portfolioId);
+    expect(policy?.policy.projects[projectId]).toMatchObject({
+      allowedPools: [LOCAL_WORKROOM_EXECUTOR_POOL_ID, LOCAL_WORKROOM_MODEL_POOL_ID],
+      status: 'active',
+    });
+    const bundleAuthority = resources.use(portfolioAtomicBundleAuthorityToken);
+    const capacityRequest = {
+      requestId: 'request-1',
+      projectId,
+      workRef: { runId: 'run-1', profileRevisionId, profileDigest },
+      schedulerRevision: sha('s'), schedulerSequence: 3, localOrder: 3,
+      projectPolicyRevision: 1, opaqueHeadId: 'head-1', payloadDigest: sha('h'),
+      resourceBundle: LOCAL_WORKROOM_RESOURCE_REQUIREMENTS,
+      preemptibility: 'atomic' as const,
+      starvationAt: 10,
+    };
+    const validated = await bundleAuthority.validate({
+      generation,
+      portfolioId: binding!.portfolioId,
+      tenantId: binding!.tenantId,
+      catalogRevision: binding!.resourceCatalogRevision,
+      catalogDigest: binding!.resourceCatalogDigest,
+      capacityRequest,
+    });
+    expect(validated).toMatchObject({
+      requestId: 'request-1',
+      projectId,
+      model: { poolId: LOCAL_WORKROOM_MODEL_POOL_ID },
+      executor: { poolId: LOCAL_WORKROOM_EXECUTOR_POOL_ID },
+    });
+  });
+});
+
+function acceptancePolicy() {
+  return {
+    pinContract: (input: Readonly<{ task: Readonly<{ key: string; revision: number }> }>) => ({
+      id: `contract:${input.task.key}:${input.task.revision}`,
+      revision: 1,
+      digest: sha('f'),
+      taskKey: input.task.key,
+      taskRevision: input.task.revision,
+      kind: 'task_result' as const,
+      policy: { id: 'acceptance-1', revision: 1, digest: sha('g') },
+      criteria: [{ id: 'review', kind: 'judgment' as const, description: 'Review result' }],
+      requiredEvidence: [],
+    }),
+    decide: () => { throw new Error('not used'); },
+  };
+}
+
+function catalogSnapshot(): WorkroomCatalogSnapshot {
+  return Object.freeze({
+    revision: 'a'.repeat(64),
+    definitions: Object.freeze({
+      [projectId]: Object.freeze({
+        name: 'Project One',
+        enabled: true,
+        sponsors: Object.freeze(['workroom-admin']),
+        members: Object.freeze([
+          Object.freeze({ agent: 'orchestrator', role: 'orchestrator' as const }),
+          Object.freeze({ agent: 'developer', role: 'executor' as const }),
+        ]),
+        conversation: Object.freeze({
+          adapter: 'sandbox', endpoint: 'sandbox-1', kind: 'group' as const,
+          id: 'project-1', agent: 'orchestrator',
+        }),
+      }),
+    }),
+  });
+}
+
+function profileRegistry(runId: string) {
+  const compiledProfile = Object.freeze({
+    revisionId: profileRevisionId,
+    projectId,
+    digest: profileDigest,
+    tools: Object.freeze([{ id: 'read_file', digest: sha('1') }]),
+    skills: Object.freeze([{ id: 'typescript', digest: sha('2'), requiresTools: ['read_file'] }]),
+    agents: Object.freeze([{
+      id: 'developer', digest: sha('3'), role: 'executor' as const,
+      allowedTools: ['read_file'], allowedSkills: ['typescript'],
+    }]),
+  });
+  return {
+    projectId,
+    registryRevision: 2,
+    runPins: {
+      [runId]: {
+        projectId, runId, profileRevisionId, profileDigest,
+        activationRegistryRevision: 1, pinnedAtRegistryRevision: 2,
+      },
+    },
+    revisions: {
+      [profileRevisionId]: {
+        revisionId: profileRevisionId,
+        projectId,
+        compiledDigest: profileDigest,
+        compiledProfile,
+      },
+    },
+  } as never;
+}
+
+function sha(value: string): string {
+  return `sha256:${createHash('sha256').update(value).digest('hex')}`;
+}

--- a/packages/im/agent/src/data-governance/governance-authority-repository.ts
+++ b/packages/im/agent/src/data-governance/governance-authority-repository.ts
@@ -252,6 +252,11 @@ export function createDataGovernanceBlocker(input: DataGovernanceBlockerInput): 
 
 export interface DataGovernanceAuthorityRepository {
   readProject(projectId: string): Promise<ProjectDataGovernanceAuthority | undefined>;
+  /** Resolves an immutable historical authority pinned by an older payload. */
+  readProjectRevision?(
+    projectId: string,
+    revision: number,
+  ): Promise<ProjectDataGovernanceAuthority | undefined>;
   appendProject(
     authority: ProjectDataGovernanceAuthority,
     expectedDigest: string | undefined,
@@ -303,6 +308,18 @@ export class FileDataGovernanceAuthorityRepository implements DataGovernanceAuth
   }
 
   async readProject(projectId: string): Promise<ProjectDataGovernanceAuthority | undefined> {
+    return (await this.#readProjects(projectId)).at(-1);
+  }
+
+  async readProjectRevision(
+    projectId: string,
+    revision: number,
+  ): Promise<ProjectDataGovernanceAuthority | undefined> {
+    positive(revision, 'Project authority revision');
+    return (await this.#readProjects(projectId)).find(authority => authority.revision === revision);
+  }
+
+  async #readProjects(projectId: string): Promise<readonly ProjectDataGovernanceAuthority[]> {
     requireText(projectId, 'projectId');
     await this.#ensureReady();
     await this.#projects.syncLeaf();
@@ -310,6 +327,7 @@ export class FileDataGovernanceAuthorityRepository implements DataGovernanceAuth
     const names = (await readdir(this.#projects.directory))
       .filter(name => name.startsWith(prefix) && name.endsWith('.json'))
       .sort();
+    const history: ProjectDataGovernanceAuthority[] = [];
     let latest: ProjectDataGovernanceAuthority | undefined;
     for (const [index, name] of names.entries()) {
       const match = /^[a-f\d]{64}\.(\d{12})\.json$/u.exec(name);
@@ -323,8 +341,9 @@ export class FileDataGovernanceAuthorityRepository implements DataGovernanceAuth
         throw new DataGovernanceAuthorityConflictError(projectId, latest?.digest, current.previousDigest);
       }
       latest = current;
+      history.push(current);
     }
-    return latest;
+    return history;
   }
 
   async appendProject(authority: ProjectDataGovernanceAuthority, expectedDigest: string | undefined) {

--- a/packages/im/agent/src/plugin-runtime/index.ts
+++ b/packages/im/agent/src/plugin-runtime/index.ts
@@ -64,6 +64,7 @@ export * from './workroom-data-governance-authority-writer.js';
 export * from './workroom-data-governance-bootstrap.js';
 export * from './workroom-journal-payload-composition.js';
 export * from './workroom-data-governance-root-provider.js';
+export { digestCanonicalWorkroomValue } from '../workroom/canonical-value.js';
 export * from './workroom-data-governance-storage.js';
 export * from './workroom-governed-dispatch-composition.js';
 export * from './workroom-governed-dispatch-reasons.js';

--- a/packages/im/agent/src/plugin-runtime/workroom-acceptance-internal-providers.ts
+++ b/packages/im/agent/src/plugin-runtime/workroom-acceptance-internal-providers.ts
@@ -63,7 +63,8 @@ WorkroomAcceptanceProjectionSourceAuthorityPort {
       && candidate.profileDigest === active.compiledDigest
       && candidate.activationRegistryRevision === active.activatedAtRegistryRevision);
     if (!pin) return Object.freeze([]);
-    return Object.freeze([candidateForPin(profile, catalog, pin)]);
+    const candidate = candidateForPin(profile, catalog, pin);
+    return candidate ? Object.freeze([candidate]) : Object.freeze([]);
   }
 
   async authorize(candidate: WorkroomAcceptanceProjectionCandidate): Promise<boolean> {
@@ -104,6 +105,7 @@ WorkroomAcceptanceProjectionSourceAuthorityPort {
     const byRevision = new Map<string, WorkroomAcceptanceProjectionCandidate>();
     for (const pin of pins) {
       const candidate = candidateForPin(profile, catalog, pin);
+      if (!candidate) continue;
       const key = `${pin.profileRevisionId}:${pin.profileDigest}`;
       const current = byRevision.get(key);
       if (current && canonicalWorkroomJson(current) !== canonicalWorkroomJson(candidate)) {
@@ -487,7 +489,7 @@ function candidateForPin(
   profile: ProjectProfileRegistrySnapshot,
   catalog: WorkroomCatalogSnapshot,
   pin: WorkroomRunProfilePin,
-): WorkroomAcceptanceProjectionCandidate {
+): WorkroomAcceptanceProjectionCandidate | undefined {
   const revision = profile.revisions[pin.profileRevisionId];
   if (!revision || revision.projectId !== pin.projectId
     || revision.compiledDigest !== pin.profileDigest
@@ -500,7 +502,8 @@ function candidateForPin(
     throw new Error('Acceptance Profile source Project is unavailable in the persistent Catalog');
   }
   const policies = revision.compiledProfile.acceptancePolicies ?? [];
-  if (policies.length !== 1) {
+  if (policies.length === 0) return undefined;
+  if (policies.length > 1) {
     throw new Error('Acceptance Profile source requires exactly one compiled Acceptance Policy');
   }
   const policy = policies[0]!;

--- a/packages/im/agent/src/plugin-runtime/workroom-acceptance-production-composition.ts
+++ b/packages/im/agent/src/plugin-runtime/workroom-acceptance-production-composition.ts
@@ -15,6 +15,7 @@ import {
 } from '../workroom/effect-ledger.js';
 import type { ProjectProfileRegistry } from '../workroom/profile-registry.js';
 import type { WorkroomCatalog } from '../workroom/catalog.js';
+import type { WorkroomJournal } from '../workroom/journal.js';
 import type { WorkroomRunState } from '../workroom/kernel-contracts.js';
 import { workroomAcceptanceAuthorityToken } from './workroom-acceptance-authority.js';
 import { workroomAcceptancePolicyDecisionToken } from './workroom-acceptance-policy.js';
@@ -533,6 +534,7 @@ export interface InstallWorkroomAcceptanceResourcesOptions {
   readonly resources: Pick<Scope, 'has' | 'provide'>;
   readonly profiles: Pick<ProjectProfileRegistry, 'read'>;
   readonly catalog: Pick<WorkroomCatalog, 'read'>;
+  readonly journal?: Pick<WorkroomJournal, 'read'>;
   readonly projections?: WorkroomGovernedAcceptanceProjectionPort;
   readonly reports: WorkroomAcceptedReportReader;
   readonly riskHeaders?: WorkroomKernelRiskHeaderPort;
@@ -662,6 +664,7 @@ export function installWorkroomAcceptanceResources(
     profiles: options.profiles,
     catalog: options.catalog,
     projections,
+    ...(options.journal ? { journal: options.journal } : {}),
   });
   const principals = new CatalogWorkroomAcceptancePrincipalRegistry({
     profiles: options.profiles,

--- a/packages/im/agent/src/plugin-runtime/workroom-acceptance-provider-composition.ts
+++ b/packages/im/agent/src/plugin-runtime/workroom-acceptance-provider-composition.ts
@@ -1,8 +1,13 @@
 import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
-import type { WorkroomCatalog } from '../workroom/catalog.js';
+import type { WorkroomCatalog, WorkroomCatalogSnapshot } from '../workroom/catalog.js';
 import type { WorkroomDefinition } from '../workroom/catalog-definition.js';
 import type { ProjectProfileRegistry, ProjectProfileRegistrySnapshot } from '../workroom/profile-registry.js';
+import type { WorkroomJournal } from '../workroom/journal.js';
+import {
+  assertWorkflowPlanProposal,
+  type WorkflowPlanProposal,
+} from '../workroom/workflow-plan-builder.js';
 import {
   createWorkroomProjectMemorySchemaSnapshot,
   type WorkroomProjectMemoryClaimRule,
@@ -131,6 +136,16 @@ export interface ProfileOwnedWorkroomAcceptanceProviderOptions {
   readonly profiles: Pick<ProjectProfileRegistry, 'read'>;
   readonly catalog: Pick<WorkroomCatalog, 'read'>;
   readonly projections: WorkroomGovernedAcceptanceProjectionPort;
+  /** Exact admitted Plan authority used to map dynamic Task keys to Profile templates. */
+  readonly journal?: Pick<WorkroomJournal, 'read'>;
+}
+
+interface ProfileOwnedWorkroomAcceptanceContext {
+  readonly profile: ProjectProfileRegistrySnapshot;
+  readonly catalog: WorkroomCatalogSnapshot;
+  readonly pin: ReturnType<typeof exactRunProfile>;
+  readonly definition: WorkroomDefinition;
+  readonly projection: WorkroomGovernedAcceptanceProjection;
 }
 
 /** Exact Run Profile projection shared by Acceptance contracts and Memory Schema authority. */
@@ -150,8 +165,7 @@ implements WorkroomAcceptancePolicyFactsPort {
     positive(input.taskRevision, 'Acceptance Task revision');
     const context = await this.#context(input.projectId, input.runId);
     const projection = context.projection;
-    const task = projection.tasks.find(candidate => candidate.taskKey === input.taskKey);
-    if (!task) throw new Error(`Pinned Profile has no Acceptance policy for Task ${input.taskKey}`);
+    const task = await this.#taskPolicy(context, input.runId, input.taskKey);
     assertPrincipals(
       task,
       context.definition,
@@ -205,8 +219,7 @@ implements WorkroomAcceptancePolicyFactsPort {
     acceptance: WorkroomAcceptanceRecord;
   }>): Promise<WorkroomProjectMemorySchemaSnapshot> {
     const context = await this.#context(input.projectId, input.runId);
-    const task = context.projection.tasks.find(candidate => candidate.taskKey === input.taskKey);
-    if (!task) throw new Error(`Pinned Profile has no Memory policy for Task ${input.taskKey}`);
+    await this.#taskPolicy(context, input.runId, input.taskKey);
     const expected = await this.resolve({
       projectId: input.projectId,
       runId: input.runId,
@@ -221,6 +234,48 @@ implements WorkroomAcceptancePolicyFactsPort {
       throw new Error('Project Memory Schema authority targets a stale Acceptance/Profile binding');
     }
     return createWorkroomProjectMemorySchemaSnapshot(context.projection.memorySchema);
+  }
+
+  async #taskPolicy(
+    context: ProfileOwnedWorkroomAcceptanceContext,
+    runId: string,
+    taskKey: string,
+  ): Promise<WorkroomGovernedAcceptanceTaskPolicy> {
+    const exact = context.projection.tasks.find(candidate => candidate.taskKey === taskKey);
+    if (exact) return exact;
+    if (!this.options.journal) {
+      throw new Error(`Pinned Profile has no Acceptance policy for Task ${taskKey}`);
+    }
+    const events = await this.options.journal.read(runId);
+    const admitted = events.filter(event => event.type === 'plan.admitted');
+    if (admitted.length !== 1) throw new Error('Acceptance requires exactly one admitted Workflow Plan');
+    const value = admitted[0]!.payload.plan;
+    if (!value || typeof value !== 'object') {
+      throw new Error('Acceptance admitted Workflow Plan is unavailable');
+    }
+    const plan = value as WorkflowPlanProposal;
+    assertWorkflowPlanProposal(plan);
+    if (plan.projectId !== context.pin.projectId
+      || plan.authority.profileRevisionId !== context.pin.profileRevisionId
+      || plan.authority.profileDigest !== context.pin.profileDigest
+      || plan.strategy.version !== context.pin.profileRevisionId) {
+      throw new Error('Acceptance Workflow Plan does not bind the exact Run Profile');
+    }
+    const plannedTask = plan.tasks.find(candidate => candidate.key === taskKey);
+    if (!plannedTask) throw new Error(`Admitted Workflow Plan has no Task ${taskKey}`);
+    const compiled = context.profile.revisions[context.pin.profileRevisionId]!.compiledProfile;
+    const workflows = compiled.workflows.filter(workflow =>
+      workflow.id === plan.strategy.id && workflow.digest === plan.strategy.digest);
+    if (workflows.length !== 1) throw new Error('Acceptance Workflow strategy is not uniquely pinned');
+    const templates = workflows[0]!.tasks.filter(candidate => candidate.role === plannedTask.role);
+    if (templates.length !== 1) {
+      throw new Error(`Acceptance Workflow role ${plannedTask.role} has no unique Task template`);
+    }
+    const template = context.projection.tasks.filter(candidate => candidate.taskKey === templates[0]!.key);
+    if (template.length !== 1) {
+      throw new Error(`Pinned Profile has no Acceptance policy for Workflow Task ${templates[0]!.key}`);
+    }
+    return deepFreeze({ ...template[0]!, taskKey });
   }
 
   async #context(projectId: string, runId: string) {

--- a/packages/im/agent/src/plugin-runtime/workroom-assignment-authority-provider.ts
+++ b/packages/im/agent/src/plugin-runtime/workroom-assignment-authority-provider.ts
@@ -426,11 +426,11 @@ export function createWorkroomGenerationAuthoritySnapshotFromRuntime(
   const skillIndex = runtimeProjection(snapshot, skillFeatureId, SkillIndex);
   return createWorkroomGenerationAuthoritySnapshot({
     generation: snapshot.generation,
-    tools: (toolIndex?.list() ?? []).filter(tool => tool.hidden !== true).map(tool => ({
+    tools: (toolIndex?.visible(snapshot.root) ?? []).filter(tool => tool.hidden !== true).map(tool => ({
       name: tool.name,
       digest: digestGenerationDescriptor('tool', generationToolProjection(tool)),
     })),
-    skills: (skillIndex?.list() ?? []).map(skill => ({
+    skills: (skillIndex?.visible(snapshot.root) ?? []).map(skill => ({
       name: skill.name,
       digest: digestGenerationDescriptor('skill', generationSkillProjection(skill)),
     })),

--- a/packages/im/agent/src/plugin-runtime/workroom-data-governance-authority-writer.ts
+++ b/packages/im/agent/src/plugin-runtime/workroom-data-governance-authority-writer.ts
@@ -65,6 +65,7 @@ implements WorkroomDataGovernanceAuthorityControlPort {
     }
     assertProjectionAuthority(input.candidate, definition);
     assertWorkroomJournalDataGovernanceAuthority(input.candidate);
+    assertAcceptanceProjectionDataGovernanceAuthority(input.candidate);
     const candidate = canonicalizeProjectDataGovernanceAuthorityCandidate(input.candidate);
     const current = await this.options.repository.readProject(candidate.projectId);
     if ((!current && candidate.revision !== 1)
@@ -120,6 +121,32 @@ export function assertWorkroomJournalDataGovernanceAuthority(
     || !destination.noTraining
     || destination.loggingMode !== 'metadata_only') {
     throw new Error('Project Data Governance authority lacks exact Workroom Journal derived/sink policy');
+  }
+}
+
+/** Exact policy gate for materializing Acceptance Profile projections. */
+export function assertAcceptanceProjectionDataGovernanceAuthority(
+  candidate: ProjectDataGovernanceAuthorityCandidate,
+): void {
+  const rule = candidate.derivedPayloads.acceptanceProjection;
+  const sink = candidate.sinks['acceptance-projection:acceptance-policy'];
+  const servicePrincipal = `service:workroom-acceptance-policy:${candidate.projectId}`;
+  const destination = sink && candidate.policy.destinations[sink.destinationId];
+  if (!rule
+    || !rule.allowedPurposes.includes('acceptance_review')
+    || !sink
+    || sink.channel !== 'context_view'
+    || sink.purpose !== 'acceptance_review'
+    || sink.requestedMode !== 'full'
+    || sink.fixedPrincipalId !== servicePrincipal
+    || sink.principal.role !== 'reviewer'
+    || !sink.principal.allowedPurposes.includes('acceptance_review')
+    || !sink.recipients.recipients.some(recipient => recipient.principalId === servicePrincipal)
+    || !destination
+    || destination.external
+    || !destination.noTraining
+    || destination.loggingMode !== 'metadata_only') {
+    throw new Error('Project Data Governance authority lacks exact Acceptance Projection derived/sink policy');
   }
 }
 

--- a/packages/im/agent/src/plugin-runtime/workroom-data-governance-bootstrap.ts
+++ b/packages/im/agent/src/plugin-runtime/workroom-data-governance-bootstrap.ts
@@ -58,6 +58,7 @@ export function createWorkroomDataGovernanceBootstrapCandidate(input: Readonly<{
       `room:${input.projectId}`,
       `service:workroom-kernel:${input.projectId}`,
       `service:workroom-projection:${input.projectId}`,
+      `service:workroom-acceptance-policy:${input.projectId}`,
     ].map(principalId => ({
       principalId,
       tenantId: input.tenantId,
@@ -220,6 +221,11 @@ export function createWorkroomDataGovernanceBootstrapCandidate(input: Readonly<{
     ...operationalRule,
     allowedPurposes: ['workroom_awareness' as const, 'portfolio_oversight' as const],
   });
+  const acceptanceProjectionRule = Object.freeze({
+    ...operationalRule,
+    allowedPurposes: ['acceptance_review' as const],
+    retentionClass: 'project_record' as const,
+  });
   const candidate: ProjectDataGovernanceAuthorityCandidate = {
     version: 1,
     revision: input.revision,
@@ -309,10 +315,23 @@ export function createWorkroomDataGovernanceBootstrapCandidate(input: Readonly<{
         },
         requestedMode: 'full',
       },
+      'acceptance-projection:acceptance-policy': {
+        destinationId: workroomDestination.id,
+        channel: 'context_view',
+        purpose: 'acceptance_review',
+        fixedPrincipalId: `service:workroom-acceptance-policy:${input.projectId}`,
+        recipients: workroomRecipients,
+        principal: {
+          role: 'reviewer', clearance: 'project_internal',
+          allowedPurposes: ['acceptance_review'],
+        },
+        requestedMode: 'full',
+      },
     },
     derivedPayloads: {
       projection: projectionRule,
       journal: operationalRule,
+      acceptanceProjection: acceptanceProjectionRule,
     },
     approvals: [],
   };

--- a/packages/im/agent/src/plugin-runtime/workroom-data-governance-runtime.ts
+++ b/packages/im/agent/src/plugin-runtime/workroom-data-governance-runtime.ts
@@ -383,6 +383,7 @@ export class WorkroomDataGovernanceRuntime {
       payload,
       source,
       signal: this.options.signal,
+      createdAt: input.occurredAt,
       publicationScope: input.runId,
     });
   }
@@ -392,7 +393,14 @@ export class WorkroomDataGovernanceRuntime {
   ): Promise<void> {
     if (!this.options.payloadWrites) return;
     for (const receipt of input.receipts) {
-      await this.options.payloadWrites.publish(journalIntentId(input.projectId, input.runId, receipt), input.publicationDigest);
+      const intentId = journalIntentId(input.projectId, input.runId, receipt);
+      const pending = await this.options.payloadWrites.read(intentId);
+      if (!pending) throw new Error('Governed Workroom Journal payload intent is unavailable');
+      if (pending.state === 'published') continue;
+      if (pending.state !== 'authority_indexed') {
+        throw new Error(`Governed Workroom Journal payload cannot be published from ${pending.state}`);
+      }
+      await this.options.payloadWrites.publish(intentId, input.publicationDigest);
     }
   }
 
@@ -400,12 +408,12 @@ export class WorkroomDataGovernanceRuntime {
     input: Parameters<NonNullable<WorkroomJournalPayloadPort['prepare']>>[0],
   ): Promise<void> {
     if (!this.options.payloadWrites) return;
-    const candidates = new Set(input.receipts.map(receipt =>
-      journalIntentId(input.projectId, input.runId, receipt)));
-    for (const pending of await this.options.payloadWrites.listUnpublished(input.projectId, input.runId)) {
-      if (!candidates.has(pending.intentId)) {
-        await this.options.payloadWrites.requirePurge(pending.intentId, 'restart_unpublished');
-        await this.#purgeIntent(pending.intentId);
+    for (const receipt of input.receipts) {
+      const pending = await this.options.payloadWrites.read(
+        journalIntentId(input.projectId, input.runId, receipt),
+      );
+      if (!pending || (pending.state !== 'authority_indexed' && pending.state !== 'published')) {
+        throw new Error('Governed Workroom Journal payload is not ready for header publication');
       }
     }
   }
@@ -415,11 +423,11 @@ export class WorkroomDataGovernanceRuntime {
   ): Promise<void> {
     if (!this.options.payloadWrites) return;
     for (const receipt of input.receipts) {
-      await this.options.payloadWrites.requirePurge(
-        journalIntentId(input.projectId, input.runId, receipt),
-        input.reason,
-      );
-      await this.#purgeIntent(journalIntentId(input.projectId, input.runId, receipt));
+      const intentId = journalIntentId(input.projectId, input.runId, receipt);
+      const pending = await this.options.payloadWrites.read(intentId);
+      if (!pending || pending.state === 'published' || pending.state === 'purge_required') continue;
+      await this.options.payloadWrites.requirePurge(intentId, input.reason);
+      await this.#purgeIntent(intentId);
     }
   }
 
@@ -427,15 +435,15 @@ export class WorkroomDataGovernanceRuntime {
     input: Parameters<NonNullable<WorkroomJournalPayloadPort['reconcile']>>[0],
   ): Promise<void> {
     if (!this.options.payloadWrites) return;
-    const published = new Set(input.receipts.map(receipt =>
-      journalIntentId(input.projectId, input.runId, receipt)));
-    for (const pending of await this.options.payloadWrites.listUnpublished(input.projectId, input.runId)) {
-      if (published.has(pending.intentId)) {
-        await this.options.payloadWrites.publish(pending.intentId, input.publicationDigest);
-      } else {
-        await this.options.payloadWrites.requirePurge(pending.intentId, 'restart_unpublished');
-        await this.#purgeIntent(pending.intentId);
+    for (const receipt of input.receipts) {
+      const intentId = journalIntentId(input.projectId, input.runId, receipt);
+      const pending = await this.options.payloadWrites.read(intentId);
+      if (!pending) throw new Error('Governed Workroom Journal payload intent is unavailable');
+      if (pending.state === 'published') continue;
+      if (pending.state !== 'authority_indexed') {
+        throw new Error(`Governed Workroom Journal committed payload is ${pending.state}`);
       }
+      await this.options.payloadWrites.publish(intentId, input.publicationDigest);
     }
   }
 
@@ -444,20 +452,48 @@ export class WorkroomDataGovernanceRuntime {
       operationId: `workroom-journal-read:${input.eventId}:${digest(input.fieldPath)}`,
       projectId: input.projectId,
     });
-    const authority = await this.options.repository.readProject(input.projectId);
+    const currentAuthority = await this.options.repository.readProject(input.projectId);
+    const source = await this.options.repository.readSource(
+      input.projectId,
+      input.receipt.descriptor.objectId,
+      input.receipt.descriptor.payloadHash,
+    );
+    const authority = source && currentAuthority
+      ? source.projectAuthorityDigest === currentAuthority.digest
+        ? currentAuthority
+        : await this.options.repository.readProjectRevision?.(
+          input.projectId,
+          source.projectAuthorityRevision,
+        )
+      : undefined;
     const sinkRuleId = 'workroom-journal:kernel-replay';
     const sink = authority?.sinks[sinkRuleId];
-    if (!authority || !sink?.fixedPrincipalId) {
+    const destination = sink && authority?.policy.destinations[sink.destinationId];
+    if (!source || !authority || source.projectAuthorityDigest !== authority.digest
+      || source.projectAuthorityRevision !== authority.revision || !sink?.fixedPrincipalId
+      || !destination) {
       throw new Error('Workroom Journal replay disclosure authority is unavailable');
     }
-    const manifest = await this.disclosureManifest.materialize({
+    const manifest = await this.#materialize({
       operationId: `workroom-journal-read:${input.eventId}:${digest(input.fieldPath)}`,
-      projectId: input.projectId,
-      sourceRef: input.receipt.descriptor.objectId,
-      sourceDigest: input.receipt.descriptor.payloadHash,
-      sinkRuleId,
-      principalId: sink.fixedPrincipalId,
-    }, this.options.signal);
+      authority,
+      source,
+      context: {
+        channel: sink.channel,
+        purpose: sink.purpose,
+        requestedMode: sink.requestedMode,
+        policyRevision: authority.policy.revision,
+        principal: {
+          principalId: sink.fixedPrincipalId,
+          tenantId: authority.tenantId,
+          projectId: authority.projectId,
+          ...sink.principal,
+        },
+        destination,
+        recipients: structuredClone(sink.recipients),
+      },
+      signal: this.options.signal,
+    });
     if (!manifest || manifest.output.mode !== 'full'
       || manifest.output.handle.vaultObjectId !== input.receipt.descriptor.vaultObjectId
       || manifest.output.handle.descriptorDigest !== input.receipt.descriptor.descriptorDigest
@@ -650,19 +686,52 @@ export class WorkroomDataGovernanceRuntime {
       if (!trusted || canonicalWorkroomJson(trusted) !== canonicalWorkroomJson(input.receipt.source)) {
         return undefined;
       }
-      const authority = await this.options.repository.readProject(input.projectId);
+      const sourceAuthority = await this.options.repository.readSource(
+        input.projectId,
+        input.receipt.objectId,
+        input.receipt.payloadHash,
+      );
+      if (!sourceAuthority
+        || sourceAuthority.sourceBindingDigest !== input.receipt.source.bindingDigest
+        || sourceAuthority.handle.vaultObjectId !== input.receipt.vaultObjectId
+        || sourceAuthority.handle.descriptorDigest !== input.receipt.descriptorDigest
+        || sourceAuthority.handle.locationManifestDigest !== input.receipt.locationManifestDigest) {
+        return undefined;
+      }
+      const currentAuthority = await this.options.repository.readProject(input.projectId);
+      const authority = currentAuthority?.revision === sourceAuthority.projectAuthorityRevision
+        && currentAuthority.digest === sourceAuthority.projectAuthorityDigest
+        ? currentAuthority
+        : await this.options.repository.readProjectRevision?.(
+          input.projectId,
+          sourceAuthority.projectAuthorityRevision,
+        );
       const sinkRuleId = 'acceptance-projection:acceptance-policy';
       const sink = authority?.sinks[sinkRuleId];
-      if (!authority || !sink?.fixedPrincipalId) return undefined;
-      const manifest = await this.disclosureManifest.materialize({
+      const destination = sink && authority?.policy.destinations[sink.destinationId];
+      if (!authority || authority.digest !== sourceAuthority.projectAuthorityDigest
+        || !sink?.fixedPrincipalId || !destination) return undefined;
+      const manifest = await this.#materialize({
         operationId: input.operationId,
-        projectId: input.projectId,
-        sourceRef: input.receipt.objectId,
-        sourceDigest: input.receipt.payloadHash,
-        sinkRuleId,
-        principalId: sink.fixedPrincipalId,
-      }, linked.signal);
-      if (!manifest || manifest.output.mode !== 'full'
+        authority,
+        source: sourceAuthority,
+        context: {
+          channel: sink.channel,
+          purpose: sink.purpose,
+          requestedMode: sink.requestedMode,
+          policyRevision: authority.policy.revision,
+          principal: {
+            principalId: sink.fixedPrincipalId,
+            tenantId: authority.tenantId,
+            projectId: authority.projectId,
+            ...sink.principal,
+          },
+          destination,
+          recipients: structuredClone(sink.recipients),
+        },
+        signal: linked.signal,
+      });
+      if (manifest.output.mode !== 'full'
         || manifest.output.handle.vaultObjectId !== input.receipt.vaultObjectId
         || manifest.output.handle.descriptorDigest !== input.receipt.descriptorDigest
         || manifest.output.handle.locationManifestDigest !== input.receipt.locationManifestDigest
@@ -708,6 +777,7 @@ export class WorkroomDataGovernanceRuntime {
     payload: Uint8Array;
     source: TSource;
     signal: AbortSignal;
+    createdAt?: number;
     consumer?: 'authority_source' | 'evidence_header' | 'task_report_header' | 'journal_header';
     publicationScope?: string;
     publication?: WorkroomGovernedPayloadPublicationPort;
@@ -726,10 +796,41 @@ export class WorkroomDataGovernanceRuntime {
       if (!authority) throw new Error('Data Governance Project authority is unavailable');
       const rule = authority.derivedPayloads[input.kind];
       if (!rule) throw new Error(`Governed ${input.kind} payload authority is unavailable`);
-      const createdAt = this.#now();
+      const payloadHash = hashBytes(input.payload);
+      const existingSource = await this.options.repository.readSource(
+        input.projectId,
+        input.objectId,
+        payloadHash,
+      );
+      if (existingSource && !input.publication
+        && existingSource.sourceBindingDigest === input.source.bindingDigest
+        && existingSource.projectAuthorityRevision === authority.revision
+        && existingSource.projectAuthorityDigest === authority.digest
+        && existingSource.descriptor.objectId === input.objectId
+        && existingSource.descriptor.payloadHash === payloadHash
+        && existingSource.handle.objectId === input.objectId
+        && existingSource.handle.payloadHash === payloadHash
+        && existingSource.handle.descriptorDigest === digest(existingSource.descriptor)) {
+        await infrastructure.payloadLifecycleIndex.register({
+          operationId: input.operationId,
+          handle: existingSource.handle,
+        }, linked.signal);
+        return deepFreeze({
+          descriptor: {
+            vaultObjectId: existingSource.handle.vaultObjectId,
+            objectId: existingSource.handle.objectId,
+            payloadHash: existingSource.handle.payloadHash,
+            descriptorDigest: existingSource.handle.descriptorDigest,
+            locationManifestDigest: existingSource.handle.locationManifestDigest,
+            bytes: input.payload.byteLength,
+          },
+          source: structuredClone(input.source),
+        });
+      }
+      const createdAt = input.createdAt ?? this.#now();
       const classified = classifyDataDescriptor({
         objectId: input.objectId,
-        payloadHash: hashBytes(input.payload),
+        payloadHash,
         tenantId: authority.tenantId,
         projectId: authority.projectId,
         kind: input.kind === 'evidence'
@@ -1029,6 +1130,7 @@ export class WorkroomDataGovernanceRuntime {
     sourceBindingDigest: string,
     signal: AbortSignal,
   ): Promise<GovernedSourceAuthority> {
+    const infrastructure = await this.#requirePayloadInfrastructure(signal);
     const existing = await this.options.repository.readSource(
       request.input.projectId,
       request.input.source.ref,
@@ -1040,9 +1142,12 @@ export class WorkroomDataGovernanceRuntime {
         || existing.projectAuthorityRevision !== authority.revision) {
         throw new Error('Governed source authority is stale for current policy');
       }
+      await infrastructure.payloadLifecycleIndex.register({
+        operationId: request.input.operationId,
+        handle: existing.handle,
+      }, signal);
       return existing;
     }
-    await this.#requirePayloadInfrastructure(signal);
     const payload = new TextEncoder().encode(request.input.source.text);
     const payloadHash = hashBytes(payload);
     const timestamp = nonNegative(request.input.source.event.timestamp, 'source timestamp');
@@ -1074,6 +1179,10 @@ export class WorkroomDataGovernanceRuntime {
       descriptorDigest: digest(descriptor),
       payload,
       sourceBindingDigest,
+    }, signal);
+    await infrastructure.payloadLifecycleIndex.register({
+      operationId: request.input.operationId,
+      handle,
     }, signal);
     return await this.options.repository.appendSource(createGovernedSourceAuthority({
       version: 1,
@@ -1171,6 +1280,10 @@ export class WorkroomDataGovernanceRuntime {
           undefined, authority.digest);
         return deepFreeze({ status: 'blocked', reason: 'source_authority_conflict' });
       }
+      const authorityEpoch = deepFreeze({
+        revision: authority.revision,
+        digest: authority.digest,
+      });
       const payload = new TextEncoder().encode(input.body);
       const payloadHash = hashBytes(payload);
       const source = deepFreeze<WorkroomGovernedPayloadReceipt['source']>({
@@ -1178,19 +1291,21 @@ export class WorkroomDataGovernanceRuntime {
         ref: `workroom-projection-events:${digest({
           projectId: input.projectId,
           sourceEventIds: input.sourceEventIds,
+          authorityEpoch,
         })}`,
-        digest: digest({ version: 1, sourceEventIds: input.sourceEventIds }),
+        digest: digest({ version: 1, sourceEventIds: input.sourceEventIds, authorityEpoch }),
         bindingDigest: digest({
           version: 1, projectId: input.projectId, sourceEventIds: input.sourceEventIds, payloadHash,
+          authorityEpoch,
         }),
         verification: 'verified',
       });
       const receipt = await this.#writeDerivedPayload({
-        operationId: input.operationId,
+        operationId: `${input.operationId}:authority:${authority.revision}:${authority.digest}`,
         projectId: input.projectId,
         kind: 'projection',
         objectId: `workroom-projection-payload:${digest({
-          projectId: input.projectId, sourceEventIds: input.sourceEventIds, payloadHash,
+          projectId: input.projectId, sourceEventIds: input.sourceEventIds, payloadHash, authorityEpoch,
         })}`,
         payload,
         source,

--- a/packages/im/agent/src/plugin-runtime/workroom-data-governance-storage.ts
+++ b/packages/im/agent/src/plugin-runtime/workroom-data-governance-storage.ts
@@ -111,8 +111,7 @@ export class ActivatableWorkroomDataGovernanceStorage {
     const before = await lifecycleStreams(this.#fileLifecycle, projects);
     await this.lifecycle.activate(input.lifecycle, projects, this.#fileLifecycle);
     const afterSource = await lifecycleStreams(this.#fileLifecycle, projects);
-    const afterTarget = await lifecycleStreams(this.lifecycle, projects);
-    if (digest(before) !== digest(afterSource) || digest(before) !== digest(afterTarget)) {
+    if (digest(before) !== digest(afterSource)) {
       throw new Error('Workroom Data Governance Lifecycle cutover replay drift');
     }
     input.signal.throwIfAborted();

--- a/packages/im/agent/src/plugin-runtime/workroom-dynamic-planning-provider.ts
+++ b/packages/im/agent/src/plugin-runtime/workroom-dynamic-planning-provider.ts
@@ -12,6 +12,7 @@ import {
   type TrustedDisclosureTransformPort,
 } from '../data-governance/disclosure-manifest.js';
 import type { WorkroomCatalog } from '../workroom/catalog.js';
+import { digestWorkroomCatalogProjectBinding } from '../workroom/catalog-definition.js';
 import {
   compareCanonicalWorkroomText,
   canonicalWorkroomJson,
@@ -384,7 +385,7 @@ async function resolvePlanningAuthority(
   const definition = catalog.definitions[input.projectId];
   if (!definition || definition.enabled === false || !definition.conversation
     || catalog.revision !== input.projectRevision
-    || digest(definition) !== input.projectDigest
+    || digestWorkroomCatalogProjectBinding(definition) !== input.projectDigest
     || definition.conversation.agent !== input.orchestratorAgentDefinitionId
     || !definition.members.some(member => member.agent === input.orchestratorAgentDefinitionId
       && member.role === 'orchestrator')) {

--- a/packages/im/agent/src/plugin-runtime/workroom-local-agent-loop.ts
+++ b/packages/im/agent/src/plugin-runtime/workroom-local-agent-loop.ts
@@ -259,10 +259,21 @@ export class DurableReportLocalModelExecutionPort implements LocalModelExecution
     return [
       `Execute Workroom Task ${request.envelope.taskKey}@${request.envelope.taskRevision}.`,
       `Workspace mount: ${request.envelope.workspace.mountRef}.`,
-      'Return only JSON with claims[] and evidence[]. Each claim uses a human-readable label; the Host assigns its canonical claimId. Verified claims must reference evidenceIds.',
+      ...structuredTaskReportPrompt(),
       'Do not use chat Subagent lifecycle or emit Task status commands.',
     ].join('\n');
   }
+}
+
+export function structuredTaskReportPrompt(): readonly string[] {
+  return Object.freeze([
+    'Return exactly one JSON object, with no Markdown fence or prose before or after it.',
+    'The only permitted top-level keys are "claims" and "evidence". Never add task_id, taskId, taskKey, status, summary, or other metadata.',
+    'Each claims[] item must use exactly: label, key, value, status, evidenceIds, artifactRefs; optional keys are validUntil and supersedesFactIds. Use [] for empty evidenceIds and artifactRefs.',
+    'Each evidence[] item must use exactly: id, mediaType, content, source. Each source must use exactly: kind and locator; kind is command, file, url, tool, or human.',
+    'The Host owns Task/Assignment identity and canonical claimId. Do not repeat those fields. A verified claim must reference verified evidenceIds; otherwise use status "assumed".',
+    'Required shape: {"claims":[{"label":"result","key":"task.result","value":"...","status":"assumed","evidenceIds":[],"artifactRefs":[]}],"evidence":[]}',
+  ]);
 }
 
 function parseReportOutput(serialized: string): LocalTaskReportOutput {

--- a/packages/im/agent/src/plugin-runtime/workroom-local-assignment-runtime.ts
+++ b/packages/im/agent/src/plugin-runtime/workroom-local-assignment-runtime.ts
@@ -16,6 +16,7 @@ export interface WorkroomLocalAssignmentRuntimeOptions {
   readonly executor: AssignmentExecutorPort;
   readonly now?: () => number;
   readonly intervalMs?: number;
+  readonly heartbeatIntervalMs?: number;
   readonly maxCasRetries?: number;
   readonly onError?: (error: unknown) => void;
 }
@@ -38,6 +39,7 @@ export class WorkroomLocalAssignmentRuntime {
   readonly #ingress: AssignmentObservationIngress;
   readonly #now: () => number;
   readonly #intervalMs: number;
+  readonly #heartbeatIntervalMs: number;
   readonly #maxCasRetries: number;
   readonly #active = new Map<string, Readonly<{
     controller: AbortController;
@@ -51,6 +53,10 @@ export class WorkroomLocalAssignmentRuntime {
     this.#ingress = new AssignmentObservationIngress({ kernel: options.kernel });
     this.#now = options.now ?? Date.now;
     this.#intervalMs = positive(options.intervalMs ?? 1_000, 'intervalMs');
+    this.#heartbeatIntervalMs = positive(
+      options.heartbeatIntervalMs ?? 10_000,
+      'heartbeatIntervalMs',
+    );
     this.#maxCasRetries = positive(options.maxCasRetries ?? 4, 'maxCasRetries');
   }
 
@@ -79,7 +85,7 @@ export class WorkroomLocalAssignmentRuntime {
     const controller = new AbortController();
     const promise = (async () => {
       await this.#assertLeased(envelope);
-      await this.#execute(envelope, controller.signal);
+      await this.#execute(envelope, controller);
     })();
     this.#active.set(envelope.assignmentId, Object.freeze({ controller, promise }));
     try {
@@ -144,36 +150,79 @@ export class WorkroomLocalAssignmentRuntime {
     return Object.freeze({ started, recovered });
   }
 
-  async #execute(envelope: AssignmentExecutionEnvelope, signal: AbortSignal): Promise<void> {
+  async #execute(envelope: AssignmentExecutionEnvelope, controller: AbortController): Promise<void> {
+    const { signal } = controller;
     await this.options.kernel.execute(envelope.projectId, envelope.runId, {
       type: 'start_assignment',
       assignmentId: envelope.assignmentId,
     });
     const observations = this.#ingress.bind(envelope);
-    for await (const observation of executeAssignment(this.options.executor, envelope, signal)) {
-      signal.throwIfAborted();
-      let committed = false;
-      for (let attempt = 0; attempt < this.#maxCasRetries; attempt += 1) {
-        const state = await this.options.kernel.read(envelope.projectId, envelope.runId);
-        const assignment = state.assignments[envelope.assignmentId];
-        if (!assignment
-          || assignment.envelopeDigest !== envelope.digest
-          || assignment.fence !== envelope.fence
-          || assignment.taskRevision !== envelope.taskRevision) {
-          throw new Error('Local Assignment observation Envelope is stale or targets another authority scope');
-        }
-        try {
-          await observations.apply(observation, state.sequence);
-          committed = true;
-          break;
-        } catch (error) {
-          if (!(error instanceof WorkroomSequenceConflictError)) throw error;
-        }
+    let heartbeatSequence = 0;
+    let heartbeatTimer: ReturnType<typeof setTimeout> | undefined;
+    let heartbeatRunning: Promise<void> | undefined;
+    let heartbeatsStopped = false;
+    const scheduleHeartbeat = (): void => {
+      if (heartbeatsStopped || signal.aborted) return;
+      heartbeatTimer = setTimeout(() => {
+        heartbeatTimer = undefined;
+        if (heartbeatsStopped || signal.aborted) return;
+        heartbeatSequence += 1;
+        heartbeatRunning = this.#applyObservation(envelope, observations, {
+          version: 1,
+          type: 'heartbeat',
+          observationId: `local-runtime-heartbeat:${heartbeatSequence}`,
+          envelopeDigest: envelope.digest,
+        }).catch(error => {
+          if (!controller.signal.aborted) controller.abort(error);
+          throw error;
+        }).finally(() => {
+          heartbeatRunning = undefined;
+          scheduleHeartbeat();
+        });
+        void heartbeatRunning.catch(() => undefined);
+      }, this.#heartbeatIntervalMs);
+      heartbeatTimer.unref?.();
+    };
+    const stopHeartbeats = async (): Promise<void> => {
+      heartbeatsStopped = true;
+      if (heartbeatTimer) clearTimeout(heartbeatTimer);
+      heartbeatTimer = undefined;
+      await heartbeatRunning?.catch(() => undefined);
+    };
+    scheduleHeartbeat();
+    try {
+      for await (const observation of executeAssignment(this.options.executor, envelope, signal)) {
+        signal.throwIfAborted();
+        if (observation.type === 'execution_completed') await stopHeartbeats();
+        await this.#applyObservation(envelope, observations, observation);
       }
-      if (!committed) {
-        throw new Error('Local Assignment observation exceeded Kernel CAS retry budget');
+    } finally {
+      await stopHeartbeats();
+    }
+  }
+
+  async #applyObservation(
+    envelope: AssignmentExecutionEnvelope,
+    observations: ReturnType<AssignmentObservationIngress['bind']>,
+    observation: Parameters<ReturnType<AssignmentObservationIngress['bind']>['apply']>[0],
+  ): Promise<void> {
+    for (let attempt = 0; attempt < this.#maxCasRetries; attempt += 1) {
+      const state = await this.options.kernel.read(envelope.projectId, envelope.runId);
+      const assignment = state.assignments[envelope.assignmentId];
+      if (!assignment
+        || assignment.envelopeDigest !== envelope.digest
+        || assignment.fence !== envelope.fence
+        || assignment.taskRevision !== envelope.taskRevision) {
+        throw new Error('Local Assignment observation Envelope is stale or targets another authority scope');
+      }
+      try {
+        await observations.apply(observation, state.sequence);
+        return;
+      } catch (error) {
+        if (!(error instanceof WorkroomSequenceConflictError)) throw error;
       }
     }
+    throw new Error('Local Assignment observation exceeded Kernel CAS retry budget');
   }
 
   async #assertLeased(envelope: AssignmentExecutionEnvelope): Promise<void> {

--- a/packages/im/agent/src/plugin-runtime/workroom-portfolio-control-composition.ts
+++ b/packages/im/agent/src/plugin-runtime/workroom-portfolio-control-composition.ts
@@ -57,6 +57,7 @@ export function installWorkroomPortfolioControlWorker(
     route: options.route,
     delivery: control,
     acknowledgements: control,
+    ...(options.onError ? { onDeliveryError: options.onError } : {}),
   });
   const worker = new GenerationOwnedPortfolioControlWorker({
     runtime,

--- a/packages/im/agent/src/plugin-runtime/workroom-portfolio-control-runtime.ts
+++ b/packages/im/agent/src/plugin-runtime/workroom-portfolio-control-runtime.ts
@@ -56,6 +56,7 @@ export interface WorkroomPortfolioControlRuntimeOptions {
   readonly route: PortfolioWorkroomRouteAuthorityPort;
   readonly delivery: PortfolioWorkroomControlDeliveryPort;
   readonly acknowledgements: PortfolioWorkroomAckAuthorityPort;
+  readonly onDeliveryError?: (error: unknown, item: PortfolioControlOutboxItem) => void;
 }
 
 /** Durable source scanner + two-phase owning Workroom control worker. */
@@ -176,6 +177,7 @@ export class WorkroomPortfolioControlRuntime {
           ? await this.options.delivery.reconcile(item, signal)
           : await this.options.delivery.deliver(item, signal);
       } catch (error) {
+        this.options.onDeliveryError?.(error, item);
         if (error instanceof PortfolioGrantAssignmentCompensatedError) {
           await this.#append(portfolioId, {
             type: 'item.compensated', payload: {

--- a/packages/im/agent/src/plugin-runtime/workroom-portfolio-grant-assignment.ts
+++ b/packages/im/agent/src/plugin-runtime/workroom-portfolio-grant-assignment.ts
@@ -247,7 +247,13 @@ export class KernelPortfolioGrantAssignmentIssuance implements PortfolioGrantAss
       if (recovered) return deepFreeze({ kind: 'claimed' as const, ...recovered });
       const state = await this.kernel.read(claim.request.projectId, claim.request.runId);
       const task = state.tasks[claim.request.taskKey];
-      const reason = deterministicFailureReason(state.status, task?.status, task?.revision, preview.taskRevision);
+      const reason = deterministicFailureReason(
+        state.status,
+        task?.status,
+        task?.revision,
+        preview.taskRevision,
+        task?.acceptanceContract !== undefined,
+      );
       if (!reason) throw error;
       const kernelFactDigest = digest(state);
       const proofBody = deepFreeze({
@@ -452,13 +458,16 @@ function deterministicFailureReason(
   taskStatus: string | undefined,
   taskRevision: number | undefined,
   previewTaskRevision: number,
+  acceptanceContractPinned: boolean,
 ): PortfolioGrantAssignmentFailureReason | undefined {
   if (runStatus === 'completed' || runStatus === 'cancelled') return 'run_terminal';
   if (taskStatus === 'accepted' || taskStatus === 'failed' || taskStatus === 'cancelled') {
     return 'task_terminal';
   }
   if (taskRevision !== undefined && taskRevision !== previewTaskRevision) return 'task_stale';
-  if (taskStatus === 'executing' || taskStatus === 'awaiting_acceptance' || taskStatus === 'cancelling') {
+  if (!acceptanceContractPinned) return 'task_stale';
+  if (taskStatus === 'blocked' || taskStatus === 'executing'
+    || taskStatus === 'awaiting_acceptance' || taskStatus === 'cancelling') {
     return 'task_stale';
   }
   return undefined;

--- a/packages/im/agent/src/plugin-runtime/workroom-portfolio-kernel-authority.ts
+++ b/packages/im/agent/src/plugin-runtime/workroom-portfolio-kernel-authority.ts
@@ -57,8 +57,11 @@ implements PortfolioKernelCommandAuthorityPort {
     const state = replayWorkroom(events);
     if (state.sequence !== input.kernelSequence || digest(state) !== input.kernelFactDigest
       || Object.hasOwn(state.assignments, input.assignmentRef)) return undefined;
-    if (failureReason(state.status, state.tasks[decision.taskKey]?.status,
-      state.tasks[decision.taskKey]?.revision, decision.taskRevision) !== input.failureReason) return undefined;
+    if (failureReason(
+      state.status,
+      state.tasks[decision.taskKey],
+      decision.taskRevision,
+    ) !== input.failureReason) return undefined;
     const claims = {
       portfolioId: input.portfolioId,
       action: 'assignment_failed' as const,
@@ -84,16 +87,20 @@ implements PortfolioKernelCommandAuthorityPort {
 
 function failureReason(
   runStatus: string,
-  taskStatus: string | undefined,
-  taskRevision: number | undefined,
+  task: ReturnType<typeof replayWorkroom>['tasks'][string] | undefined,
   decisionTaskRevision: number,
 ) {
   if (runStatus === 'completed' || runStatus === 'cancelled') return 'run_terminal' as const;
-  if (taskStatus === 'accepted' || taskStatus === 'failed' || taskStatus === 'cancelled') {
+  if (task?.status === 'accepted' || task?.status === 'failed' || task?.status === 'cancelled') {
     return 'task_terminal' as const;
   }
-  if (taskRevision !== undefined && taskRevision !== decisionTaskRevision) return 'task_stale' as const;
-  if (taskStatus === 'executing' || taskStatus === 'awaiting_acceptance' || taskStatus === 'cancelling') {
+  if (task?.revision !== undefined && task.revision !== decisionTaskRevision) return 'task_stale' as const;
+  // Pre-contract Grants created by an older runtime cannot be issued safely.
+  // The issuer and this exact Kernel proof authority must agree so the durable
+  // consumed Grant can be compensated instead of retrying forever.
+  if (task && !task.acceptanceContract) return 'task_stale' as const;
+  if (task?.status === 'executing' || task?.status === 'awaiting_acceptance'
+    || task?.status === 'cancelling') {
     return 'task_stale' as const;
   }
   return undefined;

--- a/packages/im/agent/src/plugin-runtime/workroom-profile-authority-composition.ts
+++ b/packages/im/agent/src/plugin-runtime/workroom-profile-authority-composition.ts
@@ -8,6 +8,10 @@ import {
   deepFreezeWorkroomValue as deepFreeze,
   digestCanonicalWorkroomValue as digest,
 } from '../workroom/canonical-value.js';
+import {
+  digestWorkroomCatalogProjectBinding,
+  type WorkroomDefinition,
+} from '../workroom/catalog-definition.js';
 import { DurableFileStore } from '../workroom/durable-file-store.js';
 import { FileProjectProfileJournal } from '../workroom/file-profile-journal.js';
 import { workroomProjectProfileRegistryToken } from './workroom-assignment-authority-provider.js';
@@ -120,7 +124,7 @@ export function digestWorkroomProfileCatalogProject(definition: unknown): string
   if (!definition || typeof definition !== 'object' || Array.isArray(definition)) {
     throw new Error('Workroom Profile Catalog Project definition is invalid');
   }
-  return digest(structuredClone(definition));
+  return digestWorkroomCatalogProjectBinding(definition as WorkroomDefinition);
 }
 
 export function createSnapshotWorkroomProfileGenerationView(options: Readonly<{

--- a/packages/im/agent/src/plugin-runtime/workroom-profile-authority-runtime.ts
+++ b/packages/im/agent/src/plugin-runtime/workroom-profile-authority-runtime.ts
@@ -476,6 +476,10 @@ export interface PublishPlanningPolicyCommand {
 }
 
 export interface WorkroomProfileControlPort {
+  readPlanningPolicy(
+    projectId: string,
+    profileRevisionId: string,
+  ): Promise<WorkroomPlanningPolicyRevision | undefined>;
   publishPack(command: PublishCapabilityPackCommand, signal: AbortSignal): Promise<CapabilityPackPublication>;
   publishProfile(command: PublishProjectProfileCommand, signal: AbortSignal): Promise<ProjectProfileRegistrySnapshot>;
   publishRollback(
@@ -607,6 +611,8 @@ export class WorkroomProfileAuthorityRuntime {
 
   constructor(readonly options: WorkroomProfileAuthorityRuntimeOptions) {
     this.control = Object.freeze({
+      readPlanningPolicy: async (projectId: string, profileRevisionId: string) =>
+        await this.options.repository.readPlanningPolicy(projectId, profileRevisionId),
       publishPack: async (command: PublishCapabilityPackCommand, signal: AbortSignal) =>
         await this.#publishPack(command, signal),
       publishProfile: async (command: PublishProjectProfileCommand, signal: AbortSignal) =>

--- a/packages/im/agent/src/plugin-runtime/workroom-projection-runtime.ts
+++ b/packages/im/agent/src/plugin-runtime/workroom-projection-runtime.ts
@@ -45,6 +45,12 @@ export interface WorkroomProjectionRuntimeOptions {
   readonly maxRunsPerTick: number;
   readonly maxDeliveriesPerTick: number;
   readonly governance?: WorkroomProjectionGovernancePort;
+  /** Renews one Workroom view from the exact current Catalog + Endpoint generation. */
+  readonly renewWorkroomBinding?: (
+    projectId: string,
+    catalog: WorkroomCatalogSnapshot,
+    signal: AbortSignal,
+  ) => Promise<void>;
   /** Resolves a persistent Sponsor Room definition to the exact current Endpoint capability. */
   readonly resolveSponsorConversation?: (
     projectId: string,
@@ -91,6 +97,15 @@ export class WorkroomProjectionRuntime {
   async runOnce(signal: AbortSignal): Promise<WorkroomProjectionTickResult> {
     signal.throwIfAborted();
     const catalog = await this.options.catalog.read();
+    if (this.options.renewWorkroomBinding) {
+      for (const projectId of Object.keys(catalog.definitions).sort()) {
+        signal.throwIfAborted();
+        const definition = catalog.definitions[projectId];
+        if (!definition || definition.enabled === false || !definition.conversation
+          || definition.conversation.kind === 'repository') continue;
+        await this.options.renewWorkroomBinding(projectId, catalog, signal);
+      }
+    }
     if (this.options.lifecycleOverdue || this.options.portfolioSponsor) {
       await this.#ensureSponsorRoomBindings(catalog, signal);
     }

--- a/packages/im/agent/src/plugin-runtime/workroom-scheduler-portfolio-composition.ts
+++ b/packages/im/agent/src/plugin-runtime/workroom-scheduler-portfolio-composition.ts
@@ -1,7 +1,9 @@
 import type { Scope } from '@zhin.js/plugin-runtime';
 import type { WorkroomCatalog } from '../workroom/catalog.js';
 import type { WorkroomJournal } from '../workroom/journal.js';
+import type { WorkroomRunState } from '../workroom/kernel-contracts.js';
 import type { ProjectProfileRegistry } from '../workroom/profile-registry.js';
+import type { PortfolioResourceBundle } from '../portfolio/portfolio-journal.js';
 import {
   portfolioAtomicBundleAuthorityToken,
   portfolioPolicyAuthorityToken,
@@ -35,6 +37,11 @@ export interface InstallWorkroomSchedulerPortfolioDispatchResourcesOptions {
   readonly catalog: Pick<WorkroomCatalog, 'read'>;
   readonly profiles: Pick<ProjectProfileRegistry, 'read'>;
   readonly journal?: Pick<WorkroomJournal, 'read'>;
+  readonly fallbackResourceRequirements?: PortfolioResourceBundle;
+  readonly runState: Readonly<{
+    read(projectId: string, runId: string): Promise<WorkroomRunState>;
+    pinTaskAcceptance(projectId: string, runId: string, taskKey: string): Promise<WorkroomRunState>;
+  }>;
 }
 
 export interface WorkroomSchedulerPortfolioDispatchResources {
@@ -89,6 +96,9 @@ export function installWorkroomSchedulerPortfolioDispatchResources(
               ? options.resources.use(portfolioAtomicBundleAuthorityToken).validate(input)
               : Promise.resolve(undefined),
         }),
+        ...(options.fallbackResourceRequirements
+          ? { fallbackResourceRequirements: options.fallbackResourceRequirements }
+          : {}),
       }),
     );
   }
@@ -119,6 +129,7 @@ export function installWorkroomSchedulerPortfolioDispatchResources(
           return options.resources.use(workroomSchedulerCapacityRequestToken).request(input);
         },
       }),
+      runState: options.runState,
     });
     options.resources.provide(workroomSchedulerDispatchSupplyToken, supply);
   }

--- a/packages/im/agent/src/plugin-runtime/workroom-scheduler-portfolio-request-authority.ts
+++ b/packages/im/agent/src/plugin-runtime/workroom-scheduler-portfolio-request-authority.ts
@@ -10,6 +10,7 @@ import {
   parsePortfolioCapacityRequest,
   parsePortfolioPolicySnapshot,
   parsePortfolioResourceBundle,
+  type PortfolioResourceBundle,
   type PortfolioPolicySnapshot,
 } from '../portfolio/portfolio-journal.js';
 import type { ValidatedAtomicResourceBundle } from '../portfolio/resource-bundle.js';
@@ -18,6 +19,7 @@ import {
   parseWorkroomDispatchTaskDecision,
   type WorkroomDispatchTaskDecision,
 } from '../workroom/workroom-scheduler.js';
+import { assertWorkflowPlanProposal, type WorkflowPlanProposal } from '../workroom/workflow-plan-builder.js';
 import type {
   PortfolioAtomicBundleAuthorityPort,
   PortfolioPolicyAuthorityPort,
@@ -79,6 +81,8 @@ export interface PinnedProfileWorkroomSchedulerPortfolioRequestAuthorityOptions 
   readonly scopes: WorkroomSchedulerPortfolioScopeAuthorityPort;
   readonly policies: PortfolioPolicyAuthorityPort;
   readonly bundles: PortfolioAtomicBundleAuthorityPort;
+  /** Explicit generation-owned fallback for legacy Profiles without a resource declaration. */
+  readonly fallbackResourceRequirements?: PortfolioResourceBundle;
 }
 
 /**
@@ -117,6 +121,16 @@ implements WorkroomSchedulerPortfolioRequestAuthorityPort {
     const task = getWorkroomScheduledTaskCapacitySnapshot(events, decision.taskKey);
     if (task.taskRevision !== decision.taskRevision || task.role !== decision.role) return undefined;
 
+    const admitted = events.filter(event => event.type === 'plan.admitted');
+    if (admitted.length !== 1) return undefined;
+    const plan = admitted[0]!.payload.plan;
+    if (!plan || typeof plan !== 'object') return undefined;
+    assertWorkflowPlanProposal(plan as WorkflowPlanProposal);
+    const admittedPlan = plan as WorkflowPlanProposal;
+    if (admittedPlan.projectId !== decision.projectId
+      || !admittedPlan.tasks.some(candidate => candidate.key === decision.taskKey
+        && candidate.role === decision.role)) return undefined;
+
     const registry = await this.options.profiles.read(decision.projectId);
     const pin = registry.runPins[decision.runId];
     const revision = pin && registry.revisions[pin.profileRevisionId];
@@ -127,12 +141,15 @@ implements WorkroomSchedulerPortfolioRequestAuthorityPort {
       || revision.compiledProfile.revisionId !== pin.profileRevisionId
       || revision.compiledProfile.projectId !== decision.projectId
       || revision.compiledProfile.digest !== pin.profileDigest) return undefined;
-    const requirements = revision.compiledProfile.workflows.flatMap(workflow => workflow.tasks)
-      .filter(candidate => candidate.key === decision.taskKey
-        && candidate.role === decision.role
-        && candidate.resourceRequirements !== undefined);
-    if (requirements.length !== 1) return undefined;
-    const resourceBundle = parsePortfolioResourceBundle(requirements[0]!.resourceRequirements);
+    const workflows = revision.compiledProfile.workflows.filter(workflow =>
+      workflow.id === admittedPlan.strategy.id && workflow.digest === admittedPlan.strategy.digest);
+    if (workflows.length !== 1 || admittedPlan.strategy.version !== pin.profileRevisionId) return undefined;
+    const templates = workflows[0]!.tasks.filter(candidate => candidate.role === decision.role);
+    if (templates.length !== 1) return undefined;
+    const requirements = templates[0]!.resourceRequirements
+      ?? this.options.fallbackResourceRequirements;
+    if (!requirements) return undefined;
+    const resourceBundle = parsePortfolioResourceBundle(requirements);
 
     const scopeInput = Object.freeze({
       generation: this.#generation,

--- a/packages/im/agent/src/plugin-runtime/workroom-scheduler-portfolio-supply.ts
+++ b/packages/im/agent/src/plugin-runtime/workroom-scheduler-portfolio-supply.ts
@@ -1,5 +1,6 @@
 import { createToken } from '@zhin.js/plugin-runtime';
 import type { WorkroomCatalog } from '../workroom/catalog.js';
+import type { WorkroomRunState } from '../workroom/kernel-contracts.js';
 import { parsePortfolioCapacityRequest } from '../portfolio/portfolio-journal.js';
 import {
   parseWorkroomDispatchTaskDecision,
@@ -11,6 +12,7 @@ import type {
 } from './workroom-portfolio-capacity.js';
 import {
   WorkroomSchedulerAssignmentRouteUnavailableError,
+  WorkroomSchedulerDurablyBlockedError,
   type WorkroomSchedulerAssignmentRoute,
   type WorkroomSchedulerAssignmentRoutePort,
   type WorkroomSchedulerDispatchSupplyPort,
@@ -43,6 +45,10 @@ export interface PortfolioFirstWorkroomSchedulerDispatchSupplyOptions {
   readonly routes: WorkroomSchedulerAssignmentRoutePort;
   readonly requests: WorkroomSchedulerPortfolioRequestAuthorityPort;
   readonly capacity: WorkroomSchedulerCapacityRequestPort;
+  readonly runState: Readonly<{
+    read(projectId: string, runId: string): Promise<WorkroomRunState>;
+    pinTaskAcceptance(projectId: string, runId: string, taskKey: string): Promise<WorkroomRunState>;
+  }>;
 }
 
 export class WorkroomSchedulerPortfolioCapacityUnavailableError
@@ -78,6 +84,34 @@ implements WorkroomSchedulerDispatchSupplyPort {
   async deliver(decision: WorkroomDispatchTaskDecision): Promise<void> {
     const exactDecision = parseWorkroomDispatchTaskDecision(decision);
     const resolved = await this.#resolve(exactDecision);
+    let state = await this.options.runState.read(exactDecision.projectId, exactDecision.runId);
+    let task = state.tasks[exactDecision.taskKey];
+    if (!task || task.revision !== exactDecision.taskRevision || task.status !== 'ready') {
+      throw new WorkroomSchedulerPortfolioCapacityUnavailableError(exactDecision, {
+        cause: new Error('Portfolio Capacity Request targets a stale Task'),
+      });
+    }
+    if (!task.acceptanceContract) {
+      try {
+        state = await this.options.runState.pinTaskAcceptance(
+          exactDecision.projectId,
+          exactDecision.runId,
+          exactDecision.taskKey,
+        );
+        task = state.tasks[exactDecision.taskKey];
+      } catch {
+        throw new WorkroomSchedulerDurablyBlockedError(
+          exactDecision,
+          `acceptance-contract:${exactDecision.projectId}:${exactDecision.runId}:${exactDecision.taskKey}`,
+        );
+      }
+      if (!task?.acceptanceContract) {
+        throw new WorkroomSchedulerDurablyBlockedError(
+          exactDecision,
+          `acceptance-contract:${exactDecision.projectId}:${exactDecision.runId}:${exactDecision.taskKey}`,
+        );
+      }
+    }
     try {
       await this.options.capacity.request(resolved.request);
     } catch (error) {

--- a/packages/im/agent/src/plugin-runtime/workroom-scheduler-runtime.ts
+++ b/packages/im/agent/src/plugin-runtime/workroom-scheduler-runtime.ts
@@ -228,9 +228,13 @@ export class WorkroomSchedulerRuntime {
               await this.options.unavailableControl?.block(decision);
               continue;
             }
+            // The exact Scheduler supply blocker changes the Task to blocked.
+            // Recover it before delivery so supplies that validate current Task
+            // readiness can consume the same durable dispatch fact.
+            await this.options.unavailableControl?.recover(decision);
           }
           await supply.deliver(decision);
-          await this.options.unavailableControl?.recover(decision);
+          if (!supply.probe) await this.options.unavailableControl?.recover(decision);
         } catch (error) {
           if (error instanceof WorkroomSchedulerDurablyBlockedError) continue;
           if (error instanceof WorkroomSchedulerAssignmentRouteUnavailableError

--- a/packages/im/agent/src/workroom/assignment-authority-grant-repository.ts
+++ b/packages/im/agent/src/workroom/assignment-authority-grant-repository.ts
@@ -37,7 +37,8 @@ export interface AssignmentAuthorityGrantRecordInput {
   readonly fence: number;
   readonly operationId: string;
   readonly agentDefinitionId: string;
-  readonly endpointId: string;
+  /** Absent for a local-only Assignment grant. */
+  readonly endpointId?: string;
   readonly profileRevisionId: string;
   readonly profileDigest: string;
   readonly factAnchor: AssignmentExecutionFactAnchor;
@@ -382,8 +383,9 @@ function validateRecordInput(input: AssignmentAuthorityGrantRecordInput): void {
   if (unexpected) throw new Error(`Assignment Authority Grant record has unexpected ${unexpected}`);
   for (const field of [
     'assignmentKey', 'projectId', 'runId', 'taskKey', 'assignmentId', 'operationId',
-    'agentDefinitionId', 'endpointId', 'profileRevisionId', 'profileDigest',
+    'agentDefinitionId', 'profileRevisionId', 'profileDigest',
   ] as const) requiredText(input[field], field);
+  if (input.endpointId !== undefined) requiredText(input.endpointId, 'endpointId');
   for (const field of [
     'revision', 'generation', 'taskRevision', 'assignmentRevision', 'attempt', 'fence',
   ] as const) positive(input[field], field);

--- a/packages/im/agent/src/workroom/human-ingress-orchestrator.ts
+++ b/packages/im/agent/src/workroom/human-ingress-orchestrator.ts
@@ -190,6 +190,28 @@ implements HumanIngressOrchestratorProposalPort {
     }
     const title = source.text.replace(/^\/(?:work|task)(?:\s+|$)/iu, '').trim();
     if (!title) return clarification(request, 'missing_work_scope');
+    const replay = await this.options.kernel.readWorkflowPlanAdmission(request.operationId);
+    if (replay) {
+      const { plan, receipt } = replay;
+      if (replay.operationId !== request.operationId
+        || replay.sourceEventRef !== source.ref
+        || replay.sourceEventDigest !== source.digest
+        || replay.orchestratorAgentDefinitionId !== authority.orchestratorAgentDefinitionId
+        || plan.projectId !== request.identity.projectId
+        || plan.proposalId !== request.operationId
+        || plan.parameterDigest !== source.digest
+        || receipt.state.projectId !== request.identity.projectId
+        || receipt.state.title !== title) {
+        throw new Error('Human ingress persisted Plan admission is outside the exact operation/source scope');
+      }
+      await this.options.afterPlanAdmission?.({
+        operationId: request.operationId,
+        projectId: request.identity.projectId,
+        plan,
+        receipt,
+      });
+      return applied(request, 'plan_proposal_submitted', receipt);
+    }
     if (!this.options.planning) return clarification(request, 'planning_unavailable');
     let plan: WorkflowPlanProposal;
     try {
@@ -315,7 +337,13 @@ function applied(
   kind: Extract<HumanIngressApplicationDecision, { status: 'applied' }>['kind'],
   receipt: Readonly<{ receiptRef: string; receiptDigest: string }>,
 ): HumanIngressApplicationDecision {
-  return deepFreeze({ ...request.identity, status: 'applied', kind, ...receipt });
+  return deepFreeze({
+    ...request.identity,
+    status: 'applied',
+    kind,
+    receiptRef: receipt.receiptRef,
+    receiptDigest: receipt.receiptDigest,
+  });
 }
 
 function clarification(

--- a/packages/im/agent/src/workroom/journal.ts
+++ b/packages/im/agent/src/workroom/journal.ts
@@ -46,6 +46,7 @@ export interface WorkroomJournalPayloadWriteInput {
   readonly runId: string;
   readonly eventId: string;
   readonly eventType: WorkroomEvent['type'];
+  readonly occurredAt: number;
   readonly fieldPath: string;
   readonly value: unknown;
   readonly contentHash: string;
@@ -728,59 +729,70 @@ export class DatabaseWorkroomJournal implements WorkroomJournal {
       protectedEvents: readonly StoredWorkroomEvent[];
       current: readonly StoredWorkroomEvent[];
     }> | undefined;
+    let headerPublished = false;
     try {
-      const appended = await this.#database.transaction(async transaction => {
-        const allRows = await transaction.select('workroom_events').where({});
+      const allRows = await this.#eventModel.select().where({});
+      await assertActiveStoreHasNoLegacyEmbeddedPayload({
+        read: async () => legacyDatabaseJournalRecords(allRows),
+      });
+      const current = parseStoredRowGroups(allRows).get(runId) ?? Object.freeze([]);
+      if (current.length > 0) {
+        await reconcileJournalPayloads(runId, current, this.#requirePayloads());
+      }
+      const actualSequence = current.at(-1)?.sequence ?? -1;
+      if (actualSequence !== expectedSequence) {
+        throw new WorkroomSequenceConflictError(runId, expectedSequence, actualSequence);
+      }
+      if (drafts.length === 0) return [];
+      const appended = materializeEvents(runId, expectedSequence, drafts);
+      const projectId = projectIdForAppend(current, appended);
+      const protectedEvents = await protectEvents(appended, projectId, this.#requirePayloads());
+      publication = { projectId, protectedEvents, current };
+      await this.#requirePayloads().prepare?.({
+        projectId,
+        runId,
+        receipts: collectGovernedPayloadReceipts(protectedEvents),
+      });
+      await this.#database.transaction(async transaction => {
+        const transactionRows = await transaction.select('workroom_events').where({});
         await assertActiveStoreHasNoLegacyEmbeddedPayload({
-          read: async () => legacyDatabaseJournalRecords(allRows),
+          read: async () => legacyDatabaseJournalRecords(transactionRows),
         });
-        const current = parseStoredRowGroups(allRows).get(runId) ?? Object.freeze([]);
-        if (current.length > 0) await reconcileJournalPayloads(runId, current, this.#requirePayloads());
-        const actualSequence = current.at(-1)?.sequence ?? -1;
-        if (actualSequence !== expectedSequence) {
-          throw new WorkroomSequenceConflictError(runId, expectedSequence, actualSequence);
+        const transactionCurrent = parseStoredRowGroups(transactionRows).get(runId)
+          ?? Object.freeze([]);
+        const transactionSequence = transactionCurrent.at(-1)?.sequence ?? -1;
+        if (transactionSequence !== expectedSequence) {
+          throw new WorkroomSequenceConflictError(runId, expectedSequence, transactionSequence);
         }
-        if (drafts.length === 0) return [];
-        const appended = materializeEvents(runId, expectedSequence, drafts);
-        const projectId = projectIdForAppend(current, appended);
-        const protectedEvents = await protectEvents(appended, projectId, this.#requirePayloads());
-        await this.#requirePayloads().prepare?.({
-          projectId,
-          runId,
-          receipts: collectGovernedPayloadReceipts(protectedEvents),
-        });
         await transaction.insertMany('workroom_events', protectedEvents.map(toRow));
-        publication = { projectId, protectedEvents, current };
-        return appended;
       }, { isolationLevel: 'SERIALIZABLE' });
-      if (publication) {
-        await this.#requirePayloads().publish?.({
+      headerPublished = true;
+      await this.#requirePayloads().publish?.({
+        projectId: publication.projectId,
+        runId,
+        receipts: collectGovernedPayloadReceipts(publication.protectedEvents),
+        publicationDigest: journalPublicationDigest(
+          runId,
+          [...publication.current, ...publication.protectedEvents],
+        ),
+      });
+      return appended;
+    } catch (error) {
+      if (publication && !headerPublished) {
+        await this.#requirePayloads().abandon?.({
           projectId: publication.projectId,
           runId,
           receipts: collectGovernedPayloadReceipts(publication.protectedEvents),
-          publicationDigest: journalPublicationDigest(
-            runId,
-            [...publication.current, ...publication.protectedEvents],
-          ),
+          reason: error instanceof WorkroomSequenceConflictError ? 'cas_lost' : 'write_failed',
         });
       }
-      return appended;
-    } catch (error) {
-      if (error instanceof WorkroomSequenceConflictError) throw error;
+      if (error instanceof WorkroomSequenceConflictError || headerPublished) throw error;
       // A serializable/unique-key loser is dialect-specific. Re-read the
       // authoritative sequence and normalize only a proven concurrent winner;
       // unrelated database failures retain their original error.
       const actualSequence = (await this.read(runId)).at(-1)?.sequence ?? -1;
       if (actualSequence !== expectedSequence) {
         throw new WorkroomSequenceConflictError(runId, expectedSequence, actualSequence);
-      }
-      if (publication) {
-        await this.#requirePayloads().abandon?.({
-          projectId: publication.projectId,
-          runId,
-          receipts: collectGovernedPayloadReceipts(publication.protectedEvents),
-          reason: 'write_failed',
-        });
       }
       throw error;
     }
@@ -1371,6 +1383,7 @@ async function protectValue(
         runId: event.runId,
         eventId: event.eventId,
         eventType: event.type,
+        occurredAt: event.occurredAt,
         fieldPath: path,
         value: structuredClone(child),
         contentHash,
@@ -1383,6 +1396,7 @@ async function protectValue(
           runId: event.runId,
           eventId: event.eventId,
           eventType: event.type,
+          occurredAt: event.occurredAt,
           fieldPath: path,
           contentHash,
         }),
@@ -1522,6 +1536,7 @@ async function materializeValue(
         runId: event.runId,
         eventId: event.eventId,
         eventType: event.type,
+        occurredAt: event.occurredAt,
         fieldPath,
         contentHash: value.contentHash,
       }),
@@ -1637,6 +1652,7 @@ function assertStoredEventReceiptBindings(events: readonly StoredWorkroomEvent[]
           runId: event.runId,
           eventId: event.eventId,
           eventType: event.type,
+          occurredAt: event.occurredAt,
           fieldPath,
           contentHash: value.contentHash,
         }),
@@ -1663,14 +1679,17 @@ export function createWorkroomJournalPayloadObjectId(input: Readonly<{
   runId: string;
   eventId: string;
   eventType: WorkroomEvent['type'];
+  occurredAt: number;
   fieldPath: string;
   contentHash: string;
 }>): string {
   return `workroom-journal-payload:${digestCanonicalWorkroomValue({
+    version: 2,
     projectId: input.projectId,
     runId: input.runId,
     eventId: input.eventId,
     eventType: input.eventType,
+    occurredAt: input.occurredAt,
     fieldPath: input.fieldPath,
     contentHash: input.contentHash,
   })}`;

--- a/packages/im/agent/src/workroom/projection-outbox.ts
+++ b/packages/im/agent/src/workroom/projection-outbox.ts
@@ -1672,7 +1672,9 @@ function requireAgentIdentity(
   assignment: AssignmentProjectionScope,
 ): WorkroomProjectionAgentIdentity {
   const matches = binding.agents.filter(identity =>
-    identity.principalId === assignment.owner && identity.role === assignment.role);
+    (identity.principalId === assignment.owner
+      || `agent:${identity.agentDefinitionId}` === assignment.owner)
+    && identity.role === assignment.role);
   if (matches.length !== 1) {
     throw new Error(`Workroom Projection requires one named Agent identity for ${assignment.assignmentId}`);
   }

--- a/packages/im/agent/src/workroom/workroom-kernel.ts
+++ b/packages/im/agent/src/workroom/workroom-kernel.ts
@@ -159,6 +159,15 @@ export interface WorkroomPlanAdmissionReceipt {
   readonly state: WorkroomRunState;
 }
 
+export interface WorkroomPlanAdmissionReplay {
+  readonly operationId: string;
+  readonly sourceEventRef: string;
+  readonly sourceEventDigest: string;
+  readonly orchestratorAgentDefinitionId: string;
+  readonly plan: WorkflowPlanProposal;
+  readonly receipt: WorkroomPlanAdmissionReceipt;
+}
+
 export interface WorkroomSchedulerCommitReceipt {
   readonly status: 'committed' | 'duplicate';
   readonly decisionId: string;
@@ -308,18 +317,63 @@ export class WorkroomKernel {
     }
     assertExactPlanAdmission(existing, normalized, admittedPayload);
     const state = replayWorkroom(existing);
-    const receiptRef = `workroom-run:${runId}:plan:${encodeURIComponent(normalized.plan.proposalId)}`;
-    return Object.freeze({
+    return planAdmissionReceipt(
       runId,
-      receiptRef,
-      receiptDigest: digestCanonicalWorkroomValue({
-        version: 1,
-        runId,
-        operationId: normalized.operationId,
-        planDigest: normalized.plan.digest,
-        sourceEventDigest: normalized.sourceEventDigest,
-      }),
+      normalized.operationId,
+      normalized.sourceEventDigest,
+      normalized.plan,
       state,
+    );
+  }
+
+  /** Exact persisted admission lookup used to finish a crash-interrupted application replay. */
+  async readWorkflowPlanAdmission(
+    operationId: string,
+  ): Promise<WorkroomPlanAdmissionReplay | undefined> {
+    requireCanonicalText(operationId, 'operationId');
+    const runId = planAdmissionRunId(operationId);
+    const events = await this.#journal.read(runId);
+    if (events.length === 0) return undefined;
+    const created = events[0];
+    const admitted = events[1];
+    if (created?.type !== 'run.created' || admitted?.type !== 'plan.admitted') {
+      throw new Error('Workflow Plan persisted admission header is invalid');
+    }
+    const projectId = created.payload.projectId;
+    const title = created.payload.title;
+    const sourceEventRef = admitted.payload.sourceEventRef;
+    const sourceEventDigest = admitted.payload.sourceEventDigest;
+    const orchestratorAgentDefinitionId = admitted.payload.orchestratorAgentDefinitionId;
+    const persistedOperationId = admitted.payload.operationId;
+    const plan = admitted.payload.plan;
+    requireCanonicalText(projectId, 'projectId');
+    requireCanonicalText(title, 'title');
+    requireCanonicalText(sourceEventRef, 'sourceEventRef');
+    requireDigest(sourceEventDigest, 'sourceEventDigest');
+    requireCanonicalText(orchestratorAgentDefinitionId, 'orchestratorAgentDefinitionId');
+    requireCanonicalText(persistedOperationId, 'persisted operationId');
+    assertWorkflowPlanProposal(plan as WorkflowPlanProposal);
+    if (persistedOperationId !== operationId) {
+      throw new Error('Workflow Plan persisted admission operation drift');
+    }
+    const admission = {
+      operationId,
+      projectId,
+      title,
+      sourceEventRef,
+      sourceEventDigest,
+      orchestratorAgentDefinitionId,
+      plan: plan as WorkflowPlanProposal,
+    };
+    assertExactPlanAdmission(events, admission, admitted.payload);
+    const state = replayWorkroom(events);
+    return Object.freeze({
+      operationId,
+      sourceEventRef,
+      sourceEventDigest,
+      orchestratorAgentDefinitionId,
+      plan: admission.plan,
+      receipt: planAdmissionReceipt(runId, operationId, sourceEventDigest, admission.plan, state),
     });
   }
 
@@ -833,8 +887,9 @@ export class WorkroomKernel {
         ?? workroomLocalAssignmentId(request.operationId),
       claimDigest: digestCanonicalWorkroomValue({ kind: 'local', request }),
       taskRevision: existing?.envelope.taskRevision ?? task.revision,
-      kernelSequence: state.sequence,
-      kernelStateDigest: digestCanonicalWorkroomValue(events),
+      kernelSequence: existing?.envelope.factAnchor.sequence ?? state.sequence,
+      kernelStateDigest: existing?.envelope.factAnchor.digest
+        ?? digestCanonicalWorkroomValue(events),
     });
   }
 
@@ -969,8 +1024,9 @@ export class WorkroomKernel {
         ?? workroomRemoteAssignmentId(request.operationId),
       claimDigest: digestCanonicalWorkroomValue({ kind: 'remote', request }),
       taskRevision: existing?.envelope.taskRevision ?? task.revision,
-      kernelSequence: state.sequence,
-      kernelStateDigest: digestCanonicalWorkroomValue(events),
+      kernelSequence: existing?.envelope.factAnchor.sequence ?? state.sequence,
+      kernelStateDigest: existing?.envelope.factAnchor.digest
+        ?? digestCanonicalWorkroomValue(events),
     });
   }
 
@@ -1692,6 +1748,27 @@ function planAdmissionRunId(operationId: string): string {
   return `run-${digestCanonicalWorkroomValue({ operationId }).slice('sha256:'.length, 38)}`;
 }
 
+function planAdmissionReceipt(
+  runId: string,
+  operationId: string,
+  sourceEventDigest: string,
+  plan: WorkflowPlanProposal,
+  state: WorkroomRunState,
+): WorkroomPlanAdmissionReceipt {
+  return Object.freeze({
+    runId,
+    receiptRef: `workroom-run:${runId}:plan:${encodeURIComponent(plan.proposalId)}`,
+    receiptDigest: digestCanonicalWorkroomValue({
+      version: 1,
+      runId,
+      operationId,
+      planDigest: plan.digest,
+      sourceEventDigest,
+    }),
+    state,
+  });
+}
+
 function assertExactPlanAdmission(
   events: readonly import('./kernel-contracts.js').WorkroomEvent[],
   input: WorkroomPlanAdmissionInput,
@@ -1705,8 +1782,9 @@ function assertExactPlanAdmission(
       ...(task.approvalGate ? ['task.blocked'] : []),
     ]),
   ];
-  if (events.length !== expectedTypes.length
-    || events.some((event, index) => event.type !== expectedTypes[index])) {
+  if (events.length < expectedTypes.length
+    || events.slice(0, expectedTypes.length)
+      .some((event, index) => event.type !== expectedTypes[index])) {
     throw new Error('Workflow Plan operation replay conflicts with persisted Run shape');
   }
   const created = events[0]!;

--- a/packages/im/agent/tests/plugin-runtime/workroom-assignment-authority-provider.test.ts
+++ b/packages/im/agent/tests/plugin-runtime/workroom-assignment-authority-provider.test.ts
@@ -2,10 +2,14 @@ import { describe, expect, it } from 'vitest';
 import {
   createWorkroomAssignmentAuthorityGrant,
   createWorkroomGenerationAuthoritySnapshot,
+  createWorkroomGenerationAuthoritySnapshotFromRuntime,
   digestWorkroomCatalogProjectBinding,
   digestWorkroomRemoteEndpointAuthority,
   GenerationOwnedWorkroomAssignmentAuthorityProvider,
 } from '../../src/plugin-runtime/workroom-assignment-authority-provider.js';
+import { rootPluginId, type RuntimeSnapshot } from '@zhin.js/plugin-runtime';
+import { SkillIndex, skillFeatureId } from '@zhin.js/skill';
+import { ToolIndex, toolFeatureId } from '@zhin.js/tool';
 import { MemoryProjectProfileJournal, ProjectProfileRegistry } from '../../src/workroom/profile-registry.js';
 import type { WorkroomCatalogSnapshot } from '../../src/workroom/catalog.js';
 import type { WorkroomRemoteAssignmentAuthorityInput } from '../../src/workroom/remote-assignment-issuance.js';
@@ -17,6 +21,31 @@ import { compileWorkroomProfile, type CapabilityPack } from '../../src/workroom/
 const SHA = (value: string): string => `sha256:${value.repeat(64)}`;
 
 describe('generation-owned Workroom Assignment authority provider', () => {
+  it('publishes only capabilities executable from the Root generation owner', () => {
+    const root = rootPluginId();
+    const toolIndex = Object.assign(Object.create(ToolIndex.prototype), {
+      list: () => [toolDescriptor('root_tool'), toolDescriptor('child_tool')],
+      visible: () => [toolDescriptor('root_tool')],
+    }) as ToolIndex;
+    const skillIndex = Object.assign(Object.create(SkillIndex.prototype), {
+      list: () => [skillDescriptor('root_skill'), skillDescriptor('child_skill')],
+      visible: () => [skillDescriptor('root_skill')],
+    }) as SkillIndex;
+    const snapshot = {
+      generation: 3,
+      root,
+      projections: new Map([
+        [toolFeatureId, toolIndex],
+        [skillFeatureId, skillIndex],
+      ]),
+    } as unknown as RuntimeSnapshot;
+
+    const authority = createWorkroomGenerationAuthoritySnapshotFromRuntime(snapshot, []);
+
+    expect(authority.tools.map(tool => tool.name)).toEqual(['root_tool']);
+    expect(authority.skills.map(skill => skill.name)).toEqual(['root_skill']);
+  });
+
   it('composes only the exact persisted Run Profile pin, generation supply, Project member, grant and endpoint', async () => {
     const fixture = await createFixture();
 
@@ -232,4 +261,12 @@ function ceiling(id: string, revision: number) {
     tools: [{ name: 'read_file', digest: SHA('1') }],
     skills: [{ name: 'typescript', digest: SHA('2'), requiredTools: ['read_file'] }],
   } as const;
+}
+
+function toolDescriptor(name: string) {
+  return { name, description: name, approval: 'never' as const, hidden: false };
+}
+
+function skillDescriptor(name: string) {
+  return { name, description: name, instructions: `Use ${name}` };
 }

--- a/packages/im/agent/tests/plugin-runtime/workroom-data-governance-authority-writer.test.ts
+++ b/packages/im/agent/tests/plugin-runtime/workroom-data-governance-authority-writer.test.ts
@@ -13,7 +13,7 @@ import {
   WorkroomDataGovernanceAuthorityWriter,
   type ProjectDataGovernanceAuthorityCandidate,
 } from '../../src/plugin-runtime/workroom-data-governance-authority-writer.js';
-import { digestWorkroomCatalogProjectBinding } from '../../src/plugin-runtime/workroom-assignment-authority-provider.js';
+import { digestWorkroomCatalogProjectBinding } from '../../src/workroom/catalog-definition.js';
 import { digestCanonicalWorkroomValue as digest } from '../../src/workroom/canonical-value.js';
 
 describe('trusted Project Data Governance authority writer', () => {
@@ -122,6 +122,15 @@ describe('trusted Project Data Governance authority writer', () => {
     await expect(writer.publish({
       catalogRevision: 'catalog:1',
       catalogBindingDigest: digestWorkroomCatalogProjectBinding(definition),
+      candidate: {
+        ...candidate,
+        derivedPayloads: { ...candidate.derivedPayloads, acceptanceProjection: undefined },
+      },
+    }, new AbortController().signal)).rejects.toThrow('Acceptance Projection derived/sink');
+
+    await expect(writer.publish({
+      catalogRevision: 'catalog:1',
+      catalogBindingDigest: digestWorkroomCatalogProjectBinding(definition),
       candidate,
     }, new AbortController().signal)).rejects.toThrow('decision');
   });
@@ -163,6 +172,10 @@ function projectionCandidate(): ProjectDataGovernanceAuthorityCandidate {
       },
       {
         principalId: 'service:workroom-kernel:project-1', tenantId: 'tenant-1', projectId: 'project-1',
+        clearance: 'confidential',
+      },
+      {
+        principalId: 'service:workroom-acceptance-policy:project-1', tenantId: 'tenant-1', projectId: 'project-1',
         clearance: 'confidential',
       },
       {
@@ -259,10 +272,23 @@ function projectionCandidate(): ProjectDataGovernanceAuthorityCandidate {
         },
         requestedMode: 'full',
       },
+      'acceptance-projection:acceptance-policy': {
+        destinationId: destination.id, channel: 'context_view', purpose: 'acceptance_review',
+        fixedPrincipalId: 'service:workroom-acceptance-policy:project-1', recipients,
+        principal: {
+          role: 'reviewer', clearance: 'confidential', allowedPurposes: ['acceptance_review'],
+        },
+        requestedMode: 'full',
+      },
     },
     derivedPayloads: {
       projection: derivedRule,
       journal: { ...derivedRule, allowedPurposes: ['orchestration'] },
+      acceptanceProjection: {
+        ...derivedRule,
+        allowedPurposes: ['acceptance_review'],
+        retentionClass: 'project_record',
+      },
     },
     approvals: [],
   };

--- a/packages/im/agent/tests/plugin-runtime/workroom-data-governance-bootstrap.test.ts
+++ b/packages/im/agent/tests/plugin-runtime/workroom-data-governance-bootstrap.test.ts
@@ -12,7 +12,7 @@ import {
 import {
   WorkroomDataGovernanceAuthorityWriter,
 } from '../../src/plugin-runtime/workroom-data-governance-authority-writer.js';
-import { digestWorkroomCatalogProjectBinding } from '../../src/plugin-runtime/workroom-assignment-authority-provider.js';
+import { digestWorkroomCatalogProjectBinding } from '../../src/workroom/catalog-definition.js';
 import { createCatalogGovernedWorkroomProjectionAuthority } from '../../src/workroom/runtime.js';
 
 describe('Workroom Data Governance bootstrap', () => {

--- a/packages/im/agent/tests/plugin-runtime/workroom-data-governance-runtime.test.ts
+++ b/packages/im/agent/tests/plugin-runtime/workroom-data-governance-runtime.test.ts
@@ -21,6 +21,7 @@ import {
 import {
   FileGovernedPayloadWriteSagaRepository,
   GovernedPayloadWritePurgeConsumer,
+  createGovernedPayloadWriteIntentId,
 } from '../../src/data-governance/governed-payload-write-saga.js';
 import {
   WorkroomDataGovernanceRuntime,
@@ -39,6 +40,67 @@ import { FileWorkroomJournal } from '../../src/workroom/journal.js';
 import { WorkroomKernel } from '../../src/workroom/workroom-kernel.js';
 
 describe('WorkroomDataGovernanceRuntime', () => {
+  it('does not purge another in-flight Journal append while preparing or reconciling exact receipts', async () => {
+    const root = join(tmpdir(), `zhin-governance-journal-concurrency-${randomUUID()}`);
+    await mkdir(root);
+    const repository = new FileDataGovernanceAuthorityRepository(
+      join(root, 'authority'), { verify: async () => true },
+    );
+    await repository.appendProject(projectAuthority('full'), undefined);
+    const payloadWrites = new FileGovernedPayloadWriteSagaRepository(join(root, 'sagas'));
+    const runtime = new WorkroomDataGovernanceRuntime({
+      generation: 5,
+      repository,
+      vault: new EncryptedFilePayloadVault({
+        directory: join(root, 'payloads'), generation: 5,
+        cryptography: testCryptography(new Uint8Array(32).fill(2), 'kms:key-journal-concurrency'),
+      }),
+      ...payloadInfrastructure(root, 5, payloadWrites),
+      signal: new AbortController().signal,
+      now: () => 100,
+    });
+    const write = async (eventId: string, value: string) => {
+      const source = {
+        ref: `workroom-journal-event:run-1:${eventId}:$.payload.title`,
+        digest: digestCanonicalWorkroomValue({ eventId, value }),
+        bindingDigest: digestCanonicalWorkroomValue({ eventId, value, binding: true }),
+      };
+      const receipt = await runtime.journalPayloads.write({
+        projectId: 'project-1', runId: 'run-1', eventId,
+        eventType: 'run.created', fieldPath: '$.payload.title', value,
+        contentHash: digestCanonicalWorkroomValue(value), source,
+      });
+      const intentId = createGovernedPayloadWriteIntentId({
+        operationId: `journal-publication:run-1`,
+        projectId: 'project-1',
+        objectId: receipt.descriptor.objectId,
+        payloadHash: receipt.descriptor.payloadHash,
+        descriptorDigest: receipt.descriptor.descriptorDigest,
+        sourceBindingDigest: receipt.source.bindingDigest,
+        consumer: 'journal_header',
+        publicationScope: 'run-1',
+      });
+      return { receipt, intentId };
+    };
+    const first = await write('event-1', 'first private payload');
+    const second = await write('event-2', 'second private payload');
+
+    await runtime.journalPayloads.prepare?.({
+      projectId: 'project-1', runId: 'run-1', receipts: [first.receipt],
+    });
+    await runtime.journalPayloads.reconcile?.({
+      projectId: 'project-1', runId: 'run-1', receipts: [first.receipt],
+      publicationDigest: digestCanonicalWorkroomValue({ header: 1 }),
+    });
+    await runtime.journalPayloads.abandon?.({
+      projectId: 'project-1', runId: 'run-1', receipts: [first.receipt], reason: 'cas_lost',
+    });
+
+    await expect(payloadWrites.read(first.intentId)).resolves.toMatchObject({ state: 'published' });
+    await expect(payloadWrites.read(second.intentId)).resolves.toMatchObject({ state: 'authority_indexed' });
+    await expect(payloadWrites.listPurgeRequired('project-1')).resolves.toEqual([]);
+  });
+
   it('settles an authority-indexed publication during generation handoff without a Vault rewrite', async () => {
     const root = join(tmpdir(), `zhin-governance-handoff-publication-${randomUUID()}`);
     await mkdir(root);

--- a/packages/im/agent/tests/plugin-runtime/workroom-dynamic-planning-provider.test.ts
+++ b/packages/im/agent/tests/plugin-runtime/workroom-dynamic-planning-provider.test.ts
@@ -9,6 +9,7 @@ import {
   createWorkroomPlanningDisclosureSourceBinding,
   type WorkroomDynamicPlanningPolicyRequest,
 } from '../../src/plugin-runtime/workroom-dynamic-planning-provider.js';
+import { digestWorkroomCatalogProjectBinding } from '../../src/workroom/catalog-definition.js';
 import { digestCanonicalWorkroomValue as digest } from '../../src/workroom/canonical-value.js';
 import type { HumanIngressPlanningInput } from '../../src/workroom/human-ingress-orchestrator.js';
 import { createWorkroomSchedulerPolicySnapshot } from '../../src/workroom/workroom-scheduler.js';
@@ -39,7 +40,7 @@ const input: HumanIngressPlanningInput = Object.freeze({
   operationId: 'human-ingress-application:p1',
   projectId: 'project-1',
   projectRevision: `sha256:${'2'.repeat(64)}`,
-  projectDigest: digest(definition),
+  projectDigest: digestWorkroomCatalogProjectBinding(definition),
   orchestratorAgentDefinitionId: 'lead',
   orchestratorAuthorityDigest: `sha256:${'3'.repeat(64)}`,
   principalId: 'human:owner',

--- a/packages/im/agent/tests/plugin-runtime/workroom-local-agent-loop.test.ts
+++ b/packages/im/agent/tests/plugin-runtime/workroom-local-agent-loop.test.ts
@@ -16,6 +16,8 @@ describe('Workroom local Agent loop adapter', () => {
       run: vi.fn(async input => {
         operations.push(`turn:${input.turnId}:${input.principalId}`);
         expect(input.capabilityPlan).toBe(capabilityPlan);
+        expect(input.prompt).toContain('only permitted top-level keys');
+        expect(input.prompt).toContain('Never add task_id');
         return {
           output: JSON.stringify({
             claims: [{

--- a/packages/im/agent/tests/plugin-runtime/workroom-local-assignment-runtime.test.ts
+++ b/packages/im/agent/tests/plugin-runtime/workroom-local-assignment-runtime.test.ts
@@ -144,6 +144,35 @@ describe('Workroom Local Assignment Runtime', () => {
     expect(execute).toHaveBeenCalledTimes(1);
   });
 
+  it('renews the Assignment lease while a local model turn is silent', async () => {
+    const { kernel } = await harness(Date.now, 120);
+    const issued = await kernel.issueLocalAssignment(request());
+    const runtime = new WorkroomLocalAssignmentRuntime({
+      kernel,
+      heartbeatIntervalMs: 30,
+      executor: {
+        async *execute(envelope) {
+          await new Promise(resolve => setTimeout(resolve, 220));
+          yield {
+            version: 1, type: 'execution_completed', observationId: 'complete-after-silence',
+            envelopeDigest: envelope.digest,
+            completion: {
+              report: { ref: 'report:after-silence', digest: SHA_A },
+              candidate: { ref: 'candidate:after-silence', hash: SHA_B },
+            },
+          };
+        },
+      },
+    });
+
+    await expect(runtime.execute(issued.envelope)).resolves.toBeUndefined();
+    const state = await kernel.read('project-1', 'run-1');
+    expect(state.assignments[issued.envelope.assignmentId]).toMatchObject({
+      status: 'execution_completed',
+    });
+    expect(state.sequence).toBeGreaterThan(6);
+  });
+
   it('rejects a persisted request whose Envelope no longer matches the claimed fence', async () => {
     const { kernel } = await harness();
     const issued = await kernel.issueLocalAssignment(request());
@@ -162,12 +191,12 @@ describe('Workroom Local Assignment Runtime', () => {
   });
 });
 
-async function harness(now: () => number = () => 100) {
+async function harness(now: () => number = () => 100, assignmentHeartbeatLeaseMs = 30) {
   const journal = new MemoryWorkroomJournal();
   const kernel = new WorkroomKernel({
     journal,
     now,
-    assignmentHeartbeatLeaseMs: 30,
+    assignmentHeartbeatLeaseMs,
     acceptancePolicy: acceptancePolicy(),
     localAssignmentAuthority: authority(),
   });

--- a/packages/im/agent/tests/plugin-runtime/workroom-profile-authority-composition.test.ts
+++ b/packages/im/agent/tests/plugin-runtime/workroom-profile-authority-composition.test.ts
@@ -8,8 +8,10 @@ import {
   WORKROOM_CONTROL_PLANE_ROOT_PRINCIPAL,
   createCatalogWorkroomProfilePublisherAuthority,
   createSnapshotWorkroomProfileGenerationView,
+  digestWorkroomProfileCatalogProject,
   installWorkroomProfileAuthorityResources,
 } from '../../src/plugin-runtime/workroom-profile-authority-composition.js';
+import { digestWorkroomCatalogProjectBinding } from '../../src/workroom/catalog-definition.js';
 import { workroomProjectProfileRegistryToken } from '../../src/plugin-runtime/workroom-assignment-authority-provider.js';
 import { workroomDynamicPlanningPolicyToken } from '../../src/plugin-runtime/workroom-dynamic-planning-provider.js';
 import { createWorkroomProfileOverlay } from '../../src/plugin-runtime/workroom-profile-authority-runtime.js';
@@ -51,6 +53,16 @@ const pack = Object.freeze({
 });
 
 describe('Workroom Profile authority production composition', () => {
+  it('uses the canonical Catalog Project binding digest for planning authority', () => {
+    const definition = Object.freeze({
+      name: 'Alpha',
+      members: Object.freeze([]),
+      sponsors: Object.freeze(['human:alice']),
+    });
+    expect(digestWorkroomProfileCatalogProject(definition))
+      .toBe(digestWorkroomCatalogProjectBinding(definition));
+  });
+
   it('holds one current Snapshot lease for the complete operation and releases it on failure', async () => {
     const store = snapshots();
     const acquire = vi.spyOn(store, 'acquire');

--- a/packages/im/agent/tests/plugin-runtime/workroom-scheduler-portfolio-composition.test.ts
+++ b/packages/im/agent/tests/plugin-runtime/workroom-scheduler-portfolio-composition.test.ts
@@ -30,13 +30,13 @@ describe('standard Portfolio-first Workroom Scheduler composition', () => {
     const catalog = catalogSnapshot();
     const installed = installWorkroomSchedulerPortfolioDispatchResources({
       generation: 7, signal: controller.signal, resources,
-      catalog: { read: async () => catalog }, profiles: pinnedProfiles(),
+      catalog: { read: async () => catalog }, profiles: pinnedProfiles(), runState: readyRunState(),
     });
     expect(resources.use(workroomSchedulerAssignmentRouteRegistryToken)).toBe(installed.routes);
     expect(resources.use(workroomSchedulerDispatchSupplyToken)).toBe(installed.supply);
     expect(installWorkroomSchedulerPortfolioDispatchResources({
       generation: 7, signal: controller.signal, resources,
-      catalog: { read: async () => catalog }, profiles: pinnedProfiles(),
+      catalog: { read: async () => catalog }, profiles: pinnedProfiles(), runState: readyRunState(),
     })).toEqual(installed);
     installed.routes.register({
       providerId: 'local', generation: 7,
@@ -54,7 +54,7 @@ describe('standard Portfolio-first Workroom Scheduler composition', () => {
     const catalog = catalogSnapshot();
     const installed = installWorkroomSchedulerPortfolioDispatchResources({
       generation: 7, signal: new AbortController().signal, resources,
-      catalog: { read: async () => catalog }, profiles: pinnedProfiles(),
+      catalog: { read: async () => catalog }, profiles: pinnedProfiles(), runState: readyRunState(),
     });
     installed.routes.register({ providerId: 'local', generation: 7, resolve: async () => route });
     const request = {
@@ -90,6 +90,7 @@ describe('standard Portfolio-first Workroom Scheduler composition', () => {
       resources,
       catalog: { read: async () => catalogSnapshot() },
       profiles: pinnedProfiles(),
+      runState: readyRunState(),
       journal: { read: async () => [
         ...readyJournal(),
         event(3, 'scheduler.dispatch_requested', selected),
@@ -116,6 +117,16 @@ function catalogSnapshot() {
   return { revision: sha('d'), definitions: { 'project-1': {
     enabled: true, members: [{ role: 'executor', agent: 'developer' }],
   } } } as never;
+}
+
+function readyRunState() {
+  const state = { tasks: { build: {
+    revision: 1, status: 'ready', acceptanceContract: { id: 'acceptance:build' },
+  } } } as never;
+  return {
+    read: async () => state,
+    pinTaskAcceptance: async () => state,
+  };
 }
 
 function decision() { return decideWorkroomSchedule(readyJournal())!; }

--- a/packages/im/agent/tests/plugin-runtime/workroom-scheduler-portfolio-request-authority.test.ts
+++ b/packages/im/agent/tests/plugin-runtime/workroom-scheduler-portfolio-request-authority.test.ts
@@ -14,6 +14,7 @@ import {
   decideWorkroomSchedule,
 } from '../../src/workroom/workroom-scheduler.js';
 import type { WorkroomEvent } from '../../src/workroom/kernel-contracts.js';
+import { WorkflowPlanBuilder } from '../../src/workroom/workflow-plan-builder.js';
 
 describe('pinned Profile Workroom Scheduler Portfolio Request authority', () => {
   it('constructs one content-free request from exact Kernel, Profile, Portfolio, and Catalog facts', async () => {
@@ -162,7 +163,7 @@ function pinnedProfile(withResources = true) {
       revisionId: 'profile-1', projectId: 'project-1', compiledDigest: sha('a'),
       compiledProfile: {
         revisionId: 'profile-1', projectId: 'project-1', digest: sha('a'),
-        workflows: [{ id: 'build-workflow', tasks: [{
+        workflows: [{ id: 'build-workflow', digest: sha('9'), tasks: [{
           key: 'build', role: 'executor', requires: { tools: [], skills: [] },
           ...(withResources ? { resourceRequirements: { demands: [
               { poolId: 'model-main', capacityUnits: 1, rateUnits: 2, budgetUnits: 50 },
@@ -273,13 +274,49 @@ function readyJournal(): readonly WorkroomEvent[] {
   });
   return [
     event(0, 'run.created', { projectId: 'project-1', title: 'Private run title' }),
-    event(1, 'plan.admitted', { schedulerPolicy: policy }),
+    event(1, 'plan.admitted', { schedulerPolicy: policy, plan: admittedPlan(policy) }),
     event(2, 'task.planned', {
       taskKey: 'build', title: 'Build secret release', role: 'executor', required: true, maxAttempts: 1,
       sponsorLane: 'normal', localRank: 0, deadline: 1_000, enqueuedAt: 10,
       dependsOn: [], preemptibility: 'atomic',
     }),
   ];
+}
+
+function admittedPlan(policy: ReturnType<typeof createWorkroomSchedulerPolicySnapshot>) {
+  return WorkflowPlanBuilder.create({
+    proposalId: 'proposal-1',
+    projectId: 'project-1',
+    strategy: { id: 'build-workflow', version: 'profile-1', digest: sha('9') },
+    parameterDigest: sha('1'),
+    authority: {
+      projectRevision: sha('b'),
+      projectDigest: sha('2'),
+      profileRevisionId: 'profile-1',
+      profileDigest: sha('a'),
+      planningPolicyRevisionId: 'planning-policy-1',
+      planningPolicyDigest: sha('3'),
+      orchestratorAgentDefinitionId: 'orchestrator',
+      orchestratorAuthorityDigest: sha('4'),
+    },
+    budget: { maxTasks: 1, maxTotalAttempts: 1 },
+    schedulerPolicy: policy,
+  }).addTask({
+    key: 'build',
+    title: 'Build secret release',
+    role: 'executor',
+    required: true,
+    maxAttempts: 1,
+    dependsOn: [],
+    requires: {},
+    scheduler: {
+      sponsorLane: 'normal',
+      localRank: 0,
+      deadline: 1_000,
+      enqueuedAt: 10,
+      preemptibility: 'atomic',
+    },
+  }).build();
 }
 
 function withDispatch(decision: NonNullable<ReturnType<typeof decideWorkroomSchedule>>): readonly WorkroomEvent[] {

--- a/packages/im/agent/tests/plugin-runtime/workroom-scheduler-portfolio-supply.test.ts
+++ b/packages/im/agent/tests/plugin-runtime/workroom-scheduler-portfolio-supply.test.ts
@@ -28,6 +28,7 @@ describe('Portfolio-first Workroom Scheduler supply', () => {
       routes: { resolve: async () => route },
       requests: { resolve: async () => request },
       capacity,
+      runState: readyRunState(),
     });
 
     await expect(supply.deliver(selected)).resolves.toBeUndefined();
@@ -42,6 +43,7 @@ describe('Portfolio-first Workroom Scheduler supply', () => {
       routes: { resolve: async () => null },
       requests: { resolve: vi.fn() },
       capacity,
+      runState: readyRunState(),
     });
 
     await expect(supply.probe(decision())).resolves.toBe(false);
@@ -68,6 +70,7 @@ describe('Portfolio-first Workroom Scheduler supply', () => {
       routes: { resolve: async () => route },
       requests: { resolve: async () => forged },
       capacity,
+      runState: readyRunState(),
     });
 
     await expect(supply.deliver(selected)).rejects.toThrow('exact Scheduler decision/route');
@@ -112,6 +115,16 @@ function catalog() {
       'project-1': { enabled: true, members: [{ role: 'executor', agent: 'developer' }] },
     },
   } as never;
+}
+
+function readyRunState() {
+  const state = { tasks: { build: {
+    revision: 1, status: 'ready', acceptanceContract: { id: 'acceptance:build' },
+  } } } as never;
+  return {
+    read: async () => state,
+    pinTaskAcceptance: async () => state,
+  };
 }
 
 function decision() {

--- a/packages/im/agent/tests/plugin-runtime/workroom-scheduler-runtime.test.ts
+++ b/packages/im/agent/tests/plugin-runtime/workroom-scheduler-runtime.test.ts
@@ -161,6 +161,7 @@ describe('WorkroomSchedulerRuntime', () => {
     const blocked: string[] = [];
     const recovered: string[] = [];
     const delivered: string[] = [];
+    const operations: string[] = [];
     const runtime = new WorkroomSchedulerRuntime({
       journal: { listRunIds: async () => ['run-1'], read: async () => events },
       commands: { commit: async candidate => ({
@@ -168,11 +169,17 @@ describe('WorkroomSchedulerRuntime', () => {
       }) },
       resolveSupply: () => ({
         probe: async () => ready,
-        deliver: async candidate => { delivered.push(candidate.decisionId); },
+        deliver: async candidate => {
+          operations.push('deliver');
+          delivered.push(candidate.decisionId);
+        },
       }),
       unavailableControl: {
         block: async candidate => { blocked.push(candidate.decisionId); },
-        recover: async candidate => { recovered.push(candidate.decisionId); },
+        recover: async candidate => {
+          operations.push('recover');
+          recovered.push(candidate.decisionId);
+        },
       },
     });
 
@@ -186,9 +193,10 @@ describe('WorkroomSchedulerRuntime', () => {
     expect(blocked).toEqual([decision.decisionId]);
     expect(recovered).toEqual([decision.decisionId]);
     expect(delivered).toEqual([decision.decisionId]);
+    expect(operations).toEqual(['recover', 'deliver']);
   });
 
-  it('does not recover a blocker when readiness probed true but delivery still fails closed', async () => {
+  it('reblocks after recovering the exact blocker when delivery still fails closed', async () => {
     const base = readyJournal();
     const decision = (await import('../../src/workroom/workroom-scheduler.js'))
       .decideWorkroomSchedule(base)!;
@@ -214,7 +222,7 @@ describe('WorkroomSchedulerRuntime', () => {
 
     await expect(runtime.drain()).resolves.toEqual({ scheduled: 0, delivered: 0 });
     expect(blocked).toEqual([decision.decisionId]);
-    expect(recovered).toEqual([]);
+    expect(recovered).toEqual([decision.decisionId]);
   });
 });
 

--- a/packages/im/agent/tests/workroom/local-assignment-issuance.test.ts
+++ b/packages/im/agent/tests/workroom/local-assignment-issuance.test.ts
@@ -65,9 +65,7 @@ describe('Kernel-owned Local Assignment issuance', () => {
       },
     });
     await expect(restarted.issueLocalAssignment(request)).resolves.toEqual(issued);
-    expect(await restarted.previewLocalAssignment(request)).toMatchObject({
-      assignmentRef: issued.envelope.assignmentId, taskRevision: issued.envelope.taskRevision,
-    });
+    expect(await restarted.previewLocalAssignment(request)).toEqual(preview);
     expect(await restarted.findLocalAssignment(request)).toEqual(issued);
     expect(await restarted.listLocalAssignmentIssuances()).toEqual([issued]);
   });

--- a/packages/im/agent/tests/workroom/projection-outbox.test.ts
+++ b/packages/im/agent/tests/workroom/projection-outbox.test.ts
@@ -140,6 +140,32 @@ describe('Workroom Projection Outbox', () => {
     expect(JSON.stringify(captured)).not.toContain('完成 durable projection schema');
   });
 
+  it('resolves a namespaced Assignment principal through its exact Agent definition identity', async () => {
+    const repository = new MemoryWorkroomProjectionRepository();
+    const events: WorkroomEvent[] = [
+      workroomEvent(0, 'run.created', { projectId: 'project-1', title: 'Namespaced identity' }),
+      workroomEvent(1, 'task.planned', { taskKey: 'build' }),
+      workroomEvent(2, 'assignment.claimed', {
+        taskKey: 'build', assignmentId: 'assignment-1', owner: 'agent:software.developer',
+        role: 'executor', taskRevision: 1, assignmentRevision: 1,
+      }),
+    ];
+    const tracer = new WorkroomProjectionTracer({
+      repository,
+      governance,
+      journal: {
+        listRunIds: async () => ['run-1'],
+        read: async () => events,
+        append: async () => { throw new Error('read-only test Journal'); },
+      },
+    });
+
+    const state = await tracer.capture(binding(), 'run-1');
+
+    expect(Object.values(state.items).find(item => item.sourceSequence === 2)?.speaker)
+      .toMatchObject({ agentDefinitionId: 'software.developer', displayName: 'Developer' });
+  });
+
   it('recovers outbox items and cursors after restart and fences concurrent CAS writers', async () => {
     const fixture = await runningAssignment();
     const root = join(tmpdir(), `workroom-projection-${crypto.randomUUID()}`);

--- a/packages/im/agent/tests/workroom/remote-assignment-issuance.test.ts
+++ b/packages/im/agent/tests/workroom/remote-assignment-issuance.test.ts
@@ -121,6 +121,7 @@ describe('Kernel-owned Remote Assignment issuance', () => {
       taskKey: 'build',
       agentDefinitionId: 'developer', endpointId: 'endpoint-1',
     };
+    const preview = await first.previewRemoteAssignment(request);
     const original = await first.issueRemoteAssignment(request);
     const restarted = new WorkroomKernel({
       journal, now: () => 200,
@@ -128,6 +129,7 @@ describe('Kernel-owned Remote Assignment issuance', () => {
     });
 
     await expect(restarted.issueRemoteAssignment(request)).resolves.toEqual(original);
+    await expect(restarted.previewRemoteAssignment(request)).resolves.toEqual(preview);
     await expect(restarted.issueRemoteAssignment({ ...request, endpointId: 'endpoint-drift' }))
       .rejects.toThrow('operation payload conflict');
     expect(await journal.read('run-1')).toHaveLength(5);

--- a/tests/snapshots/plugin-runtime-api.json
+++ b/tests/snapshots/plugin-runtime-api.json
@@ -100,7 +100,8 @@
     "export{FileJournalStore}from '../journal/file-journal-store.js';",
     "export{capabilityToTool,toolInvocationFromTurn,toolsFromCapabilities,type GenerationStampedTool,}from './capability-tools.js';",
     "export{createCatalogGovernedWorkroomProjectionAuthority,createCatalogGovernedConsoleDisclosureAuthority,createWorkroomRuntime,type WorkroomProjectionReadAuthorityPort,type WorkroomRunDetail,type WorkroomRunHeader,type WorkroomRuntimeHandle,}from '../workroom/runtime.js';",
-    "export{createSessionTreeRuntimeFromAgent,type SessionTreeRuntimeHandle,}from '../session-tree-runtime.js';"
+    "export{createSessionTreeRuntimeFromAgent,type SessionTreeRuntimeHandle,}from '../session-tree-runtime.js';",
+    "export{digestCanonicalWorkroomValue}from '../workroom/canonical-value.js';"
   ],
   "cli/runtime": [
     "export * from './migrate/index.js';",


### PR DESCRIPTION
## Summary
- repair fresh Workroom bootstrap, planning policy renewal, dynamic acceptance and disclosure authority
- restore local Portfolio grants, Scheduler delivery, governed Journal/Task Report payloads and projection renewal
- harden shutdown handling and surface delivery failures

## Validation
- pnpm build --concurrency=1 (88/88 packages)
- pnpm lint (0 errors)
- 21 focused test files / 181 tests passed
- local-workroom-portfolio.ts: 77.44% line coverage, 62.06% branch coverage

## Release
- patch changeset for @zhin.js/agent and @zhin.js/cli

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores end-to-end `/work` execution in freshly bootstrapped self-hosted Workroom projects. Planning authority, Portfolio assignment, scheduler delivery, governed Journal payloads, and shutdown now trace through consistent authorities so local runs no longer dead-end.

**Fixes**

- The CLI runtime now installs a local Portfolio authority (assignment grants, policy snapshots, and atomic resource bundles), with `endpointId` optional for local-only grants.
- The projection outbox resolves namespaced assignment principals (`agent:<agentDefinitionId>`), and the human-ingress orchestrator verifies the exact persisted plan admission before continuing.
- The Windows CI build drops the incremental retry workaround now that the project builds cleanly on the first pass.

**Behavior changes**

- Catalog project binding digests now come from the canonical `digestWorkroomCatalogProjectBinding` instead of a full-clone digest.
- The Scheduler recovers durably blocked decisions before delivery and only recovers again on the probe-less path, so supplies can read current task readiness directly.
- Local assignments renew their execution lease with heartbeats while a model turn stays silent.
- Task Report prompts now require exactly one JSON object with only `claims` and `evidence` top-level keys.
- Governed Journal payloads publish only from an `authority_indexed` intent, and lifecycle cutover no longer double-checks the target store digest.
- The governance writer now rejects candidates missing the acceptance-projection derived rule, so existing authorities must be re-bootstrapped.
- Portfolio control delivery errors reach the configured handler, and the supervisor waits out the full shutdown budget before fencing leaked handles.

<sup>Written for commit 3ac2772dd30ec701f847c388df54989894c08ba4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zhinjs/zhin/pull/651?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

