### PR TITLE
test(workroom): cover recovery authority paths

### DIFF
--- a/basic/cli/tests/plugin-runtime/agent-host-gaps.test.ts
+++ b/basic/cli/tests/plugin-runtime/agent-host-gaps.test.ts
@@ -25,6 +25,7 @@ import {
   assertWorkroomCatalogMatchesGeneration,
   createCatalogWorkroomProjectionBinding,
   createCatalogSponsorRoomProjectionBinding,
+  resolveCatalogWorkroomProjectionConversation,
   resolveCatalogSponsorProjectionConversation,
   resolveWorkroomStorageMode,
   routeSpecialistAgent,
@@ -37,6 +38,8 @@ import {
   resolveWorkroomDisclosureBootstrap,
   assessWorkroomDisclosureSetup,
   resolveWorkroomDisclosureAuthorityPublication,
+  resolveWorkroomPlanningPolicyPublication,
+  isWorkroomPlanningPolicyReady,
 } from '../../src/plugin-runtime/agent-host-installer.js';
 import {
   createEndpointRoleResolver,
@@ -583,6 +586,41 @@ describe('process-fixed Workroom storage identity', () => {
       kind: 'channel', id: 'portfolio-sponsors',
     });
     expect(resolveCatalogSponsorProjectionConversation(definition, [])).toBeUndefined();
+  });
+
+  it('renews Workroom conversation and Planning Policy bindings from exact current authorities', () => {
+    const definition = {
+      name: 'Engineering', members: [{ agent: 'orchestrator', role: 'orchestrator' as const }],
+      conversation: {
+        adapter: 'slack', endpoint: 'main', kind: 'channel' as const,
+        id: 'engineering', agent: 'orchestrator',
+      },
+    };
+    const endpoint = {
+      id: 'root\0zhin.adapter\0slack~main', name: 'main', adapter: 'slack', owner: 'adapter-owner',
+    };
+    expect(resolveCatalogWorkroomProjectionConversation(definition, [endpoint])).toEqual({
+      endpoint: { id: endpoint.id, adapter: endpoint.owner },
+      kind: 'channel', id: 'engineering',
+    });
+    expect(resolveCatalogWorkroomProjectionConversation(definition, [endpoint, {
+      ...endpoint, id: 'duplicate', owner: 'duplicate-owner',
+    }])).toBeUndefined();
+    expect(resolveCatalogWorkroomProjectionConversation({
+      ...definition,
+      conversation: { kind: 'repository' as const, id: 'zhinjs/zhin', agent: 'orchestrator' },
+    }, [endpoint])).toBeUndefined();
+
+    expect(resolveWorkroomPlanningPolicyPublication(undefined)).toEqual({ revision: 1 });
+    expect(resolveWorkroomPlanningPolicyPublication({ revision: 3, digest: 'sha256:previous' }))
+      .toEqual({ revision: 4, expectedPreviousDigest: 'sha256:previous' });
+    expect(isWorkroomPlanningPolicyReady(undefined)).toBe(false);
+    expect(isWorkroomPlanningPolicyReady({
+      policy: { schedulerPolicy: { pinnedAtSequence: 0 } },
+    })).toBe(false);
+    expect(isWorkroomPlanningPolicyReady({
+      policy: { schedulerPolicy: { pinnedAtSequence: 1 } },
+    })).toBe(true);
   });
 
   it('derives one backend from the initial process configuration', () => {

--- a/basic/cli/tests/plugin-runtime/local-workroom-data-governance.test.ts
+++ b/basic/cli/tests/plugin-runtime/local-workroom-data-governance.test.ts
@@ -155,4 +155,83 @@ describe('local Workroom Data Governance authority', () => {
     await expect(authority.issuePublicationDecision(decisionInput, controller.signal))
       .rejects.toThrow('cancelled');
   });
+
+  it('provides signed lifecycle authorization, deletion receipts, and conservative orphan reconciliation', async () => {
+    const root = join(tmpdir(), `zhin-local-workroom-governance-${randomUUID()}`);
+    await mkdir(root);
+    const authority = createLocalWorkroomDataGovernanceAuthority({ stateRoot: root, now: () => 73 });
+    const lifecycle = authority.lifecycle;
+    const clock = await lifecycle.clock.read();
+    expect(clock).toMatchObject({ version: 1, now: 73, revision: 1 });
+
+    const deniedRequest = {
+      authenticatedPrincipalId: 'principal:attacker',
+      requiredRole: 'data_steward',
+      clock,
+      digest: `sha256:${'1'.repeat(64)}`,
+    } as never;
+    await expect(lifecycle.authority.authorize(deniedRequest)).resolves.toEqual({
+      approved: false,
+      requestDigest: deniedRequest.digest,
+      reason: 'local_root_principal_required',
+    });
+
+    const request = {
+      ...deniedRequest,
+      authenticatedPrincipalId: lifecycle.registrationPrincipalId,
+      digest: `sha256:${'2'.repeat(64)}`,
+    } as never;
+    const decision = await lifecycle.authority.authorize(request);
+    if (!decision.approved) throw new Error('fixture lifecycle decision must be approved');
+    await expect(lifecycle.authority.verify(request, decision)).resolves.toBe(true);
+    await expect(lifecycle.authority.verify(request, {
+      ...decision,
+      role: 'privacy',
+    } as never)).resolves.toBe(false);
+    await expect(lifecycle.subjects.resolve()).resolves.toBeUndefined();
+
+    const dispatch = {
+      id: 'purge-1',
+      governance: { request: { projectId: 'project-1', objectId: 'object-1' } },
+      location: {
+        id: 'primary',
+        authorityDigest: `sha256:${'3'.repeat(64)}`,
+      },
+      locationManifestDigest: `sha256:${'4'.repeat(64)}`,
+      attempt: 1,
+      fence: 1,
+      requestDigest: `sha256:${'5'.repeat(64)}`,
+      requestedAt: 50,
+      digest: `sha256:${'6'.repeat(64)}`,
+    } as never;
+    const receipt = await lifecycle.deletion.purge(dispatch);
+    expect(receipt).toMatchObject({
+      purgeId: 'purge-1',
+      projectId: 'project-1',
+      objectId: 'object-1',
+      status: 'failed',
+      reasonCode: 'unsupported',
+      authenticatedBy: lifecycle.registrationPrincipalId,
+      observedAt: 73,
+    });
+    await expect(lifecycle.receipts.verify(receipt, dispatch)).resolves.toBe(true);
+    await expect(lifecycle.receipts.verify({
+      ...receipt,
+      requestDigest: `sha256:${'7'.repeat(64)}`,
+    }, dispatch)).resolves.toBe(false);
+
+    const orphanRequest = { digest: `sha256:${'8'.repeat(64)}` } as never;
+    const orphan = await lifecycle.orphanPurge.purge(orphanRequest);
+    expect(orphan).toMatchObject({
+      requestDigest: orphanRequest.digest,
+      providerId: 'local-workroom-orphan-purge',
+      status: 'outcome_unknown',
+      observedAt: 73,
+    });
+    await expect(lifecycle.orphanPurge.reconcile(orphanRequest, orphan)).resolves.toBe(orphan);
+    await expect(lifecycle.orphanPurge.reconcile(orphanRequest, {
+      ...orphan,
+      requestDigest: `sha256:${'9'.repeat(64)}`,
+    })).resolves.toEqual(orphan);
+  });
 });

--- a/basic/cli/tests/plugin-runtime/local-workroom-portfolio.test.ts
+++ b/basic/cli/tests/plugin-runtime/local-workroom-portfolio.test.ts
@@ -14,6 +14,7 @@ import {
 import {
   digestWorkroomCatalogProjectBinding,
   portfolioAtomicBundleAuthorityToken,
+  portfolioKernelCommandAuthorityToken,
   portfolioPolicyAuthorityToken,
   workroomSchedulerPortfolioScopeAuthorityToken,
 } from '@zhin.js/agent/runtime';
@@ -152,18 +153,41 @@ describe('CLI local Workroom Portfolio authorities', () => {
     });
     expect(binding?.portfolioId).toMatch(/^workroom-local:/u);
     await expect(scope.resolve({
+      generation,
+      projectId,
+      workroomCatalogRevision: catalog.revision,
+      profileRevisionId,
+      profileDigest,
+    })).resolves.toEqual(binding);
+    await expect(scope.resolve({
       generation: generation + 1,
       projectId,
       workroomCatalogRevision: catalog.revision,
       profileRevisionId,
       profileDigest,
     })).resolves.toBeUndefined();
+    await expect(scope.resolve({
+      generation,
+      projectId: 'missing-project',
+      workroomCatalogRevision: catalog.revision,
+      profileRevisionId,
+      profileDigest,
+    })).resolves.toBeUndefined();
+    await expect(scope.resolve({
+      generation,
+      projectId,
+      workroomCatalogRevision: catalog.revision,
+      profileRevisionId,
+      profileDigest: sha('stale-profile'),
+    })).resolves.toBeUndefined();
 
-    const policy = await resources.use(portfolioPolicyAuthorityToken).resolve(binding!.portfolioId);
+    const policyAuthority = resources.use(portfolioPolicyAuthorityToken);
+    const policy = await policyAuthority.resolve(binding!.portfolioId);
     expect(policy?.policy.projects[projectId]).toMatchObject({
       allowedPools: [LOCAL_WORKROOM_EXECUTOR_POOL_ID, LOCAL_WORKROOM_MODEL_POOL_ID],
       status: 'active',
     });
+    await expect(policyAuthority.resolve('workroom-local:missing')).resolves.toBeUndefined();
     const bundleAuthority = resources.use(portfolioAtomicBundleAuthorityToken);
     const capacityRequest = {
       requestId: 'request-1',
@@ -189,6 +213,34 @@ describe('CLI local Workroom Portfolio authorities', () => {
       model: { poolId: LOCAL_WORKROOM_MODEL_POOL_ID },
       executor: { poolId: LOCAL_WORKROOM_EXECUTOR_POOL_ID },
     });
+    await expect(bundleAuthority.validate({
+      generation: generation + 1,
+      portfolioId: binding!.portfolioId,
+      tenantId: binding!.tenantId,
+      catalogRevision: binding!.resourceCatalogRevision,
+      catalogDigest: binding!.resourceCatalogDigest,
+      capacityRequest,
+    })).resolves.toBeUndefined();
+    await expect(bundleAuthority.validate({
+      generation,
+      portfolioId: binding!.portfolioId,
+      tenantId: binding!.tenantId,
+      catalogRevision: binding!.resourceCatalogRevision,
+      catalogDigest: binding!.resourceCatalogDigest,
+      capacityRequest: {
+        ...capacityRequest,
+        workRef: { ...capacityRequest.workRef, profileDigest: sha('stale-profile') },
+      },
+    })).resolves.toBeUndefined();
+
+    const kernelAuthority = resources.use(portfolioKernelCommandAuthorityToken);
+    await expect(kernelAuthority.authorize({
+      generation: generation + 1,
+      portfolioId: binding!.portfolioId,
+      action: 'consume',
+      assignmentRef: 'assignment-1',
+      grant: {} as never,
+    })).resolves.toBeUndefined();
   });
 });
 

--- a/packages/im/agent/tests/plugin-runtime/workroom-acceptance-provider-composition.test.ts
+++ b/packages/im/agent/tests/plugin-runtime/workroom-acceptance-provider-composition.test.ts
@@ -25,6 +25,8 @@ import {
 import { digestCanonicalWorkroomValue as digest } from '../../src/workroom/canonical-value.js';
 import type { WorkroomAcceptanceDecisionInput } from '../../src/workroom/acceptance-policy.js';
 import type { WorkroomCatalogSnapshot } from '../../src/workroom/catalog.js';
+import { createWorkroomSchedulerPolicySnapshot } from '../../src/workroom/workroom-scheduler.js';
+import { WorkflowPlanBuilder } from '../../src/workroom/workflow-plan-builder.js';
 
 const SHA = (value: string): string => `sha256:${value.repeat(64).slice(0, 64)}`;
 
@@ -68,6 +70,75 @@ describe('P7 governed Acceptance production providers', () => {
     await expect(staleProvider.resolve({
       projectId: 'project-1', runId: 'run-1', taskKey: 'build', taskRevision: 1,
     })).rejects.toThrow(/Profile.*digest|projection.*drift/iu);
+  });
+
+  it('maps a dynamic Task to its unique governed workflow role from the exact admitted Plan', async () => {
+    const fixture = await profileFixture();
+    const projection = acceptanceProjection(fixture.profileDigest);
+    const plan = dynamicPlan(fixture);
+    const provider = new ProfileOwnedWorkroomAcceptanceProvider({
+      profiles: fixture.profiles,
+      catalog: fixture.catalog,
+      projections: { resolve: async () => projection },
+      journal: {
+        read: async () => [{ type: 'plan.admitted', payload: { plan } }] as never,
+      },
+    });
+
+    const facts = await provider.resolve({
+      projectId: 'project-1', runId: 'run-1', taskKey: 'dynamic-build', taskRevision: 1,
+    });
+    expect(facts).toMatchObject({
+      kind: 'task_result',
+      reviewerOwner: 'reviewer-1',
+      sponsorOwner: 'human:sponsor-1',
+    });
+    await expect(provider.resolveMemorySchema({
+      projectId: 'project-1', runId: 'run-1', taskKey: 'dynamic-build',
+      acceptance: acceptanceRecord(facts.policy),
+    })).resolves.toMatchObject({ revision: 1 });
+
+    const missingJournal = new ProfileOwnedWorkroomAcceptanceProvider({
+      profiles: fixture.profiles,
+      catalog: fixture.catalog,
+      projections: { resolve: async () => projection },
+    });
+    await expect(missingJournal.resolve({
+      projectId: 'project-1', runId: 'run-1', taskKey: 'dynamic-build', taskRevision: 1,
+    })).rejects.toThrow('no Acceptance policy');
+
+    const dynamicProvider = (
+      events: readonly unknown[],
+      governedProjection = projection,
+    ) => new ProfileOwnedWorkroomAcceptanceProvider({
+      profiles: fixture.profiles,
+      catalog: fixture.catalog,
+      projections: { resolve: async () => governedProjection },
+      journal: { read: async () => events as never },
+    });
+    const resolveDynamic = (candidate: ProfileOwnedWorkroomAcceptanceProvider) => candidate.resolve({
+      projectId: 'project-1', runId: 'run-1', taskKey: 'dynamic-build', taskRevision: 1,
+    });
+    await expect(resolveDynamic(dynamicProvider([])))
+      .rejects.toThrow('exactly one admitted Workflow Plan');
+    await expect(resolveDynamic(dynamicProvider([
+      { type: 'plan.admitted', payload: { plan: null } },
+    ]))).rejects.toThrow('Plan is unavailable');
+    await expect(resolveDynamic(dynamicProvider([
+      { type: 'plan.admitted', payload: { plan: dynamicPlan(fixture, { profileDigest: SHA('0') }) } },
+    ]))).rejects.toThrow('does not bind the exact Run Profile');
+    await expect(resolveDynamic(dynamicProvider([
+      { type: 'plan.admitted', payload: { plan: dynamicPlan(fixture, { taskKey: 'other-task' }) } },
+    ]))).rejects.toThrow('has no Task dynamic-build');
+    await expect(resolveDynamic(dynamicProvider([
+      { type: 'plan.admitted', payload: { plan: dynamicPlan(fixture, { strategyDigest: SHA('0') }) } },
+    ]))).rejects.toThrow('strategy is not uniquely pinned');
+    await expect(resolveDynamic(dynamicProvider([
+      { type: 'plan.admitted', payload: { plan } },
+    ], createWorkroomGovernedAcceptanceProjection({
+      ...projection,
+      tasks: [{ ...projection.tasks[0]!, taskKey: 'other-template' }],
+    })))).rejects.toThrow('no Acceptance policy for Workflow Task build');
   });
 
   it('uses Kernel headers only, binds their hashes, and routes reviewer/sponsor without report risk metadata', async () => {
@@ -297,7 +368,11 @@ async function profileFixture() {
       { id: 'executor-1', digest: SHA('1'), role: 'executor', allowedTools: [], allowedSkills: [] },
       { id: 'reviewer-1', digest: SHA('2'), role: 'reviewer', allowedTools: [], allowedSkills: [] },
     ],
-    workflows: [], memories: [], glossaries: [], acceptancePolicies: [],
+    workflows: [{
+      id: 'strategy-1', digest: SHA('6'), requiredByProfile: true,
+      tasks: [{ key: 'build', role: 'executor', requires: { tools: [], skills: [] } }],
+    }],
+    memories: [], glossaries: [], acceptancePolicies: [],
   } as const;
   const profileDigest = digest(profileProjection);
   await profiles.registerRevision({
@@ -330,6 +405,48 @@ async function profileFixture() {
   });
   const catalog = { read: async () => catalogSnapshot };
   return { profiles, profileDigest, catalog, catalogSnapshot };
+}
+
+function dynamicPlan(
+  fixture: Awaited<ReturnType<typeof profileFixture>>,
+  options: Readonly<{
+    taskKey?: string;
+    profileDigest?: string;
+    strategyDigest?: string;
+  }> = {},
+) {
+  return WorkflowPlanBuilder.create({
+    proposalId: 'plan-dynamic-1',
+    projectId: 'project-1',
+    parameterDigest: SHA('7'),
+    strategy: {
+      id: 'strategy-1', version: 'profile-1', digest: options.strategyDigest ?? SHA('6'),
+    },
+    authority: {
+      projectRevision: fixture.catalogSnapshot.revision,
+      projectDigest: digest(fixture.catalogSnapshot.definitions['project-1']),
+      profileRevisionId: 'profile-1',
+      profileDigest: options.profileDigest ?? fixture.profileDigest,
+      planningPolicyRevisionId: 'planning-1',
+      planningPolicyDigest: SHA('8'),
+      orchestratorAgentDefinitionId: 'orchestrator-1',
+      orchestratorAuthorityDigest: SHA('9'),
+    },
+    budget: { maxTasks: 1, maxTotalAttempts: 1 },
+    schedulerPolicy: createWorkroomSchedulerPolicySnapshot({
+      policyRef: 'scheduler-1', revision: 1, pinnedAtSequence: 1, capacity: 1,
+      agingStepMs: 100,
+      starvationBoundMs: { urgent: 100, high: 200, normal: 300, low: 400 },
+      preemptionDeadlineMs: 50,
+    }),
+  }).addTask({
+    key: options.taskKey ?? 'dynamic-build', title: 'Dynamic build', role: 'executor',
+    required: true, maxAttempts: 1, dependsOn: [], requires: {},
+    scheduler: {
+      sponsorLane: 'normal', localRank: 0, enqueuedAt: 1,
+      deadline: 1_000, preemptibility: 'checkpointable',
+    },
+  }).build();
 }
 
 function acceptanceProjection(profileDigest: string, criterionKind: 'deterministic' | 'judgment' = 'deterministic') {

--- a/packages/im/agent/tests/plugin-runtime/workroom-profile-authority-runtime.test.ts
+++ b/packages/im/agent/tests/plugin-runtime/workroom-profile-authority-runtime.test.ts
@@ -115,6 +115,12 @@ async function setup() {
 }
 
 describe('Workroom Profile authority production runtime', () => {
+  it('exposes an exact Planning Policy read through the narrow control port', async () => {
+    const fixture = await setup();
+    await expect(fixture.runtime.control.readPlanningPolicy('project:missing', 'profile:missing'))
+      .resolves.toBeUndefined();
+  });
+
   it('publishes one trusted content-addressed Pack revision and rejects same-version drift after restart', async () => {
     const fixture = await setup();
     const published = await fixture.runtime.control.publishPack({

--- a/packages/im/agent/tests/plugin-runtime/workroom-projection-runtime.test.ts
+++ b/packages/im/agent/tests/plugin-runtime/workroom-projection-runtime.test.ts
@@ -21,6 +21,39 @@ import type { PortfolioSponsorProjection } from '../../src/portfolio/sponsor-pro
 const governance = createTestProjectionGovernance();
 
 describe('production Workroom Projection runtime', () => {
+  it('renews each enabled IM Workroom binding before projecting durable facts', async () => {
+    const repository = new MemoryWorkroomProjectionRepository();
+    const renewWorkroomBinding = vi.fn(async () => undefined);
+    const currentCatalog = {
+      revision: 'a'.repeat(64),
+      definitions: {
+        'project-1': catalogDefinition(),
+        disabled: { ...catalogDefinition(), enabled: false },
+        repository: {
+          ...catalogDefinition(),
+          conversation: { kind: 'repository' as const, id: 'zhinjs/zhin', agent: 'software.orchestrator' },
+        },
+      },
+    };
+    const runtime = new WorkroomProjectionRuntime({
+      catalog: { read: async () => currentCatalog },
+      journal: new MemoryWorkroomJournal(),
+      repository,
+      outbound: { send: async () => ({ status: 'sent' }) },
+      workerId: 'projection-renewal', leaseMs: 30_000,
+      maxRunsPerTick: 4, maxDeliveriesPerTick: 4,
+      governance,
+      renewWorkroomBinding,
+    });
+
+    await expect(runtime.runOnce(new AbortController().signal)).resolves.toMatchObject({
+      scannedRuns: 0, capturedRuns: 0, deliveries: 0,
+    });
+    expect(renewWorkroomBinding).toHaveBeenCalledExactlyOnceWith(
+      'project-1', currentCatalog, expect.any(AbortSignal),
+    );
+  });
+
   it('recovers Catalog-bound Journal facts and drains them through the durable outbox', async () => {
     const now = vi.spyOn(Date, 'now').mockReturnValue(1_000);
     const journal = new MemoryWorkroomJournal();

--- a/packages/im/agent/tests/plugin-runtime/workroom-scheduler-portfolio-supply.test.ts
+++ b/packages/im/agent/tests/plugin-runtime/workroom-scheduler-portfolio-supply.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
   PortfolioFirstWorkroomSchedulerDispatchSupply,
+  WorkroomSchedulerPortfolioCapacityUnavailableError,
 } from '../../src/plugin-runtime/workroom-scheduler-portfolio-supply.js';
 import {
   workroomSchedulerPortfolioOpaqueHeadId,
@@ -9,6 +10,7 @@ import {
 } from '../../src/plugin-runtime/workroom-scheduler-portfolio-contract.js';
 import {
   WorkroomSchedulerAssignmentRouteUnavailableError,
+  WorkroomSchedulerDurablyBlockedError,
 } from '../../src/plugin-runtime/workroom-scheduler-runtime.js';
 import { createWorkroomSchedulerPolicySnapshot, decideWorkroomSchedule } from '../../src/workroom/workroom-scheduler.js';
 import type { WorkroomEvent } from '../../src/workroom/kernel-contracts.js';
@@ -75,6 +77,73 @@ describe('Portfolio-first Workroom Scheduler supply', () => {
 
     await expect(supply.deliver(selected)).rejects.toThrow('exact Scheduler decision/route');
     expect(capacity.request).not.toHaveBeenCalled();
+  });
+
+  it('pins Acceptance before requesting capacity and rejects stale or durably unpinnable Tasks', async () => {
+    const selected = decision();
+    const route = {
+      kind: 'local' as const, agentDefinitionId: 'developer', authorityRef: 'local:7:developer',
+    };
+    const request = capacityRequest(selected, route);
+    const capacity = { request: vi.fn(async () => null) };
+    const unpinned = { tasks: { build: { revision: 1, status: 'ready' } } } as never;
+    const pinned = readyRunState();
+    const pinTaskAcceptance = vi.fn(pinned.pinTaskAcceptance);
+    const supply = new PortfolioFirstWorkroomSchedulerDispatchSupply({
+      generation: 7,
+      catalog: { read: async () => catalog() },
+      routes: { resolve: async () => route },
+      requests: { resolve: async () => request },
+      capacity,
+      runState: {
+        read: async () => unpinned,
+        pinTaskAcceptance,
+      },
+    });
+
+    await expect(supply.deliver(selected)).resolves.toBeUndefined();
+    expect(pinTaskAcceptance).toHaveBeenCalledWith('project-1', 'run-1', 'build');
+    expect(capacity.request).toHaveBeenCalledExactlyOnceWith(request);
+
+    const stale = new PortfolioFirstWorkroomSchedulerDispatchSupply({
+      generation: 7,
+      catalog: { read: async () => catalog() },
+      routes: { resolve: async () => route },
+      requests: { resolve: async () => request },
+      capacity,
+      runState: {
+        read: async () => ({ tasks: { build: { revision: 2, status: 'ready' } } } as never),
+        pinTaskAcceptance: vi.fn(),
+      },
+    });
+    await expect(stale.deliver(selected))
+      .rejects.toBeInstanceOf(WorkroomSchedulerPortfolioCapacityUnavailableError);
+
+    const rejected = new PortfolioFirstWorkroomSchedulerDispatchSupply({
+      generation: 7,
+      catalog: { read: async () => catalog() },
+      routes: { resolve: async () => route },
+      requests: { resolve: async () => request },
+      capacity,
+      runState: {
+        read: async () => unpinned,
+        pinTaskAcceptance: async () => { throw new Error('policy unavailable'); },
+      },
+    });
+    await expect(rejected.deliver(selected)).rejects.toBeInstanceOf(WorkroomSchedulerDurablyBlockedError);
+
+    const missing = new PortfolioFirstWorkroomSchedulerDispatchSupply({
+      generation: 7,
+      catalog: { read: async () => catalog() },
+      routes: { resolve: async () => route },
+      requests: { resolve: async () => request },
+      capacity,
+      runState: {
+        read: async () => unpinned,
+        pinTaskAcceptance: async () => unpinned,
+      },
+    });
+    await expect(missing.deliver(selected)).rejects.toBeInstanceOf(WorkroomSchedulerDurablyBlockedError);
   });
 });
 


### PR DESCRIPTION
## Summary
- cover local Workroom lifecycle authorization, verification, deletion, and orphan reconciliation
- cover dynamic Acceptance mapping, Endpoint binding renewal, Portfolio validation, and Planning Policy reads
- restore strict differential coverage above the repository Codecov target after #651

## Validation
- pnpm vitest run --coverage (7170 passed, 2 skipped)
- pnpm type-check
- eslint on all changed test files
- local strict diff coverage estimate: 61.27% (target 58.84%)

## Sourcery 摘要

加强 Workroom 在生命周期、投影、组合、验收和调度权限方面的恢复路径覆盖。

增强功能：
- 扩展 Workroom 权限覆盖范围，包括本地生命周期治理、绑定续期、动态 Acceptance 解析、组合验证、Planning Policy 读取权限，以及调度器验收固定。
- 验证对未经授权、过期、缺失、不受支持以及其他被持久阻止的 Workroom 状态进行保守处理。

测试：
- 添加针对本地 Workroom 授权、删除回执、孤立项协调、投影绑定续期、动态工作流角色映射、组合权限验证、Planning Policy 访问权限以及调度器分发保护措施的回归测试。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

在不改变生产行为的前提下，加强 CLI 和 IM 代理运行时中 Workroom 权限恢复场景的覆盖。

增强功能：
- 扩展 Workroom 恢复路径的覆盖范围，包括生命周期治理、投影绑定续期、组合权限解析、Acceptance 映射、Planning Policy 访问权限以及调度器分发保护。

测试：
- 添加回归测试，覆盖已签名的生命周期授权、删除回执、保守的孤立项协调、精确的 Workflow Plan Acceptance 映射、组合验证、Planning Policy 读取、投影续期，以及调度器对过期或无法固定任务的处理。

杂项：
- 将严格差异覆盖率恢复到仓库 Codecov 目标值以上。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Strengthen Workroom authority recovery coverage across CLI and IM agent runtimes without changing production behavior.

Enhancements:
- Expand Workroom recovery-path coverage across lifecycle governance, projection binding renewal, portfolio authority resolution, Acceptance mapping, Planning Policy access, and scheduler dispatch protection.

Tests:
- Add regression tests for signed lifecycle authorization, deletion receipts, conservative orphan reconciliation, exact Workflow Plan Acceptance mapping, portfolio validation, Planning Policy reads, projection renewal, and scheduler handling of stale or unpinnable tasks.

Chores:
- Restore strict differential coverage above the repository Codecov target.

</details>

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds coverage for Workroom recovery authority paths across CLI and IM agent runtimes, restoring differential coverage above the repository Codecov target. No production behavior changes; the diff is test-only.

**Coverage**
- Local Workroom lifecycle authorization, signed deletion receipts, and conservative orphan reconciliation.
- Dynamic Acceptance mapping from exactly one admitted Workflow Plan, rejecting stale, unavailable, or unmapped plans.
- Portfolio scope resolution, policy reads, bundle validation, and kernel command authorization for local Workrooms.
- Workroom conversation and Planning Policy binding renewal from exact current authorities, plus Planning Policy reads through the narrow control port.
- Scheduler capacity requests that pin Acceptance before requesting capacity and reject stale or durably unpinnable tasks.

<sup>Written for commit c0f8960bc0cae8b3ee56e460177cd952878af5d4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zhinjs/zhin/pull/653?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->